### PR TITLE
chore: simplify pre-commit hook and update setup instructions

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,3 +1,1 @@
 yarn lint
-yarn test
-yarn workspace @quiz/quiz-service check-circular-deps

--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Clone the repo and install dependencies:
 git clone git@github.com:emilhornlund/quiz.git
 cd quiz
 yarn install
+yarn workspace @quiz/common build
 ```
 
 To start everything in dev mode:


### PR DESCRIPTION
- Removed test and circular dependency check from Husky pre-commit script to speed up local commits.
- Added `yarn workspace @quiz/common build` to README to ensure models are compiled before development.

Streamlines local development by reducing unnecessary pre-commit overhead and clarifying setup steps.