### PR TITLE
feat(user): add user persistence layer with schema, repository, and service

### DIFF
--- a/packages/quiz-service/src/user/exceptions/email-not-unique.exception.ts
+++ b/packages/quiz-service/src/user/exceptions/email-not-unique.exception.ts
@@ -1,0 +1,12 @@
+import { ConflictException } from '@nestjs/common'
+
+/**
+ * Thrown when the email is already in use (HTTP 409).
+ *
+ * @extends {ConflictException}
+ */
+export class EmailNotUniqueException extends ConflictException {
+  constructor(email: string) {
+    super(`Email "${email}" is not unique`)
+  }
+}

--- a/packages/quiz-service/src/user/exceptions/index.ts
+++ b/packages/quiz-service/src/user/exceptions/index.ts
@@ -1,0 +1,1 @@
+export * from './email-not-unique.exception'

--- a/packages/quiz-service/src/user/services/index.ts
+++ b/packages/quiz-service/src/user/services/index.ts
@@ -1,1 +1,2 @@
+export * from './user.repository'
 export * from './user.service'

--- a/packages/quiz-service/src/user/services/models/schemas/index.ts
+++ b/packages/quiz-service/src/user/services/models/schemas/index.ts
@@ -1,0 +1,1 @@
+export * from './user.schema'

--- a/packages/quiz-service/src/user/services/models/schemas/user.schema.ts
+++ b/packages/quiz-service/src/user/services/models/schemas/user.schema.ts
@@ -1,0 +1,103 @@
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose'
+import { Model, now } from 'mongoose'
+
+/**
+ * Which authentication provider created this account. *
+ * Values:
+ * - `LOCAL`: email/password stored locally
+ */
+export enum AuthProvider {
+  Local = 'LOCAL',
+}
+
+/**
+ * Mongoose schema for the User collection.
+ */
+@Schema({
+  _id: true,
+  collection: 'users',
+  discriminatorKey: 'provider',
+  timestamps: true,
+})
+export class User {
+  /**
+   * The unique identifier of the user.
+   * Acts as the primary key in the database.
+   */
+  @Prop({ type: String, required: true })
+  _id: string
+
+  /**
+   * Authentication provider.
+   * Stored as one of the AuthProvider values (e.g. `"LOCAL"`).
+   */
+  @Prop({
+    type: String,
+    enum: Object.values(AuthProvider),
+    required: true,
+  })
+  provider!: AuthProvider.Local
+
+  /**
+   * The user’s unique email address.
+   */
+  @Prop({ type: String, unique: true, required: true })
+  email: string
+
+  /**
+   * Optional given name (first name) of the user.
+   */
+  @Prop({ type: String, required: false })
+  givenName?: string
+
+  /**
+   * Optional family name (last name) of the user.
+   */
+  @Prop({ type: String, required: false })
+  familyName?: string
+
+  /**
+   * Timestamp when the user was created (ISO-8601 string).
+   */
+  @Prop({ type: Date, default: now() })
+  createdAt: Date
+
+  /**
+   * Timestamp when the user was last updated (ISO-8601 string).
+   */
+  @Prop({ type: Date, default: now() })
+  updatedAt: Date
+}
+
+/**
+ * Mongoose model type for the User schema.
+ */
+export type UserModel = Model<User>
+
+/**
+ * Schema factory for the User class.
+ */
+export const UserSchema = SchemaFactory.createForClass(User)
+
+/**
+ * Password hash for users who registered locally.
+ * Only applies when `provider === AuthProvider.LOCAL`.
+ */
+@Schema({ _id: false })
+export class LocalUser {
+  /**
+   * Must be "LOCAL" for this subdocument.
+   */
+  provider!: AuthProvider.Local
+
+  /**
+   * The user’s hashed password for a local account.
+   */
+  @Prop({ type: String, required: true })
+  hashedPassword: string
+}
+
+/**
+ * Schema factory for the LocalUser class.
+ */
+export const LocalUserSchema = SchemaFactory.createForClass(LocalUser)

--- a/packages/quiz-service/src/user/services/user.repository.ts
+++ b/packages/quiz-service/src/user/services/user.repository.ts
@@ -1,0 +1,69 @@
+import { Injectable, Logger } from '@nestjs/common'
+import { InjectModel } from '@nestjs/mongoose'
+import { v4 as uuidv4 } from 'uuid'
+
+import { EmailNotUniqueException } from '../exceptions'
+
+import { AuthProvider, User, UserModel } from './models/schemas'
+
+/**
+ * Repository for interacting with the User collection in the database.
+ */
+@Injectable()
+export class UserRepository {
+  // Logger instance for recording repository operations.
+  private readonly logger: Logger = new Logger(UserRepository.name)
+
+  /**
+   * Constructs the UserRepository.
+   *
+   * @param userModel - The Mongoose model representing the User schema.
+   */
+  public constructor(
+    @InjectModel(User.name) private readonly userModel: UserModel,
+  ) {}
+
+  /**
+   * Finds a user document by email.
+   *
+   * @param email - The email address to search for.
+   * @returns The matching User document, or null if none exists.
+   */
+  public async findUserByEmail(email: string): Promise<User> {
+    return this.userModel.findOne({ email }).exec()
+  }
+
+  /**
+   * Ensures the provided email is not already used by another user.
+   *
+   * @param email - The email address to verify.
+   * @throws EmailNotUniqueException if a user with the given email already exists.
+   */
+  public async verifyUniqueEmail(email: string): Promise<void> {
+    const foundUser = await this.findUserByEmail(email)
+
+    if (foundUser) {
+      this.logger.debug(`User email was not unique: "${email}".`)
+      throw new EmailNotUniqueException(email)
+    }
+  }
+
+  /**
+   * Creates and persists a new local‐auth user record.
+   *
+   * @param details - Object containing email, hashedPassword, givenName and familyName.
+   * @returns The newly created User document.
+   */
+  public async createLocalUser(details: {
+    email: string
+    hashedPassword: string
+    givenName?: string
+    familyName?: string
+  }): Promise<User> {
+    return new this.userModel({
+      _id: uuidv4(),
+      provider: AuthProvider.Local,
+      ...details,
+    }).save()
+  }
+}

