### PR TITLE
chore(monorepo): link @quiz/common locally and tell Dependabot to ign…

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,8 @@ updates:
       all-dependencies:
         patterns:
           - "*"
+    ignore:
+      - dependency-name: "@quiz/common"
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/packages/quiz-service/package.json
+++ b/packages/quiz-service/package.json
@@ -35,7 +35,7 @@
     "@nestjs/swagger": "^11.2.0",
     "@nestjs/terminus": "^11.0.0",
     "@nestjs/throttler": "^6.4.0",
-    "@quiz/common": "1.0.0",
+    "@quiz/common": "file:../common",
     "axios": "^1.9.0",
     "bcryptjs": "^3.0.2",
     "bullmq": "^5.52.3",

--- a/packages/quiz/package.json
+++ b/packages/quiz/package.json
@@ -23,7 +23,7 @@
     "@fortawesome/free-regular-svg-icons": "^6.7.2",
     "@fortawesome/free-solid-svg-icons": "^6.7.2",
     "@fortawesome/react-fontawesome": "^0.2.2",
-    "@quiz/common": "1.0.0",
+    "@quiz/common": "file:../common",
     "@tanstack/react-query": "5.76.1",
     "date-fns": "^4.1.0",
     "date-fns-tz": "^3.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1851,6 +1851,9 @@
   resolved "https://registry.yarnpkg.com/@pkgr/core/-/core-0.2.7.tgz#eb5014dfd0b03e7f3ba2eeeff506eed89b028058"
   integrity sha512-YLT9Zo3oNPJoBjBc4q8G2mjU4tqIbf5CEOORbUUr48dCD9q3umJ3IPlVqOqDakPfd2HuwccBaqlGhN4Gmr5OWg==
 
+"@quiz/common@file:packages/common":
+  version "1.0.0"
+
 "@redis/bloom@1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@redis/bloom/-/bloom-1.2.0.tgz#d3fd6d3c0af3ef92f26767b56414a370c7b63b71"


### PR DESCRIPTION
…ore it

* Switch @quiz/common in `packages/quiz` and `packages/quiz-service` from a published semver (`"1.0.0"`) to a path reference `"file:../common"`, making it an in-repo dependency.
* Add an `ignore:` entry for `@quiz/common` in `.github/dependabot.yml` so Dependabot stops attempting registry resolution and PRs.
* Regenerate `yarn.lock` to include the new `@quiz/common@file:packages/common` entry.

This eliminates the `private_source_authentication_failure` Dependabot error and keeps the monorepo fully self-contained.