### PR TITLE
chore(ci): tighten permissions, explicit webhook secrets & sanitize u…

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,13 +16,13 @@ on:
       INFRA_REPO_PAT:
         required: true
       QUIZ_PORTAINER_BETA_WEBHOOK:
-        required: true
+        required: false
       QUIZ_PORTAINER_PRODUCTION_WEBHOOK:
-        required: true
+        required: false
       QUIZ_SERVICE_PORTAINER_BETA_WEBHOOK:
-        required: true
+        required: false
       QUIZ_SERVICE_PORTAINER_PRODUCTION_WEBHOOK:
-        required: true
+        required: false
 
 jobs:
   deploy:
@@ -79,13 +79,34 @@ jobs:
           git commit -am "deploy(${ENV}-${SVC}): ${TAG}"
           git push
 
-      - name: Call Portainer webhook
+      - name: Notify Portainer (quiz, beta)
+        if: ${{ inputs.target_env == 'beta' && matrix.service == 'quiz' }}
+        env:
+          PORTAINER_WEBHOOK: ${{ secrets.QUIZ_PORTAINER_BETA_WEBHOOK }}
         run: |
-          if [ "${{ inputs.target_env }}" = "beta" ]; then
-            URL="${{ secrets[matrix.beta_webhook_secret] }}"
-          else
-            URL="${{ secrets[matrix.prod_webhook_secret] }}"
-          fi
+          HTTP_CODE=$(curl --write-out "%{http_code}" --silent --request POST "${PORTAINER_WEBHOOK}")
+          echo "Portainer quiz (beta) returned HTTP ${HTTP_CODE}"
 
+      - name: Notify Portainer (quiz-service, beta)
+        if: ${{ inputs.target_env == 'beta' && matrix.service == 'quiz-service' }}
+        env:
+          PORTAINER_WEBHOOK: ${{ secrets.QUIZ_SERVICE_PORTAINER_BETA_WEBHOOK }}
+        run: |
+          HTTP_CODE=$(curl --write-out "%{http_code}" --silent --request POST "${PORTAINER_WEBHOOK}")
+          echo "Portainer quiz-service (beta) returned HTTP ${HTTP_CODE}"
+
+      - name: Notify Portainer (quiz, prod)
+        if: ${{ inputs.target_env == 'prod' && matrix.service == 'quiz' }}
+        env:
+          PORTAINER_WEBHOOK: ${{ secrets.QUIZ_PORTAINER_PRODUCTION_WEBHOOK }}
+        run: |
+          HTTP_CODE=$(curl --write-out "%{http_code}" --silent --request POST "${PORTAINER_WEBHOOK}")
+          echo "Portainer quiz (prod) returned HTTP ${HTTP_CODE}"
+
+      - name: Notify Portainer (quiz-service, prod)
+        if: ${{ inputs.target_env == 'prod' && matrix.service == 'quiz-service' }}
+        env:
+          PORTAINER_WEBHOOK: ${{ secrets.QUIZ_SERVICE_PORTAINER_PRODUCTION_WEBHOOK }}
+        run: |
           HTTP_CODE=$(curl --write-out "%{http_code}" --silent --request POST "${URL}")
           echo "Portainer webhook returned HTTP ${HTTP_CODE}"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,14 +5,19 @@ on:
   push:
     branches:
       - main
+      - "release/**"
 
 jobs:
   build:
+    permissions:
+      contents: read
     uses: ./.github/workflows/build.yml
     secrets: inherit
 
   docker-build-and-push:
     needs: build
+    permissions:
+      contents: read
     uses: ./.github/workflows/docker-build-and-push.yml
     secrets: inherit
 

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,7 +1,6 @@
 # .github/workflows/pull_request.yml
 name: Pull-Request
-permissions:
-  contents: read
+permissions: {}
 on:
   pull_request:
     branches:
@@ -9,5 +8,7 @@ on:
 
 jobs:
   build:
+    permissions:
+      contents: read
     uses: ./.github/workflows/build.yml
     secrets: inherit


### PR DESCRIPTION
…pload paths

- deploy.yml: make Portainer webhook secrets optional; split notification into four scoped steps with single-secret env
- main.yml: add release/** trigger; grant contents:read permission to build and docker-build-and-push jobs
- pull_request.yml: lock default permissions ({}); set job-level contents:read on build
- parse-image-file.pipe.ts: resolve and sanitize base upload path and filename; enforce baseDir prefix before unlink to prevent path traversal