--- a/packages/quiz-service/src/user/services/user.service.ts
+++ b/packages/quiz-service/src/user/services/user.service.ts
@@ -1,15 +1,24 @@
-import { Injectable, NotImplementedException } from '@nestjs/common'
+import { Injectable, Logger } from '@nestjs/common'
 import { CreateUserRequestDto, CreateUserResponseDto } from '@quiz/common'
+import * as bcrypt from 'bcryptjs'
+
+import { User } from './models/schemas'
+import { UserRepository } from './user.repository'
 
 /**
  * Service responsible for creating and retrieving user accounts.
  */
 @Injectable()
 export class UserService {
+  // Logger instance for recording service operations.
+  private readonly logger: Logger = new Logger(UserService.name)
+
   /**
    * Initializes the UserService.
+   *
+   * @param userRepository - Repository for user data access.
    */
-  constructor() {}
+  constructor(private readonly userRepository: UserRepository) {}
 
   /**
    * Creates and persists a new user record.
@@ -18,9 +27,50 @@ export class UserService {
    * @returns Created user data including timestamps.
    */
   public async createUser(
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     requestDto: CreateUserRequestDto,
   ): Promise<CreateUserResponseDto> {
-    throw new NotImplementedException()
+    const { email, password, givenName, familyName } = requestDto
+
+    this.logger.debug(`Creating new user with email: "${email}".`)
+
+    await this.userRepository.verifyUniqueEmail(email)
+
+    const salt = await bcrypt.genSalt(10)
+    const hashedPassword = await bcrypt.hash(password, salt)
+
+    const createdUser = await this.userRepository.createLocalUser({
+      email,
+      hashedPassword,
+      givenName,
+      familyName,
+    })
+
+    this.logger.log(`Created a new user with email: "${email}".`)
+
+    return UserService.toCreateUserResponse(createdUser)
+  }
+
+  /**
+   * Transforms a User document into a CreateUserResponseDto.
+   *
+   * @param createdUser - The User document returned from the database.
+   * @returns DTO containing id, email, optional names, and timestamps.
+   *
+   * @private
+   */
+  private static toCreateUserResponse(
+    createdUser: User,
+  ): CreateUserResponseDto {
+    const { _id, email, givenName, familyName, createdAt, updatedAt } =
+      createdUser
+
+    return {
+      id: _id,
+      email,
+      givenName,
+      familyName,
+      created: createdAt,
+      updated: updatedAt,
+    }
   }
 }

--- a/packages/quiz-service/src/user/user.module.ts
+++ b/packages/quiz-service/src/user/user.module.ts
@@ -1,15 +1,30 @@
 import { Module } from '@nestjs/common'
+import { MongooseModule } from '@nestjs/mongoose'
 
 import { UserController } from './controllers'
-import { UserService } from './services'
+import { UserRepository, UserService } from './services'
+import {
+  AuthProvider,
+  LocalUserSchema,
+  User,
+  UserSchema,
+} from './services/models/schemas'
 
 /**
  * Module for managing user-related operations.
  */
 @Module({
-  imports: [],
+  imports: [
+    MongooseModule.forFeature([
+      {
+        name: User.name,
+        schema: UserSchema,
+        discriminators: [{ name: AuthProvider.Local, schema: LocalUserSchema }],
+      },
+    ]),
+  ],
   controllers: [UserController],
-  providers: [UserService],
+  providers: [UserService, UserRepository],
   exports: [UserService],
 })
 export class UserModule {}


### PR DESCRIPTION
- add EmailNotUniqueException (HTTP 409) and export from exceptions index
- define AuthProvider enum and User schema with timestamps & provider discriminator
- implement LocalUser sub-schema for storing password hash
- register schemas in UserModule via MongooseModule.forFeature
- create UserRepository:
  • findUserByEmail().exec()
  • verifyUniqueEmail() throws EmailNotUniqueException
  • createLocalUser() sets uuid and provider
- implement UserService.createUser():
  • log start/end of flow
  • verify unique email
  • bcrypt-hash password
  • call repository.createLocalUser()
  • map result to CreateUserResponseDto via toCreateUserResponse()