### PR TITLE
refactor(test): Move and update bootstrap utility for e2e tests

### DIFF
--- a/packages/quiz-service/src/auth/controllers/auth.controller.e2e-spec.ts
+++ b/packages/quiz-service/src/auth/controllers/auth.controller.e2e-spec.ts
@@ -4,7 +4,7 @@ import * as bcrypt from 'bcryptjs'
 import supertest from 'supertest'
 import { v4 as uuidv4 } from 'uuid'
 
-import { closeTestApp, createTestApp } from '../../app/utils/test'
+import { closeTestApp, createTestApp } from '../../../test/utils/bootstrap'
 import { ClientService } from '../../client/services'
 
 describe('AuthController (e2e)', () => {

--- a/packages/quiz-service/src/game/controllers/client-game.controller.e2e-spec.ts
+++ b/packages/quiz-service/src/game/controllers/client-game.controller.e2e-spec.ts
@@ -14,7 +14,7 @@ import {
   createMockQuitTaskDocument,
   offsetSeconds,
 } from '../../../test/data'
-import { closeTestApp, createTestApp } from '../../app/utils/test'
+import { closeTestApp, createTestApp } from '../../../test/utils/bootstrap'
 import { AuthService } from '../../auth/services'
 import { Client, ClientModel } from '../../client/services/models/schemas'
 import { Player, PlayerModel } from '../../player/services/models/schemas'

--- a/packages/quiz-service/src/game/controllers/game-result.controller.e2e-spec.ts
+++ b/packages/quiz-service/src/game/controllers/game-result.controller.e2e-spec.ts
@@ -12,7 +12,7 @@ import { Model } from 'mongoose'
 import supertest from 'supertest'
 import { v4 as uuidv4 } from 'uuid'
 
-import { closeTestApp, createTestApp } from '../../app/utils/test'
+import { closeTestApp, createTestApp } from '../../../test/utils/bootstrap'
 import { AuthService } from '../../auth/services'
 import { ClientService } from '../../client/services'
 import { Client } from '../../client/services/models/schemas'

--- a/packages/quiz-service/src/game/controllers/game.e2e-spec.ts
+++ b/packages/quiz-service/src/game/controllers/game.e2e-spec.ts
@@ -33,7 +33,7 @@ import {
   MOCK_TYPE_ANSWER_OPTION_VALUE_ALTERNATIVE,
   offsetSeconds,
 } from '../../../test/data'
-import { closeTestApp, createTestApp } from '../../app/utils/test'
+import { closeTestApp, createTestApp } from '../../../test/utils/bootstrap'
 import { AuthService } from '../../auth/services'
 import { ClientService } from '../../client/services'
 import { Client } from '../../client/services/models/schemas'

--- a/packages/quiz-service/src/game/controllers/quiz-game.controller.e2e-spec.ts
+++ b/packages/quiz-service/src/game/controllers/quiz-game.controller.e2e-spec.ts
@@ -17,7 +17,7 @@ import {
 import supertest from 'supertest'
 import { v4 as uuidv4 } from 'uuid'
 
-import { closeTestApp, createTestApp } from '../../app/utils/test'
+import { closeTestApp, createTestApp } from '../../../test/utils/bootstrap'
 import { AuthService } from '../../auth/services'
 import { ClientService } from '../../client/services'
 import { QuizService } from '../../quiz/services'

--- a/packages/quiz-service/src/game/services/game.repository.e2e-spec.ts
+++ b/packages/quiz-service/src/game/services/game.repository.e2e-spec.ts
@@ -3,7 +3,7 @@ import { getModelToken } from '@nestjs/mongoose'
 import { GameMode, GameStatus } from '@quiz/common'
 import { v4 as uuidv4 } from 'uuid'
 
-import { closeTestApp, createTestApp } from '../../app/utils/test'
+import { closeTestApp, createTestApp } from '../../../test/utils/bootstrap'
 import { Quiz } from '../../quiz/services/models/schemas'
 
 import { GameRepository } from './game.repository'

--- a/packages/quiz-service/src/media/controllers/media.controller.e2e-spec.ts
+++ b/packages/quiz-service/src/media/controllers/media.controller.e2e-spec.ts
@@ -5,7 +5,7 @@ import { INestApplication } from '@nestjs/common'
 import supertest from 'supertest'
 import { v4 as uuidv4 } from 'uuid'
 
-import { closeTestApp, createTestApp } from '../../app/utils/test'
+import { closeTestApp, createTestApp } from '../../../test/utils/bootstrap'
 import { AuthService } from '../../auth/services'
 
 describe('MediaController (e2e)', () => {

--- a/packages/quiz-service/src/player/controllers/client-player.controller.e2e-spec.ts
+++ b/packages/quiz-service/src/player/controllers/client-player.controller.e2e-spec.ts
@@ -11,7 +11,7 @@ import {
   MOCK_DEFAULT_PLAYER_NICKNAME,
   MOCK_SECONDARY_PLAYER_NICKNAME,
 } from '../../../test/data'
-import { closeTestApp, createTestApp } from '../../app/utils/test'
+import { closeTestApp, createTestApp } from '../../../test/utils/bootstrap'
 import { AuthService } from '../../auth/services'
 import { Client, ClientModel } from '../../client/services/models/schemas'
 import { PlayerService } from '../services'

--- a/packages/quiz-service/src/quiz/controllers/client-quiz.controller.e2e-spec.ts
+++ b/packages/quiz-service/src/quiz/controllers/client-quiz.controller.e2e-spec.ts
@@ -10,7 +10,7 @@ import {
 import supertest from 'supertest'
 import { v4 as uuidv4 } from 'uuid'
 
-import { closeTestApp, createTestApp } from '../../app/utils/test'
+import { closeTestApp, createTestApp } from '../../../test/utils/bootstrap'
 import { AuthService } from '../../auth/services'
 import { ClientService } from '../../client/services'
 import { QuizService } from '../services'

--- a/packages/quiz-service/src/quiz/controllers/quiz.controller.e2e-spec.ts
+++ b/packages/quiz-service/src/quiz/controllers/quiz.controller.e2e-spec.ts
@@ -18,7 +18,7 @@ import {
 import supertest from 'supertest'
 import { v4 as uuidv4 } from 'uuid'
 
-import { closeTestApp, createTestApp } from '../../app/utils/test'
+import { closeTestApp, createTestApp } from '../../../test/utils/bootstrap'
 import { AuthService } from '../../auth/services'
 import { ClientService } from '../../client/services'
 import { QuizService } from '../services'


### PR DESCRIPTION
- Renamed `test.ts` to `bootstrap.ts` and moved it from `src/app/utils` to `test/utils`.
- Updated import paths across all e2e spec files to use the new bootstrap location.
- Improved `closeTestApp` to drop all collections instead of the entire database for cleaner test teardown.

Helps isolate test utilities and clarifies separation between application and test code.
