### PR TITLE
refactor(common): Extract and reuse `calculateRangeMargin` helper

### DIFF
--- a/packages/common/src/utils/index.ts
+++ b/packages/common/src/utils/index.ts
@@ -1,1 +1,2 @@
 export * from './constants'
+export * from './range-margin.helper'

--- a/packages/common/src/utils/range-margin.helper.ts
+++ b/packages/common/src/utils/range-margin.helper.ts
@@ -1,0 +1,38 @@
+import { QuestionRangeAnswerMargin } from '../models'
+
+/**
+ * Calculates the acceptable margin value for a range question based on the given margin type.
+ * This determines the range around the correct answer that is considered valid.
+ *
+ * @param {QuestionRangeAnswerMargin} margin - The margin type (None, Low, Medium, High, Maximum).
+ * @param {number} correct - The correct answer value for the range question.
+ *
+ * @returns {number} - The calculated margin value. If the margin is Maximum, returns `Number.MAX_VALUE`.
+ *                     If the margin is None, returns `0`.
+ *
+ * @example
+ * calculateRangeMargin(QuestionRangeAnswerMargin.Low, 100) // Returns 5 (5% of 100)
+ * calculateRangeMargin(QuestionRangeAnswerMargin.Medium, 100) // Returns 10 (10% of 100)
+ * calculateRangeMargin(QuestionRangeAnswerMargin.High, 100) // Returns 20 (20% of 100)
+ * calculateRangeMargin(QuestionRangeAnswerMargin.Maximum, 100) // Returns Number.MAX_VALUE
+ * calculateRangeMargin(QuestionRangeAnswerMargin.None, 100) // Returns 0
+ */
+export function calculateRangeMargin(
+  margin: QuestionRangeAnswerMargin,
+  correct: number,
+): number {
+  const base = Math.abs(correct)
+  switch (margin) {
+    case QuestionRangeAnswerMargin.Low:
+      return base * 0.05
+    case QuestionRangeAnswerMargin.Medium:
+      return base * 0.1
+    case QuestionRangeAnswerMargin.High:
+      return base * 0.2
+    case QuestionRangeAnswerMargin.Maximum:
+      return Number.MAX_VALUE
+    case QuestionRangeAnswerMargin.None:
+    default:
+      return 0
+  }
+}

