### PR TITLE
chore(ci): move circular dependency check to CI workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,3 +44,6 @@ jobs:
 
       - name: Test
         run: yarn test
+
+      - name: Check for circular dependencies
+        run: yarn workspace @quiz/quiz-service check-circular-deps

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,3 +1,1 @@
 yarn lint
-yarn test
-yarn workspace @quiz/quiz-service check-circular-deps

--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Clone the repo and install dependencies:
 git clone git@github.com:emilhornlund/quiz.git
 cd quiz
 yarn install
+yarn workspace @quiz/common build
 ```
 
 To start everything in dev mode:


### PR DESCRIPTION
- Added a new step to the GitHub Actions build workflow to check for circular dependencies in @quiz/quiz-service.
- Removed the circular dependency check and tests from the pre-commit hook to speed up local development.
- Updated README with a missing build command for @quiz/common.

Improves developer experience by shifting non-critical checks to CI.