### PR TITLE
feat(game): Include player nickname in QuestionResultTaskItem

### DIFF
--- a/packages/quiz-service/src/game/controllers/game-result.controller.e2e-spec.ts
+++ b/packages/quiz-service/src/game/controllers/game-result.controller.e2e-spec.ts
@@ -370,6 +370,7 @@ function buildMockClassicModeGame(
           {
             type: QuestionType.MultiChoice,
             playerId: playerClient.player._id,
+            nickname: playerClient.player.nickname,
             answer: {
               type: QuestionType.MultiChoice,
               playerId: playerClient.player._id,
@@ -430,6 +431,7 @@ function buildMockClassicModeGame(
           {
             type: QuestionType.Range,
             playerId: playerClient.player._id,
+            nickname: playerClient.player.nickname,
             answer: {
               type: QuestionType.Range,
               playerId: playerClient.player._id,
@@ -490,6 +492,7 @@ function buildMockClassicModeGame(
           {
             type: QuestionType.TrueFalse,
             playerId: playerClient.player._id,
+            nickname: playerClient.player.nickname,
             answer: {
               type: QuestionType.TrueFalse,
               playerId: playerClient.player._id,
@@ -553,6 +556,7 @@ function buildMockClassicModeGame(
           {
             type: QuestionType.TypeAnswer,
             playerId: playerClient.player._id,
+            nickname: playerClient.player.nickname,
             answer: {
               type: QuestionType.TypeAnswer,
               playerId: playerClient.player._id,
@@ -733,6 +737,7 @@ function buildMockZeroToOneHundredModeGame(
           {
             type: QuestionType.Range,
             playerId: playerClient._id,
+            nickname: playerClient.player.nickname,
             answer: {
               type: QuestionType.Range,
               playerId: playerClient._id,
@@ -793,6 +798,7 @@ function buildMockZeroToOneHundredModeGame(
           {
             type: QuestionType.Range,
             playerId: playerClient._id,
+            nickname: playerClient.player.nickname,
             answer: {
               type: QuestionType.Range,
               playerId: playerClient._id,
@@ -853,6 +859,7 @@ function buildMockZeroToOneHundredModeGame(
           {
             type: QuestionType.Range,
             playerId: playerClient._id,
+            nickname: playerClient.player.nickname,
             answer: {
               type: QuestionType.Range,
               playerId: playerClient._id,
@@ -913,6 +920,7 @@ function buildMockZeroToOneHundredModeGame(
           {
             type: QuestionType.Range,
             playerId: playerClient._id,
+            nickname: playerClient.player.nickname,
             answer: {
               type: QuestionType.Range,
               playerId: playerClient._id,

--- a/packages/quiz-service/src/game/controllers/game.e2e-spec.ts
+++ b/packages/quiz-service/src/game/controllers/game.e2e-spec.ts
@@ -2522,6 +2522,7 @@ function buildCorrectQuestionResultTaskItem(
   return {
     type: options.answer.type,
     playerId: options.client.player._id,
+    nickname: options.client.player.nickname,
     answer: {
       type: options.answer.type,
       playerId: options.client.player._id,
@@ -2549,6 +2550,7 @@ function buildIncorrectQuestionResultTaskItem(
   return {
     type: options.answer.type,
     playerId: options.client.player._id,
+    nickname: options.client.player.nickname,
     answer: {
       type: options.answer.type,
       playerId: options.client.player._id,

--- a/packages/quiz-service/src/game/services/models/schemas/task.schema.ts
+++ b/packages/quiz-service/src/game/services/models/schemas/task.schema.ts
@@ -227,6 +227,9 @@ export class QuestionResultTaskItem {
   @Prop({ type: String, required: true })
   playerId: string
 
+  @Prop({ type: String, required: true })
+  nickname: string
+
   @Prop({ type: QuestionTaskBaseAnswerSchema, required: false })
   answer?: QuestionTaskBaseAnswer &
     (

--- a/packages/quiz-service/src/game/services/utils/game-event.converter.ts
+++ b/packages/quiz-service/src/game/services/utils/game-event.converter.ts
@@ -831,10 +831,7 @@ function buildGameResultPlayerEvent(
       behind: previousResultsEntry
         ? {
             points: previousResultsEntry.totalScore - total,
-            nickname:
-              document.participants.find(
-                ({ player: { _id } }) => _id === previousResultsEntry.playerId,
-              )?.player?.nickname ?? 'Unknown',
+            nickname: previousResultsEntry.nickname,
           }
         : undefined,
     },

--- a/packages/quiz-service/src/game/services/utils/task.converter.ts
+++ b/packages/quiz-service/src/game/services/utils/task.converter.ts
@@ -596,6 +596,7 @@ function buildQuestionResultTaskItem(
 ): QuestionResultTaskItem {
   const {
     player: { _id: playerId },
+    nickname,
     totalScore: previousScore,
     currentStreak,
   } = participantPlayer
@@ -618,6 +619,7 @@ function buildQuestionResultTaskItem(
   return {
     type,
     playerId,
+    nickname,
     answer,
     correct,
     lastScore,

--- a/packages/quiz-service/test/data/data.utils.ts
+++ b/packages/quiz-service/test/data/data.utils.ts
@@ -251,6 +251,7 @@ export function createMockQuestionResultTaskItemDocument(
   return {
     type: QuestionType.MultiChoice,
     playerId: MOCK_DEFAULT_PLAYER_ID,
+    nickname: MOCK_DEFAULT_PLAYER_NICKNAME,
     answer: createMockQuestionTaskMultiChoiceAnswer(),
     correct: true,
     lastScore: 1337,


### PR DESCRIPTION
- Added `nickname` field to the `QuestionResultTaskItem` schema and related builder utilities.
- Updated all mock data and test helpers to populate the `nickname` field.
- Simplified `buildGameResultPlayerEvent` by using `nickname` from previous results instead of re-resolving from participants.

Improves clarity and reduces reliance on nested lookups when displaying player result metadata.
