### PR TITLE
chore: Add community health files for GitHub standards

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# .github/CODEOWNERS
+* @emilhornlund

--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,0 +1,127 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at security@klurigo.com.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series
+of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or
+permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior,  harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.0, available at
+https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct
+enforcement ladder](https://github.com/mozilla/diversity).
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see the FAQ at
+https://www.contributor-covenant.org/faq. Translations are available at
+https://www.contributor-covenant.org/translations.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,35 @@
+---
+name: 🐛 Bug Report
+about: Report something that’s not working as expected
+title: "[Bug] "
+labels: bug
+assignees: ''
+
+---
+
+### Description
+
+A clear and concise description of the bug.
+
+### Steps to Reproduce
+
+1. Go to '...'
+2. Click on '...'
+3. See error
+
+### Expected Behavior
+
+What you expected to happen.
+
+### Screenshots / Logs
+
+If applicable, add screenshots or logs.
+
+### Environment
+
+- OS: [e.g. macOS, Windows]
+- Browser [e.g. Chrome, Firefox]
+
+### Additional Context
+
+Anything else we should know?

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 📫 Security vulnerability
+    url: mailto:security@klurigo.com
+    about: Please report security vulnerabilities via email, not in public issues.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,28 @@
+---
+name: 💡 Feature Request
+about: Suggest an improvement or new feature
+title: "[Feature] "
+labels: enhancement
+assignees: ''
+
+---
+
+### Summary
+
+Briefly describe the feature.
+
+### Use Case
+
+Why is this feature needed? What problem does it solve?
+
+### Describe the Solution You'd Like
+
+What should it do? How should it work?
+
+### Alternatives Considered
+
+Other options you’ve tried or considered.
+
+### Additional Context
+
+Any extra notes, mockups, or links.

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,12 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability, please report it privately.
+
+- **Email:** security@klurigo.com
+- **Do not** open public issues for security-related problems.
+- We aim to respond to reports within **2–3 business days**.
+- If a vulnerability is confirmed, we’ll coordinate a patch release and disclose it responsibly.
+
+Thank you for helping keep this project and its users safe! 🙏

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,25 @@
+# Pull Request
+
+## Summary
+
+Briefly explain the purpose of this PR. What does it change or fix?
+
+## Related Issues
+
+Closes #<issue-number>  
+Relates to #<issue-number>
+
+## Checklist
+
+- [ ] I’ve run all tests locally and they pass.
+- [ ] I’ve added or updated documentation if needed.
+- [ ] I’ve followed the code style and naming conventions.
+- [ ] I’ve added sufficient test coverage for the changes.
+
+## Screenshots / Videos (if UI-related)
+
+_Add before/after screenshots or recordings here if applicable._
+
+## Additional Notes
+
+_Anything else you’d like reviewers to know?_

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,57 @@
+# Contributing to Klurigo
+
+First off, thanks for taking the time to contribute! 🎉
+
+The following is a set of guidelines for contributing to this project. These are mostly guidelines, not rules. Use your best judgment, and feel free to propose changes to this document.
+
+## Table of Contents
+
+- [Getting Started](#getting-started)
+- [Code of Conduct](#code-of-conduct)
+- [Reporting Bugs](#reporting-bugs)
+- [Suggesting Features](#suggesting-features)
+- [Pull Request Process](#pull-request-process)
+- [Style Guide](#style-guide)
+
+## Getting Started
+
+1. Fork the repo and create your branch from `main` or the appropriate feature branch.
+2. If you’ve added code, make sure it’s covered by tests.
+3. If you’ve changed APIs, update the documentation accordingly.
+
+## Code of Conduct
+
+This project follows a [Code of Conduct](./.github/CODE_OF_CONDUCT.md).  
+By participating, you are expected to uphold this code.
+
+## Reporting Bugs
+
+Please open an [issue](https://github.com/emilhornlund/quiz/issues/new) with:
+
+- A clear description of the problem
+- Steps to reproduce
+- Expected and actual behavior
+- Screenshots/logs if helpful
+
+## Suggesting Features
+
+We welcome ideas! Submit an [issue](https://github.com/emilhornlund/quiz/issues/new) labeled `enhancement`, describing:
+
+- The problem you're trying to solve
+- A clear description of the proposed feature
+- Any alternatives considered
+
+## Pull Request Process
+
+- Ensure your PR has a clear title (consider [Conventional Commits](https://www.conventionalcommits.org/)).
+- Include a summary of changes and link to any related issues.
+- Make sure your code passes linting and tests.
+- Keep PRs focused and small if possible.
+
+## Style Guide
+
+- Use consistent formatting. We use Prettier and ESLint across the repo.
+- Prefer descriptive names and comments where helpful.
+- Avoid large formatting-only commits—keep code and formatting changes separate.
+
+Thanks again for your contribution! 🙌


### PR DESCRIPTION
- Adds CODEOWNERS to auto-assign @emilhornlund on all changes.
- Introduces Contributor Covenant v2.0 as the project's Code of Conduct.
- Adds issue templates for bug reports and feature requests.
- Sets up config to disable blank issues and route security concerns.
- Adds a SECURITY.md with private reporting instructions.
- Provides a pull request template to guide contributors.
- Adds a CONTRIBUTING.md to outline contribution guidelines and workflows.

Ensures the repository meets GitHub’s recommended community standards.