### PR TITLE
feat(player-states): show points behind next player

### DIFF
--- a/packages/common/src/models/game-event.ts
+++ b/packages/common/src/models/game-event.ts
@@ -217,6 +217,10 @@ export type GameResultPlayerEvent = {
       position: number
       streak: number
     }
+    behind?: {
+      points: number
+      nickname: string
+    }
   }
   pagination: PaginationEvent
 }
@@ -243,6 +247,10 @@ export type GameLeaderboardPlayerEvent = {
       position: number
       score: number
       streaks: number
+    }
+    behind?: {
+      points: number
+      nickname: string
     }
   }
   pagination: PaginationEvent

--- a/packages/quiz/src/states/PlayerLeaderboardState/PlayerLeaderboardState.stories.tsx
+++ b/packages/quiz/src/states/PlayerLeaderboardState/PlayerLeaderboardState.stories.tsx
@@ -26,6 +26,10 @@ export const Default = {
           score: 10458,
           streaks: 3,
         },
+        behind: {
+          points: 123,
+          nickname: 'WhiskerFox',
+        },
       },
       pagination: {
         current: 1,

--- a/packages/quiz/src/states/PlayerLeaderboardState/PlayerLeaderboardState.test.tsx
+++ b/packages/quiz/src/states/PlayerLeaderboardState/PlayerLeaderboardState.test.tsx
@@ -20,6 +20,10 @@ describe('PlayerLeaderboardState', () => {
                 score: 10458,
                 streaks: 3,
               },
+              behind: {
+                points: 123,
+                nickname: 'WhiskerFox',
+              },
             },
             pagination: {
               current: 1,

--- a/packages/quiz/src/states/PlayerLeaderboardState/PlayerLeaderboardState.tsx
+++ b/packages/quiz/src/states/PlayerLeaderboardState/PlayerLeaderboardState.tsx
@@ -8,7 +8,7 @@ import {
   PlayerGameFooter,
   StreakBadge,
 } from '../../components'
-import { GamePage } from '../common'
+import { GamePage, PointsBehindIndicator } from '../common'
 
 export interface PlayerLeaderboardStateProps {
   event: GameLeaderboardPlayerEvent
@@ -19,6 +19,7 @@ const PlayerLeaderboardState: FC<PlayerLeaderboardStateProps> = ({
     player: {
       nickname,
       score: { position, score, streaks },
+      behind,
     },
     pagination: { current: currentQuestion, total: totalQuestions },
   },
@@ -40,6 +41,7 @@ const PlayerLeaderboardState: FC<PlayerLeaderboardStateProps> = ({
       </Badge>
       <NicknameChip value={nickname} />
       <StreakBadge streak={streaks}>Streak</StreakBadge>
+      {behind && <PointsBehindIndicator {...behind} />}
     </GamePage>
   )
 }

--- a/packages/quiz/src/states/PlayerResultState/PlayerResultState.stories.tsx
+++ b/packages/quiz/src/states/PlayerResultState/PlayerResultState.stories.tsx
@@ -28,6 +28,10 @@ export const Correct = {
           position: 1,
           streak: 3,
         },
+        behind: {
+          points: 123,
+          nickname: 'WhiskerFox',
+        },
       },
       pagination: {
         current: 1,
@@ -49,6 +53,10 @@ export const Incorrect = {
           total: 10458,
           position: 1,
           streak: 0,
+        },
+        behind: {
+          points: 123,
+          nickname: 'WhiskerFox',
         },
       },
       pagination: {

--- a/packages/quiz/src/states/PlayerResultState/PlayerResultState.test.tsx
+++ b/packages/quiz/src/states/PlayerResultState/PlayerResultState.test.tsx
@@ -22,6 +22,10 @@ describe('PlayerResultState', () => {
                 position: 1,
                 streak: 3,
               },
+              behind: {
+                points: 123,
+                nickname: 'WhiskerFox',
+              },
             },
             pagination: {
               current: 1,

--- a/packages/quiz/src/states/PlayerResultState/PlayerResultState.tsx
+++ b/packages/quiz/src/states/PlayerResultState/PlayerResultState.tsx
@@ -9,7 +9,7 @@ import {
   StreakBadge,
   Typography,
 } from '../../components'
-import { GamePage } from '../common'
+import { GamePage, PointsBehindIndicator } from '../common'
 
 import { getPositionMessage } from './messages.ts'
 import styles from './PlayerResultState.module.scss'
@@ -23,6 +23,7 @@ const PlayerResultState: FC<PlayerResultStateProps> = ({
     player: {
       nickname,
       score: { correct, last: lastScore, total: totalScore, position, streak },
+      behind,
     },
     pagination: { current: currentQuestion, total: totalQuestions },
   },
@@ -52,6 +53,7 @@ const PlayerResultState: FC<PlayerResultStateProps> = ({
       <Typography variant="text" size="small">
         {message}
       </Typography>
+      {behind && <PointsBehindIndicator {...behind} />}
     </GamePage>
   )
 }

--- a/packages/quiz/src/states/common/PointsBehindIndicator/PointsBehindIndicator.module.scss
+++ b/packages/quiz/src/states/common/PointsBehindIndicator/PointsBehindIndicator.module.scss
@@ -1,0 +1,15 @@
+@use '../../../styles/helpers';
+
+.pointsBehindIndicator {
+  @include helpers.mobile {
+    @include helpers.fontSize(14px);
+  }
+
+  @include helpers.tablet {
+    @include helpers.fontSize(18px);
+  }
+
+  @include helpers.desktop {
+    @include helpers.fontSize(22px);
+  }
+}

--- a/packages/quiz/src/states/common/PointsBehindIndicator/PointsBehindIndicator.tsx
+++ b/packages/quiz/src/states/common/PointsBehindIndicator/PointsBehindIndicator.tsx
@@ -1,0 +1,19 @@
+import React, { FC } from 'react'
+
+import styles from './PointsBehindIndicator.module.scss'
+
+export interface PointBehindIndicatorProps {
+  points: number
+  nickname: string
+}
+
+const PointBehindIndicator: FC<PointBehindIndicatorProps> = ({
+  points,
+  nickname,
+}) => (
+  <div className={styles.pointsBehindIndicator}>
+    <strong>{points}</strong> points behind <strong>{nickname}</strong>
+  </div>
+)
+
+export default PointBehindIndicator

--- a/packages/quiz/src/states/common/PointsBehindIndicator/index.ts
+++ b/packages/quiz/src/states/common/PointsBehindIndicator/index.ts
@@ -1,0 +1,1 @@
+export { default } from './PointsBehindIndicator'

--- a/packages/quiz/src/states/common/index.ts
+++ b/packages/quiz/src/states/common/index.ts
@@ -1,1 +1,2 @@
 export { default as GamePage } from './GamePage'
+export { default as PointsBehindIndicator } from './PointsBehindIndicator'


### PR DESCRIPTION
- Added `behind` field to `GameResultPlayerEvent` and `GameLeaderboardPlayerEvent` models.
- Implemented logic in `game-event.converter.ts` to calculate points behind the player above.
- Created reusable `PointsBehindIndicator` component for player screens.
- Displayed the indicator in `PlayerResultState` and `PlayerLeaderboardState` when applicable.
- Updated tests and stories to reflect the new behind field in relevant events.

Improves player awareness of how close they are to the next rank on result and leaderboard screens.