### PR TITLE
feat(auth): add login & refresh endpoints and DTOs

### DIFF
--- a/packages/common/src/models/auth.ts
+++ b/packages/common/src/models/auth.ts
@@ -1,0 +1,39 @@
+/**
+ * Data transfer object for authentication login requests.
+ */
+export interface AuthLoginRequestDto {
+  /**
+   * The user’s email address, used to identify their account.
+   */
+  email: string
+
+  /**
+   * The user’s password, used to verify their identity.
+   */
+  password: string
+}
+
+/**
+ * Data transfer object for authentication login responses.
+ */
+export interface AuthLoginResponseDto {
+  /**
+   * JWT access token—short-lived credential for resource access.
+   */
+  accessToken: string
+
+  /**
+   * JWT refresh token—longer-lived credential to obtain new access tokens.
+   */
+  refreshToken: string
+}
+
+/**
+ * Data transfer object for authentication refresh requests.
+ */
+export interface AuthRefreshRequestDto {
+  /**
+   * The refresh token previously issued during login.
+   */
+  refreshToken: string
+}

--- a/packages/common/src/models/index.ts
+++ b/packages/common/src/models/index.ts
@@ -1,3 +1,4 @@
+export * from './auth'
 export * from './find-game-response.dto'
 export * from './game.dto'
 export * from './game-event'

--- a/packages/common/src/utils/constants.ts
+++ b/packages/common/src/utils/constants.ts
@@ -69,3 +69,15 @@ export const MEDIA_SEARCH_TERM_REGEX = /^[a-zA-Z0-9_ ]{2,20}$/
 export const UPLOAD_IMAGE_MIN_FILE_SIZE = 1 // 1 byte
 export const UPLOAD_IMAGE_MAX_FILE_SIZE = 20 * 1024 * 1024 // 20mb
 export const UPLOAD_IMAGE_MIMETYPE_REGEX = /^image\/(gif|jpeg|png|tiff|webp)$/
+
+/* Password */
+export const PASSWORD_MIN_LENGTH = 8
+export const PASSWORD_MAX_LENGTH = 128
+export const PASSWORD_REGEX =
+  /^(?=(?:.*[a-z]){2,})(?=(?:.*[A-Z]){2,})(?=(?:.*\d){2,})(?=(?:.*[^A-Za-z0-9]){2,}).{8,128}$/
+
+/* Email */
+export const EMAIL_MIN_LENGTH = 6
+export const EMAIL_MAX_LENGTH = 128
+export const EMAIL_REGEX =
+  /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/

