### PR TITLE
chore(dependabot): Switch package ecosystem from Yarn to NPM

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,24 +1,24 @@
 version: 2
 updates:
-  - package-ecosystem: "yarn"
+  - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "weekly"
     security-updates-only: false
 
-  - package-ecosystem: "yarn"
+  - package-ecosystem: "npm"
     directory: "/packages/common"
     schedule:
       interval: "weekly"
     security-updates-only: false
 
-  - package-ecosystem: "yarn"
+  - package-ecosystem: "npm"
     directory: "/packages/quiz"
     schedule:
       interval: "weekly"
     security-updates-only: false
 
-  - package-ecosystem: "yarn"
+  - package-ecosystem: "npm"
     directory: "/packages/quiz-service"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
- Updated `.github/dependabot.yml` to use `npm` as the package ecosystem instead of `yarn` for all monitored directories.
- This aligns with the project’s usage of NPM-compatible tooling.

Ensures Dependabot updates align with how dependencies are currently resolved.
