### PR TITLE
fix(dependabot): Remove unsupported `security-updates-only` fields fo…

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,25 +4,21 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    security-updates-only: false
 
   - package-ecosystem: "npm"
     directory: "/packages/common"
     schedule:
       interval: "weekly"
-    security-updates-only: false
 
   - package-ecosystem: "npm"
     directory: "/packages/quiz"
     schedule:
       interval: "weekly"
-    security-updates-only: false
 
   - package-ecosystem: "npm"
     directory: "/packages/quiz-service"
     schedule:
       interval: "weekly"
-    security-updates-only: false
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
…r npm

- Removed `security-updates-only: false` from all npm package-ecosystem entries in `dependabot.yml`.
- This field is not supported for npm and caused schema validation errors.

Fixes dependabot configuration validation for npm entries.