--- a/packages/quiz-service/src/auth/controllers/auth.controller.ts
+++ b/packages/quiz-service/src/auth/controllers/auth.controller.ts
@@ -1,4 +1,11 @@
-import { Body, Controller, HttpCode, HttpStatus, Post } from '@nestjs/common'
+import {
+  Body,
+  Controller,
+  HttpCode,
+  HttpStatus,
+  NotImplementedException,
+  Post,
+} from '@nestjs/common'
 import {
   ApiBadRequestResponse,
   ApiBody,
@@ -10,7 +17,13 @@ import {
 import { AuthService } from '../services'
 
 import { Public } from './decorators'
-import { LegacyAuthRequest, LegacyAuthResponse } from './models'
+import {
+  AuthLoginRequest,
+  AuthLoginResponse,
+  AuthRefreshRequest,
+  LegacyAuthRequest,
+  LegacyAuthResponse,
+} from './models'
 
 /**
  * Controller for managing authentication.
@@ -24,6 +37,73 @@ export class AuthController {
    * @param {AuthService} authService - The service handling authentication logic.
    */
   constructor(private readonly authService: AuthService) {}
+
+  /**
+   * Authenticates a user by verifying their email and password,
+   * then issues a new access token and refresh token.
+   *
+   * @param authLoginRequest - Request containing the user's email and password.
+   * @returns Promise resolving to an AuthLoginResponse with both tokens.
+   */
+  @Public()
+  @Post('/login')
+  @ApiOperation({
+    summary: 'Authenticate with email and password',
+    description:
+      'Verifies user credentials and issues a new access token and refresh token.',
+  })
+  @ApiBody({
+    description: 'Payload containing the user’s email and password.',
+    type: AuthLoginRequest,
+  })
+  @ApiOkResponse({
+    description: 'Returns the issued access and refresh tokens.',
+    type: AuthLoginResponse,
+  })
+  @ApiBadRequestResponse({
+    description: 'Validation failed or credentials are incorrect.',
+  })
+  @HttpCode(HttpStatus.OK)
+  public async login(
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    @Body() authLoginRequest: AuthLoginRequest,
+  ): Promise<AuthLoginResponse> {
+    throw new NotImplementedException()
+  }
+
+  /**
+   * Validates the provided refresh token and issues a new access token
+   * (and rotates the refresh token if applicable).
+   *
+   * @param authRefreshRequest - Request containing the existing refresh token.
+   * @returns Promise resolving to an AuthLoginResponse with new tokens.
+   */
+  @Public()
+  @Post('/refresh')
+  @ApiOperation({
+    summary: 'Refresh access token using a refresh token',
+    description:
+      'Validates the provided refresh token and issues a new access token (and optionally a new refresh token).',
+  })
+  @ApiBody({
+    description: 'Payload containing the existing refresh token.',
+    type: AuthRefreshRequest,
+  })
+  @ApiOkResponse({
+    description:
+      'Returns a new access token and, if rotated, a new refresh token.',
+    type: AuthLoginResponse,
+  })
+  @ApiBadRequestResponse({
+    description: 'Validation failed or refresh token is invalid/expired.',
+  })
+  @HttpCode(HttpStatus.OK)
+  public async refresh(
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    @Body() authRefreshRequest: AuthRefreshRequest,
+  ): Promise<AuthLoginResponse> {
+    throw new NotImplementedException()
+  }
 
   /**
    * Authenticates a client and returns a JWT token.

--- a/packages/quiz-service/src/auth/controllers/models/auth-login.request.ts
+++ b/packages/quiz-service/src/auth/controllers/models/auth-login.request.ts
@@ -1,0 +1,52 @@
+import { ApiProperty } from '@nestjs/swagger'
+import {
+  AuthLoginRequestDto,
+  EMAIL_MAX_LENGTH,
+  EMAIL_MIN_LENGTH,
+  EMAIL_REGEX,
+  PASSWORD_MAX_LENGTH,
+  PASSWORD_MIN_LENGTH,
+  PASSWORD_REGEX,
+} from '@quiz/common'
+import { Matches, MaxLength, MinLength } from 'class-validator'
+
+/**
+ * Request object for user login.
+ */
+export class AuthLoginRequest implements AuthLoginRequestDto {
+  /**
+   * The user’s email address for login.
+   */
+  @ApiProperty({
+    title: 'Email',
+    description: 'User email to authenticate.',
+    type: String,
+    pattern: `${EMAIL_REGEX}`,
+    example: 'user@example.com',
+  })
+  @MinLength(EMAIL_MIN_LENGTH)
+  @MaxLength(EMAIL_MAX_LENGTH)
+  @Matches(EMAIL_REGEX, {
+    message: 'Email must be a valid address.',
+  })
+  readonly email: string
+
+  /**
+   * The user’s password for login.
+   */
+  @ApiProperty({
+    title: 'Password',
+    description:
+      'User password; 8–128 chars, min 2 uppercase, 2 lowercase, 2 digits, 2 symbols.',
+    type: String,
+    pattern: `${PASSWORD_REGEX}`,
+    example: 'Super#SecretPassw0rd123',
+  })
+  @MinLength(PASSWORD_MIN_LENGTH)
+  @MaxLength(PASSWORD_MAX_LENGTH)
+  @Matches(PASSWORD_REGEX, {
+    message:
+      'Password must include ≥2 uppercase, ≥2 lowercase, ≥2 digits, ≥2 symbols.',
+  })
+  readonly password: string
+}

--- a/packages/quiz-service/src/auth/controllers/models/auth-login.response.ts
+++ b/packages/quiz-service/src/auth/controllers/models/auth-login.response.ts
@@ -1,0 +1,31 @@
+import { ApiProperty } from '@nestjs/swagger'
+import { AuthLoginResponseDto } from '@quiz/common'
+
+/**
+ * Response object for successful login.
+ */
+export class AuthLoginResponse implements AuthLoginResponseDto {
+  /**
+   * JWT access token for use in protected requests.
+   */
+  @ApiProperty({
+    title: 'Access Token',
+    description: 'Short-lived JWT for API authentication.',
+    type: String,
+    format: 'bearer',
+    example: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...',
+  })
+  readonly accessToken: string
+
+  /**
+   * JWT refresh token to obtain new access tokens.
+   */
+  @ApiProperty({
+    title: 'Refresh Token',
+    description: 'Long-lived JWT used to refresh the access token.',
+    type: String,
+    format: 'bearer',
+    example: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...',
+  })
+  readonly refreshToken: string
+}

--- a/packages/quiz-service/src/auth/controllers/models/auth-refresh.request.ts
+++ b/packages/quiz-service/src/auth/controllers/models/auth-refresh.request.ts
@@ -1,0 +1,21 @@
+import { ApiProperty } from '@nestjs/swagger'
+import { AuthRefreshRequestDto } from '@quiz/common'
+import { IsJWT } from 'class-validator'
+
+/**
+ * Request object for refreshing JWT tokens.
+ */
+export class AuthRefreshRequest implements AuthRefreshRequestDto {
+  /**
+   * The refresh token issued previously during login or refresh.
+   */
+  @ApiProperty({
+    title: 'Refresh Token',
+    description: 'JWT refresh token for issuing a new access token.',
+    type: String,
+    format: 'bearer',
+    example: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...',
+  })
+  @IsJWT()
+  readonly refreshToken: string
+}

--- a/packages/quiz-service/src/auth/controllers/models/index.ts
+++ b/packages/quiz-service/src/auth/controllers/models/index.ts
@@ -1,3 +1,6 @@
+export * from './auth-login.request'
+export * from './auth-login.response'
+export * from './auth-refresh.request'
 export * from './legacy-auth.request'
 export * from './legacy-auth.response'
 export * from './legacy-auth-client.response'


### PR DESCRIPTION
- introduce AuthLoginRequestDto, AuthLoginResponseDto, AuthRefreshRequestDto in common models
- export new auth model from common/src/models/index.ts
- add EMAIL_* and PASSWORD_* length/regex constants to common utils
- scaffold POST /auth/login and POST /auth/refresh in AuthController, with Swagger decorators, JSDoc, and NotImplementedException stubs
- implement AuthLoginRequest, AuthLoginResponse, AuthRefreshRequest DTO classes in quiz-service, with validation and ApiProperty metadata
- update models/index.ts to export new auth-login and auth-refresh models