### PR TITLE
chore(dependabot): consolidate directory list and add grouping rules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,26 +1,21 @@
 version: 2
 updates:
   - package-ecosystem: "npm"
-    directory: "/"
+    directories:
+      - "/"
+      - "/packages/**"
     schedule:
       interval: "weekly"
-
-  - package-ecosystem: "npm"
-    directory: "/packages/common"
-    schedule:
-      interval: "weekly"
-
-  - package-ecosystem: "npm"
-    directory: "/packages/quiz"
-    schedule:
-      interval: "weekly"
-
-  - package-ecosystem: "npm"
-    directory: "/packages/quiz-service"
-    schedule:
-      interval: "weekly"
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      all-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
* Replace multiple `directory:` blocks with a single `directories:` list covering `/` and all workspaces under `/packages/**`.
* Add `groups` stanza (`all-dependencies`) to bundle all npm updates.
* Add matching `groups` stanza (`all-actions`) for GitHub Actions updates.
* Removes redundant per-package update blocks, reducing config noise and preventing duplicate scans while keeping the weekly cadence unchanged.