--- a/packages/quiz-service/src/game/services/utils/task.converter.spec.ts
+++ b/packages/quiz-service/src/game/services/utils/task.converter.spec.ts
@@ -1,4 +1,5 @@
 import {
+  calculateRangeMargin,
   GameMode,
   GameParticipantType,
   MediaType,
@@ -31,7 +32,6 @@ import {
   calculateClassicModeRangeQuestionScore,
   calculateClassicModeRawScore,
   calculateClassicModeScore,
-  calculateRangeMargin,
   calculateZeroToOneHundredModeScore,
   isQuestionAnswerCorrect,
 } from './task.converter'

--- a/packages/quiz-service/src/game/services/utils/task.converter.ts
+++ b/packages/quiz-service/src/game/services/utils/task.converter.ts
@@ -1,4 +1,5 @@
 import {
+  calculateRangeMargin,
   GameMode,
   GameParticipantType,
   QuestionRangeAnswerMargin,
@@ -85,41 +86,6 @@ export function buildQuestionTask(
     questionIndex: gameDocument.nextQuestion,
     answers: [],
     created: new Date(),
-  }
-}
-
-/**
- * Calculates the acceptable margin value for a range question based on the given margin type.
- * This determines the range around the correct answer that is considered valid.
- *
- * @param {QuestionRangeAnswerMargin} margin - The margin type (None, Low, Medium, High, Maximum).
- * @param {number} correct - The correct answer value for the range question.
- *
- * @returns {number} - The calculated margin value. If the margin is Maximum, returns `Number.MAX_VALUE`.
- *                     If the margin is None, returns `0`.
- *
- * @example
- * calculateRangeMargin(QuestionRangeAnswerMargin.Low, 100) // Returns 5 (5% of 100)
- * calculateRangeMargin(QuestionRangeAnswerMargin.Medium, 100) // Returns 10 (10% of 100)
- * calculateRangeMargin(QuestionRangeAnswerMargin.High, 100) // Returns 20 (20% of 100)
- * calculateRangeMargin(QuestionRangeAnswerMargin.Maximum, 100) // Returns Number.MAX_VALUE
- * calculateRangeMargin(QuestionRangeAnswerMargin.None, 100) // Returns 0
- */
-export function calculateRangeMargin(
-  margin: QuestionRangeAnswerMargin,
-  correct: number,
-): number {
-  switch (margin) {
-    case QuestionRangeAnswerMargin.Low:
-      return Math.abs(correct) * 0.05 // 5%
-    case QuestionRangeAnswerMargin.Medium:
-      return Math.abs(correct) * 0.1 // 10%
-    case QuestionRangeAnswerMargin.High:
-      return Math.abs(correct) * 0.2 // 20%
-    case QuestionRangeAnswerMargin.Maximum:
-      return Number.MAX_VALUE // Accept all answers
-    default:
-      return 0 // None or invalid margin type
   }
 }
 

--- a/packages/quiz/src/pages/QuizCreatorPage/components/QuizCreatorPageUI/components/QuestionEditor/__snapshots__/QuestionEditor.test.tsx.snap
+++ b/packages/quiz/src/pages/QuizCreatorPage/components/QuizCreatorPageUI/components/QuestionEditor/__snapshots__/QuestionEditor.test.tsx.snap
@@ -1113,6 +1113,11 @@ exports[`QuestionEditor > renders a classic range question editor 1`] = `
             </div>
           </div>
         </div>
+        <div
+          class="footer"
+        >
+          Answers between 63 and 79 will be considered correct.
+        </div>
       </div>
     </div>
     <div

--- a/packages/quiz/src/pages/QuizCreatorPage/components/QuizCreatorPageUI/components/QuestionEditor/components/QuestionField/QuestionField.module.scss
+++ b/packages/quiz/src/pages/QuizCreatorPage/components/QuizCreatorPageUI/components/QuestionEditor/components/QuestionField/QuestionField.module.scss
@@ -7,15 +7,15 @@
   flex-direction: column;
 
   @include helpers.mobile {
-    row-gap: calc(#{variables.$mobile-narrow-layout-gutter} * 0.5);
+    row-gap: calc(#{variables.$mobile-narrow-layout-gutter} * 0.3);
   }
 
   @include helpers.tablet {
-    row-gap: calc(#{variables.$tablet-narrow-layout-gutter} * 0.5);
+    row-gap: calc(#{variables.$tablet-narrow-layout-gutter} * 0.3);
   }
 
   @include helpers.desktop {
-    row-gap: calc(#{variables.$desktop-narrow-layout-gutter} * 0.5);
+    row-gap: calc(#{variables.$desktop-narrow-layout-gutter} * 0.3);
   }
 
   &.layoutFull {
@@ -64,6 +64,11 @@
   .content {
     display: flex;
     flex-direction: column;
+  }
+
+  .footer {
+    display: flex;
+    flex-direction: row;
   }
 }
 

--- a/packages/quiz/src/pages/QuizCreatorPage/components/QuizCreatorPageUI/components/QuestionEditor/components/QuestionField/QuestionField.tsx
+++ b/packages/quiz/src/pages/QuizCreatorPage/components/QuizCreatorPageUI/components/QuestionEditor/components/QuestionField/QuestionField.tsx
@@ -15,7 +15,7 @@ import IconTooltip from '../../../../../../../../components/IconTooltip'
 import {
   QuestionRangeAnswerMarginLabels,
   QuestionTypeLabels,
-} from '../../../../../../../../models/labels.ts'
+} from '../../../../../../../../models'
 import { classNames } from '../../../../../../../../utils/helpers.ts'
 
 import MediaQuestionField from './MediaQuestionField'
@@ -25,7 +25,7 @@ import TrueFalseOptions from './TrueFalseOptions.tsx'
 import TypeAnswerOptions from './TypeAnswerOptions.tsx'
 import { QuestionFieldType } from './types.ts'
 
-export type QuestionFieldProps =
+export type QuestionFieldProps = (
   | {
       type: QuestionFieldType.CommonDuration
       value?: number
@@ -100,14 +100,16 @@ export type QuestionFieldProps =
       onChange: (values?: string[]) => void
       onValid: (valid: boolean) => void
     }
+) & { footer?: string }
 
 const QuestionFieldWrapper: FC<{
   label?: string
+  footer?: string
   layout?: 'full' | 'half'
   info?: ReactNode | ReactNode[] | string
   className?: string
   children: ReactNode
-}> = ({ label, layout = 'full', info, className, children }) => (
+}> = ({ label, footer, layout = 'full', info, className, children }) => (
   <div
     className={classNames(
       styles.questionFieldContainer,
@@ -122,6 +124,7 @@ const QuestionFieldWrapper: FC<{
       {info && <IconTooltip icon={faCircleInfo}>{info}</IconTooltip>}
     </div>
     <div className={classNames(styles.content, className)}>{children}</div>
+    {footer && <div className={styles.footer}>{footer}</div>}
   </div>
 )
 
@@ -148,7 +151,8 @@ const QuestionField: FC<QuestionFieldProps> = (props) => {
                 <li>4 minutes</li>
               </ul>
             </>
-          }>
+          }
+          footer={props.footer}>
           <Select
             id="duration-select"
             value={props.value !== undefined ? `${props.value}` : '30'}
@@ -211,7 +215,7 @@ const QuestionField: FC<QuestionFieldProps> = (props) => {
       )
     case QuestionFieldType.CommonMedia:
       return (
-        <QuestionFieldWrapper layout="full">
+        <QuestionFieldWrapper layout="full" footer={props.footer}>
           <MediaQuestionField
             value={props.value}
             onChange={props.onChange}
@@ -234,7 +238,8 @@ const QuestionField: FC<QuestionFieldProps> = (props) => {
                 <li>Double Points (2000)</li>
               </ul>
             </>
-          }>
+          }
+          footer={props.footer}>
           <Select
             id="points-select"
             value={props.value !== undefined ? `${props.value}` : '1000'}
@@ -262,7 +267,10 @@ const QuestionField: FC<QuestionFieldProps> = (props) => {
       )
     case QuestionFieldType.CommonQuestion:
       return (
-        <QuestionFieldWrapper label="Question" layout="full">
+        <QuestionFieldWrapper
+          label="Question"
+          layout="full"
+          footer={props.footer}>
           <TextField
             id="question-text-textfield"
             type="text"
@@ -280,7 +288,7 @@ const QuestionField: FC<QuestionFieldProps> = (props) => {
       )
     case QuestionFieldType.CommonType:
       return (
-        <QuestionFieldWrapper label="Type" layout="half">
+        <QuestionFieldWrapper label="Type" layout="half" footer={props.footer}>
           <Select
             id="question-type-select"
             value={props.value}
@@ -299,7 +307,8 @@ const QuestionField: FC<QuestionFieldProps> = (props) => {
         <QuestionFieldWrapper
           label="Options"
           layout="full"
-          info="The list of possible answers for a question.">
+          info="The list of possible answers for a question."
+          footer={props.footer}>
           <MultiChoiceOptions {...props} />
         </QuestionFieldWrapper>
       )
@@ -308,7 +317,8 @@ const QuestionField: FC<QuestionFieldProps> = (props) => {
         <QuestionFieldWrapper
           label="Correct"
           layout="half"
-          info="The correct value for the range question, which must be within the range of min and max.">
+          info="The correct value for the range question, which must be within the range of min and max."
+          footer={props.footer}>
           <TextField
             id="range-correct-textfield"
             type="number"
@@ -341,7 +351,8 @@ const QuestionField: FC<QuestionFieldProps> = (props) => {
                 <li>Maximum: Any answer is considered correct.</li>
               </ul>
             </>
-          }>
+          }
+          footer={props.footer}>
           <Select
             id="range-margin-select"
             value={props.value}
@@ -362,7 +373,8 @@ const QuestionField: FC<QuestionFieldProps> = (props) => {
         <QuestionFieldWrapper
           label="Max"
           layout="half"
-          info="The maximum possible value for the range question.">
+          info="The maximum possible value for the range question."
+          footer={props.footer}>
           <TextField
             id="range-max-textfield"
             type="number"
@@ -379,7 +391,8 @@ const QuestionField: FC<QuestionFieldProps> = (props) => {
         <QuestionFieldWrapper
           label="Min"
           layout="half"
-          info="The minimum possible value for the range question.">
+          info="The minimum possible value for the range question."
+          footer={props.footer}>
           <TextField
             id="range-min-textfield"
             type="number"
@@ -397,6 +410,7 @@ const QuestionField: FC<QuestionFieldProps> = (props) => {
         <QuestionFieldWrapper
           label="Options"
           layout="full"
+          footer={props.footer}
           className={styles.optionsContainer}>
           <TrueFalseOptions {...props} />
         </QuestionFieldWrapper>
@@ -407,6 +421,7 @@ const QuestionField: FC<QuestionFieldProps> = (props) => {
           label="Options"
           layout="full"
           info="The list of allowed typed answers for a question."
+          footer={props.footer}
           className={styles.optionsContainer}>
           <TypeAnswerOptions {...props} />
         </QuestionFieldWrapper>

--- a/packages/quiz/src/pages/QuizCreatorPage/components/QuizCreatorPageUI/components/QuestionEditor/components/QuestionForm/QuestionForm.tsx
+++ b/packages/quiz/src/pages/QuizCreatorPage/components/QuizCreatorPageUI/components/QuestionEditor/components/QuestionForm/QuestionForm.tsx
@@ -1,11 +1,13 @@
 import {
+  calculateRangeMargin,
   QuestionMultiChoiceDto,
+  QuestionRangeAnswerMargin,
   QuestionRangeDto,
   QuestionTrueFalseDto,
   QuestionTypeAnswerDto,
   QuestionZeroToOneHundredRangeDto,
 } from '@quiz/common'
-import React, { FC } from 'react'
+import React, { FC, useMemo } from 'react'
 
 import styles from '../../QuestionEditor.module.scss'
 import QuestionField, { QuestionFieldType } from '../QuestionField'
@@ -66,6 +68,29 @@ export const ClassicMultiChoiceOptionQuestionForm: FC<
 export const ClassicRangeQuestionForm: FC<
   QuestionFormProps<QuestionRangeDto>
 > = ({ data, onChange, onValidChange }) => {
+  const correctRangeMarginFooter = useMemo(() => {
+    const {
+      correct = 0,
+      margin = QuestionRangeAnswerMargin.Medium,
+      min = 0,
+      max = 100,
+    } = data
+
+    if (margin === QuestionRangeAnswerMargin.None) {
+      return `The correct answer must be exactly ${correct}.`
+    }
+
+    if (margin === QuestionRangeAnswerMargin.Maximum) {
+      return `All answers within the range ${min}–${max} will be accepted as correct.`
+    }
+
+    const marginValue = calculateRangeMargin(margin, correct)
+    const lowerBound = Math.floor(Math.max(min, correct - marginValue))
+    const upperBound = Math.ceil(Math.min(max, correct + marginValue))
+
+    return `Answers between ${lowerBound} and ${upperBound} will be considered correct.`
+  }, [data])
+
   return (
     <>
       <div className={styles.section}>
@@ -108,6 +133,7 @@ export const ClassicRangeQuestionForm: FC<
         <QuestionField
           type={QuestionFieldType.RangeMargin}
           value={data.margin}
+          footer={correctRangeMarginFooter}
           onChange={(newValue) => onChange('margin', newValue)}
           onValid={(valid) => onValidChange('margin', valid)}
         />

--- a/packages/quiz/src/pages/QuizCreatorPage/components/QuizCreatorPageUI/components/QuestionEditor/components/QuestionForm/__snapshots__/QuestionForm.test.tsx.snap
+++ b/packages/quiz/src/pages/QuizCreatorPage/components/QuizCreatorPageUI/components/QuestionEditor/components/QuestionForm/__snapshots__/QuestionForm.test.tsx.snap
@@ -968,6 +968,11 @@ exports[`QuestionForm > renders a classic range question form 1`] = `
           </div>
         </div>
       </div>
+      <div
+        class="footer"
+      >
+        Answers between 63 and 79 will be considered correct.
+      </div>
     </div>
   </div>
   <div


### PR DESCRIPTION
- Moved `calculateRangeMargin` from `task.converter.ts` to a new reusable utility in `utils/range-margin.helper.ts`.
- Exported the helper from the shared `utils/index.ts` barrel for easy access across packages.
- Updated usage in `task.converter` and `QuestionForm.tsx` to import the centralized helper.
- Polished `QuestionField` component to support optional footers, improving range margin explanations in the UI.
- Adjusted SCSS spacing and layout for cleaner rendering of footer content below fields.

Centralizes margin logic and improves maintainability while enhancing form clarity for range-based questions.