### PR TITLE
ci: enable test coverage collection and upload to Codecov

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,5 +42,12 @@ jobs:
       - name: Lint
         run: yarn lint
 
-      - name: Test
-        run: yarn test
+      - name: Test & Coverage
+        run: |
+          yarn test:coverage
+
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./packages/quiz/coverage/lcov.info,./packages/quiz-service/coverage/lcov.info

--- a/package.json
+++ b/package.json
@@ -16,7 +16,9 @@
     "serve": "concurrently \"yarn workspace @quiz/quiz-service serve\" \"yarn workspace @quiz/quiz serve\"",
     "lint": "yarn workspaces run lint",
     "lint:fix": "yarn workspaces run lint:fix",
-    "test": "concurrently \"yarn workspace @quiz/quiz-service test\" \"yarn workspace @quiz/quiz test\""
+    "test": "concurrently \"yarn workspace @quiz/quiz-service test\" \"yarn workspace @quiz/quiz test\"",
+    "test:e2e": "concurrently \"yarn workspace @quiz/quiz-service test:e2e\"",
+    "test:coverage": "concurrently \"yarn workspace @quiz/quiz-service test:coverage\" \"yarn workspace @quiz/quiz test:coverage\""
   },
   "devDependencies": {
     "@eslint/js": "^9.29.0",

--- a/packages/quiz-service/jest.config.cjs
+++ b/packages/quiz-service/jest.config.cjs
@@ -1,0 +1,9 @@
+// jest.config.cjs
+// eslint-disable-next-line no-undef
+module.exports = {
+  projects: ['<rootDir>/jest.json', '<rootDir>/test/jest-e2e.json'],
+  collectCoverage: true,
+  coverageDirectory: '<rootDir>/coverage',
+  detectOpenHandles: true,
+  forceExit: true,
+}

--- a/packages/quiz-service/jest.json
+++ b/packages/quiz-service/jest.json
@@ -1,0 +1,21 @@
+{
+  "moduleFileExtensions": ["js", "json", "ts"],
+  "rootDir": "src",
+  "testRegex": ".*\\.spec\\.ts$",
+  "transform": {
+    "^.+\\.(t|j)s$": "ts-jest"
+  },
+  "moduleNameMapper": {
+    "^@quiz/common(.*)$": "<rootDir>/../../common/src$1"
+  },
+  "collectCoverageFrom": [
+    "**/*.(t|j)s"
+  ],
+  "coverageDirectory": "../coverage",
+  "testEnvironment": "node",
+  "transformIgnorePatterns": [
+    "/node_modules/(?!@quiz/common)"
+  ],
+  "detectOpenHandles": true,
+  "maxWorkers": 1
+}

--- a/packages/quiz-service/package.json
+++ b/packages/quiz-service/package.json
@@ -11,8 +11,8 @@
     "serve": "node dist/main",
     "lint": "eslint .",
     "lint:fix": "yarn lint --fix",
-    "test": "jest --runInBand --detectOpenHandles --forceExit --testTimeout=30000",
-    "test:watch": "jest --watch",
+    "test": "jest --config ./jest.json",
+    "test:e2e": "jest --config ./test/jest-e2e.json",
     "test:coverage": "jest --coverage",
     "check-circular-deps": "./scripts/check_circular_deps.sh 0"
   },
@@ -71,31 +71,5 @@
     "ts-loader": "^9.5.2",
     "ts-node": "^10.9.2",
     "tsconfig-paths": "^4.2.0"
-  },
-  "jest": {
-    "moduleFileExtensions": [
-      "js",
-      "json",
-      "ts"
-    ],
-    "rootDir": "src",
-    "testRegex": ".*\\.(e2e-)?spec\\.ts$",
-    "transform": {
-      "^.+\\.(t|j)s$": "ts-jest"
-    },
-    "moduleNameMapper": {
-      "^@quiz/common(.*)$": "<rootDir>/../../common/src$1"
-    },
-    "collectCoverageFrom": [
-      "**/*.(t|j)s"
-    ],
-    "coverageDirectory": "../coverage",
-    "testEnvironment": "node",
-    "transformIgnorePatterns": [
-      "/node_modules/(?!@quiz/common)"
-    ],
-    "detectOpenHandles": true,
-    "forceExit": true,
-    "maxWorkers": 1
   }
 }

--- a/packages/quiz-service/test/auth.controller.e2e-spec.ts
+++ b/packages/quiz-service/test/auth.controller.e2e-spec.ts
@@ -4,8 +4,9 @@ import * as bcrypt from 'bcryptjs'
 import supertest from 'supertest'
 import { v4 as uuidv4 } from 'uuid'
 
-import { closeTestApp, createTestApp } from '../../../test/utils/bootstrap'
-import { ClientService } from '../../client/services'
+import { ClientService } from '../src/client/services'
+
+import { closeTestApp, createTestApp } from './utils/bootstrap'
 
 describe('AuthController (e2e)', () => {
   let app: INestApplication

--- a/packages/quiz-service/test/client-game.controller.e2e-spec.ts
+++ b/packages/quiz-service/test/client-game.controller.e2e-spec.ts
@@ -4,6 +4,11 @@ import { GameMode, GameParticipantType, GameStatus } from '@quiz/common'
 import supertest from 'supertest'
 import { v4 as uuidv4 } from 'uuid'
 
+import { AuthService } from '../src/auth/services'
+import { Client, ClientModel } from '../src/client/services/models/schemas'
+import { Game, GameModel } from '../src/game/services/models/schemas'
+import { Player, PlayerModel } from '../src/player/services/models/schemas'
+
 import {
   createMockClientDocument,
   createMockGameDocument,
@@ -13,12 +18,8 @@ import {
   createMockQuestionTaskDocument,
   createMockQuitTaskDocument,
   offsetSeconds,
-} from '../../../test/data'
-import { closeTestApp, createTestApp } from '../../../test/utils/bootstrap'
-import { AuthService } from '../../auth/services'
-import { Client, ClientModel } from '../../client/services/models/schemas'
-import { Player, PlayerModel } from '../../player/services/models/schemas'
-import { Game, GameModel } from '../services/models/schemas'
+} from './data'
+import { closeTestApp, createTestApp } from './utils/bootstrap'
 
 describe('ClientGameController (e2e)', () => {
   let app: INestApplication

--- a/packages/quiz-service/test/client-player.controller.e2e-spec.ts
+++ b/packages/quiz-service/test/client-player.controller.e2e-spec.ts
@@ -4,18 +4,19 @@ import { PLAYER_LINK_CODE_REGEX } from '@quiz/common'
 import supertest from 'supertest'
 import { v4 as uuidv4 } from 'uuid'
 
+import { AuthService } from '../src/auth/services'
+import { Client, ClientModel } from '../src/client/services/models/schemas'
+import { PlayerService } from '../src/player/services'
+import { Player, PlayerModel } from '../src/player/services/models/schemas'
+
 import {
   createMockClientDocument,
   createMockPlayerDocument,
   MOCK_DEFAULT_PLAYER_ID,
   MOCK_DEFAULT_PLAYER_NICKNAME,
   MOCK_SECONDARY_PLAYER_NICKNAME,
-} from '../../../test/data'
-import { closeTestApp, createTestApp } from '../../../test/utils/bootstrap'
-import { AuthService } from '../../auth/services'
-import { Client, ClientModel } from '../../client/services/models/schemas'
-import { PlayerService } from '../services'
-import { Player, PlayerModel } from '../services/models/schemas'
+} from './data'
+import { closeTestApp, createTestApp } from './utils/bootstrap'
 
 describe('ClientPlayerController (e2e)', () => {
   let app: INestApplication

--- a/packages/quiz-service/test/client-quiz.controller.e2e-spec.ts
+++ b/packages/quiz-service/test/client-quiz.controller.e2e-spec.ts
@@ -10,10 +10,11 @@ import {
 import supertest from 'supertest'
 import { v4 as uuidv4 } from 'uuid'
 
-import { closeTestApp, createTestApp } from '../../../test/utils/bootstrap'
-import { AuthService } from '../../auth/services'
-import { ClientService } from '../../client/services'
-import { QuizService } from '../services'
+import { AuthService } from '../src/auth/services'
+import { ClientService } from '../src/client/services'
+import { QuizService } from '../src/quiz/services'
+
+import { closeTestApp, createTestApp } from './utils/bootstrap'
 
 describe('ClientQuizController (e2e)', () => {
   let app: INestApplication

--- a/packages/quiz-service/test/game-result.controller.e2e-spec.ts
+++ b/packages/quiz-service/test/game-result.controller.e2e-spec.ts
@@ -12,13 +12,14 @@ import { Model } from 'mongoose'
 import supertest from 'supertest'
 import { v4 as uuidv4 } from 'uuid'
 
-import { closeTestApp, createTestApp } from '../../../test/utils/bootstrap'
-import { AuthService } from '../../auth/services'
-import { ClientService } from '../../client/services'
-import { Client } from '../../client/services/models/schemas'
-import { Player } from '../../player/services/models/schemas'
-import { Quiz } from '../../quiz/services/models/schemas'
-import { Game, GameResult, TaskType } from '../services/models/schemas'
+import { AuthService } from '../src/auth/services'
+import { ClientService } from '../src/client/services'
+import { Client } from '../src/client/services/models/schemas'
+import { Game, GameResult, TaskType } from '../src/game/services/models/schemas'
+import { Player } from '../src/player/services/models/schemas'
+import { Quiz } from '../src/quiz/services/models/schemas'
+
+import { closeTestApp, createTestApp } from './utils/bootstrap'
 
 describe('GameResultController (e2e)', () => {
   let app: INestApplication

--- a/packages/quiz-service/test/game.e2e-spec.ts
+++ b/packages/quiz-service/test/game.e2e-spec.ts
@@ -15,6 +15,27 @@ import {
 import supertest from 'supertest'
 import { v4 as uuidv4 } from 'uuid'
 
+import { AuthService } from '../src/auth/services'
+import { ClientService } from '../src/client/services'
+import { Client } from '../src/client/services/models/schemas'
+import { GameService } from '../src/game/services'
+import {
+  BaseTask,
+  Game,
+  GameModel,
+  QuestionResultTask,
+  QuestionResultTaskItem,
+  QuestionTaskBaseAnswer,
+  QuestionTaskMultiChoiceAnswer,
+  QuestionTaskRangeAnswer,
+  QuestionTaskTrueFalseAnswer,
+  QuestionTaskTypeAnswerAnswer,
+  TaskType,
+} from '../src/game/services/models/schemas'
+import { buildLobbyTask } from '../src/game/services/utils'
+import { Player, PlayerModel } from '../src/player/services/models/schemas'
+import { QuizService } from '../src/quiz/services'
+
 import {
   createMockGameDocument,
   createMockGameHostParticipantDocument,
@@ -32,28 +53,8 @@ import {
   MOCK_TYPE_ANSWER_OPTION_VALUE,
   MOCK_TYPE_ANSWER_OPTION_VALUE_ALTERNATIVE,
   offsetSeconds,
-} from '../../../test/data'
-import { closeTestApp, createTestApp } from '../../../test/utils/bootstrap'
-import { AuthService } from '../../auth/services'
-import { ClientService } from '../../client/services'
-import { Client } from '../../client/services/models/schemas'
-import { Player, PlayerModel } from '../../player/services/models/schemas'
-import { QuizService } from '../../quiz/services'
-import { GameService } from '../services'
-import {
-  BaseTask,
-  Game,
-  GameModel,
-  QuestionResultTask,
-  QuestionResultTaskItem,
-  QuestionTaskBaseAnswer,
-  QuestionTaskMultiChoiceAnswer,
-  QuestionTaskRangeAnswer,
-  QuestionTaskTrueFalseAnswer,
-  QuestionTaskTypeAnswerAnswer,
-  TaskType,
-} from '../services/models/schemas'
-import { buildLobbyTask } from '../services/utils'
+} from './data'
+import { closeTestApp, createTestApp } from './utils/bootstrap'
 
 describe('GameController (e2e)', () => {
   let app: INestApplication

--- a/packages/quiz-service/test/game.repository.e2e-spec.ts
+++ b/packages/quiz-service/test/game.repository.e2e-spec.ts
@@ -3,10 +3,7 @@ import { getModelToken } from '@nestjs/mongoose'
 import { GameMode, GameStatus } from '@quiz/common'
 import { v4 as uuidv4 } from 'uuid'
 
-import { closeTestApp, createTestApp } from '../../../test/utils/bootstrap'
-import { Quiz } from '../../quiz/services/models/schemas'
-
-import { GameRepository } from './game.repository'
+import { GameRepository } from '../src/game/services'
 import {
   BaseTask,
   Game,
@@ -18,7 +15,10 @@ import {
   QuestionTask,
   QuitTask,
   TaskType,
-} from './models/schemas'
+} from '../src/game/services/models/schemas'
+import { Quiz } from '../src/quiz/services/models/schemas'
+
+import { closeTestApp, createTestApp } from './utils/bootstrap'
 
 const ONE_HOUR = 60 * 60 * 1000
 const ONE_SECOND = 1000

--- a/packages/quiz-service/test/jest-e2e.json
+++ b/packages/quiz-service/test/jest-e2e.json
@@ -1,0 +1,21 @@
+{
+  "moduleFileExtensions": ["js", "json", "ts"],
+  "rootDir": ".",
+  "testRegex": ".*\\.e2e-spec\\.ts$",
+  "transform": {
+    "^.+\\.(t|j)s$": "ts-jest"
+  },
+  "moduleNameMapper": {
+    "^@quiz/common(.*)$": "<rootDir>/../../common/src$1"
+  },
+  "collectCoverageFrom": [
+    "**/*.(t|j)s"
+  ],
+  "coverageDirectory": "../coverage",
+  "testEnvironment": "node",
+  "transformIgnorePatterns": [
+    "/node_modules/(?!@quiz/common)"
+  ],
+  "detectOpenHandles": true,
+  "maxWorkers": 1
+}

--- a/packages/quiz-service/test/media.controller.e2e-spec.ts
+++ b/packages/quiz-service/test/media.controller.e2e-spec.ts
@@ -5,8 +5,9 @@ import { INestApplication } from '@nestjs/common'
 import supertest from 'supertest'
 import { v4 as uuidv4 } from 'uuid'
 
-import { closeTestApp, createTestApp } from '../../../test/utils/bootstrap'
-import { AuthService } from '../../auth/services'
+import { AuthService } from '../src/auth/services'
+
+import { closeTestApp, createTestApp } from './utils/bootstrap'
 
 describe('MediaController (e2e)', () => {
   let app: INestApplication
@@ -72,10 +73,7 @@ describe('MediaController (e2e)', () => {
         await supertest(app.getHttpServer())
           .post('/api/media/uploads/photos')
           .set({ Authorization: `Bearer ${token}` })
-          .attach(
-            'file',
-            join(__dirname, `../../../test/assets/photo.${extension}`),
-          )
+          .attach('file', join(__dirname, `./assets/photo.${extension}`))
           .expect(201)
           .expect((res) => {
             expect(res.body).toEqual({
@@ -84,7 +82,7 @@ describe('MediaController (e2e)', () => {
             return rm(
               join(
                 __dirname,
-                '../../../',
+                '../',
                 process.env.UPLOAD_DIRECTORY,
                 `/${dirname(res.body.filename)}`,
               ),
@@ -100,7 +98,7 @@ describe('MediaController (e2e)', () => {
       return supertest(app.getHttpServer())
         .post('/api/media/uploads/photos')
         .set({ Authorization: `Bearer ${token}` })
-        .attach('file', join(__dirname, '../../../test/assets/empty.txt'))
+        .attach('file', join(__dirname, './assets/empty.txt'))
         .expect(422)
         .expect((res) => {
           expect(res.body).toEqual({
@@ -132,10 +130,10 @@ describe('MediaController (e2e)', () => {
 
       const photoId = uuidv4()
 
-      const srcFile = join(__dirname, `../../../test/assets/photo.webp`)
+      const srcFile = join(__dirname, `./assets/photo.webp`)
       const dstFile = join(
         __dirname,
-        '../../../',
+        '../',
         process.env.UPLOAD_DIRECTORY,
         `/${clientId}/${photoId}.webp`,
       )

--- a/packages/quiz-service/test/quiz-game.controller.e2e-spec.ts
+++ b/packages/quiz-service/test/quiz-game.controller.e2e-spec.ts
@@ -17,10 +17,11 @@ import {
 import supertest from 'supertest'
 import { v4 as uuidv4 } from 'uuid'
 
-import { closeTestApp, createTestApp } from '../../../test/utils/bootstrap'
-import { AuthService } from '../../auth/services'
-import { ClientService } from '../../client/services'
-import { QuizService } from '../../quiz/services'
+import { AuthService } from '../src/auth/services'
+import { ClientService } from '../src/client/services'
+import { QuizService } from '../src/quiz/services'
+
+import { closeTestApp, createTestApp } from './utils/bootstrap'
 
 const multiChoiceQuestion: QuestionMultiChoiceDto = {
   type: QuestionType.MultiChoice,

--- a/packages/quiz-service/test/quiz.controller.e2e-spec.ts
+++ b/packages/quiz-service/test/quiz.controller.e2e-spec.ts
@@ -18,10 +18,11 @@ import {
 import supertest from 'supertest'
 import { v4 as uuidv4 } from 'uuid'
 
-import { closeTestApp, createTestApp } from '../../../test/utils/bootstrap'
-import { AuthService } from '../../auth/services'
-import { ClientService } from '../../client/services'
-import { QuizService } from '../services'
+import { AuthService } from '../src/auth/services'
+import { ClientService } from '../src/client/services'
+import { QuizService } from '../src/quiz/services'
+
+import { closeTestApp, createTestApp } from './utils/bootstrap'
 
 const multiChoiceQuestion: QuestionMultiChoiceDto = {
   type: QuestionType.MultiChoice,

--- a/packages/quiz/package.json
+++ b/packages/quiz/package.json
@@ -11,6 +11,7 @@
     "lint": "eslint .",
     "lint:fix": "yarn lint --fix",
     "test": "TZ=UTC vitest run",
+    "test:coverage": "TZ=UTC vitest run --coverage",
     "test:watch": "TZ=UTC vitest watch",
     "test:update": "TZ=UTC vitest --update",
     "storybook": "storybook dev -p 6006",
@@ -58,6 +59,7 @@
     "@types/react": "^19.1.4",
     "@types/react-dom": "^19.1.5",
     "@vitejs/plugin-react": "^4.4.1",
+    "@vitest/coverage-istanbul": "^3.2.4",
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.20",
@@ -68,6 +70,6 @@
     "storybook": "^8.6.14",
     "storybook-addon-remix-react-router": "^4.0.0",
     "vite": "^6.3.5",
-    "vitest": "^3.1.4"
+    "vitest": "^3.2.4"
   }
 }

--- a/packages/quiz/vite.config.ts
+++ b/packages/quiz/vite.config.ts
@@ -37,6 +37,23 @@ export default defineConfig(({ mode }) => {
       css: {
         modules: { classNameStrategy: 'non-scoped' },
       },
+      coverage: {
+        provider: 'istanbul',
+        all: true,
+        include: ['src/**/*.{ts,tsx}'],
+        exclude: [
+          'node_modules/**',
+          'coverage',
+          'public/**',
+          '**/*{.,-}test.ts',
+          '**/*{.,-}spec.ts',
+          '**/vite.config.ts',
+          '**/src/*.d.ts',
+          '**/src/main.ts',
+        ],
+        reporter: ['text', 'lcov', 'html'],
+        reportsDirectory: 'coverage',
+      },
     },
   }
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -207,7 +207,7 @@
     "@babel/template" "^7.27.2"
     "@babel/types" "^7.27.6"
 
-"@babel/parser@^7.1.0", "@babel/parser@^7.20.7", "@babel/parser@^7.27.2", "@babel/parser@^7.27.3", "@babel/parser@^7.27.4", "@babel/parser@^7.27.5":
+"@babel/parser@^7.1.0", "@babel/parser@^7.20.7", "@babel/parser@^7.25.4", "@babel/parser@^7.27.2", "@babel/parser@^7.27.3", "@babel/parser@^7.27.4", "@babel/parser@^7.27.5":
   version "7.27.5"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.27.5.tgz#ed22f871f110aa285a6fd934a0efed621d118826"
   integrity sha512-OsQd175SxWkGlzbny8J3K8TnnDD0N3lrIUtB92xwyRpzaenGZhxDvxN/JgU00U3CDZNj9tPuDJ5H0WS4Nt3vKg==
@@ -394,7 +394,7 @@
     debug "^4.3.1"
     globals "^11.1.0"
 
-"@babel/types@^7.0.0", "@babel/types@^7.20.7", "@babel/types@^7.27.1", "@babel/types@^7.27.3", "@babel/types@^7.27.6":
+"@babel/types@^7.0.0", "@babel/types@^7.20.7", "@babel/types@^7.25.4", "@babel/types@^7.27.1", "@babel/types@^7.27.3", "@babel/types@^7.27.6":
   version "7.27.6"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.27.6.tgz#a434ca7add514d4e646c80f7375c0aa2befc5535"
   integrity sha512-ETyHEk2VHHvl9b9jZP5IHPavHYk57EhanlRRuae9XCpb/j5bDCbPPMOBfCWhnl/7EDJz0jEMCi/RhccCE8r1+Q==
@@ -3056,6 +3056,22 @@
     "@types/babel__core" "^7.20.5"
     react-refresh "^0.17.0"
 
+"@vitest/coverage-istanbul@^3.2.4":
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/@vitest/coverage-istanbul/-/coverage-istanbul-3.2.4.tgz#a622802975935a2357d890b367fffd0dfd7a5a99"
+  integrity sha512-IDlpuFJiWU9rhcKLkpzj8mFu/lpe64gVgnV15ZOrYx1iFzxxrxCzbExiUEKtwwXRvEiEMUS6iZeYgnMxgbqbxQ==
+  dependencies:
+    "@istanbuljs/schema" "^0.1.3"
+    debug "^4.4.1"
+    istanbul-lib-coverage "^3.2.2"
+    istanbul-lib-instrument "^6.0.3"
+    istanbul-lib-report "^3.0.1"
+    istanbul-lib-source-maps "^5.0.6"
+    istanbul-reports "^3.1.7"
+    magicast "^0.3.5"
+    test-exclude "^7.0.1"
+    tinyrainbow "^2.0.0"
+
 "@vitest/expect@2.0.5":
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/@vitest/expect/-/expect-2.0.5.tgz#f3745a6a2c18acbea4d39f5935e913f40d26fa86"
@@ -3066,23 +3082,23 @@
     chai "^5.1.1"
     tinyrainbow "^1.2.0"
 
-"@vitest/expect@3.2.3":
-  version "3.2.3"
-  resolved "https://registry.yarnpkg.com/@vitest/expect/-/expect-3.2.3.tgz#45be98d6036c6dedbbbc51abdeca3bbd1f12450d"
-  integrity sha512-W2RH2TPWVHA1o7UmaFKISPvdicFJH+mjykctJFoAkUw+SPTJTGjUNdKscFBrqM7IPnCVu6zihtKYa7TkZS1dkQ==
+"@vitest/expect@3.2.4":
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/@vitest/expect/-/expect-3.2.4.tgz#8362124cd811a5ee11c5768207b9df53d34f2433"
+  integrity sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==
   dependencies:
     "@types/chai" "^5.2.2"
-    "@vitest/spy" "3.2.3"
-    "@vitest/utils" "3.2.3"
+    "@vitest/spy" "3.2.4"
+    "@vitest/utils" "3.2.4"
     chai "^5.2.0"
     tinyrainbow "^2.0.0"
 
-"@vitest/mocker@3.2.3":
-  version "3.2.3"
-  resolved "https://registry.yarnpkg.com/@vitest/mocker/-/mocker-3.2.3.tgz#95d8371182d0e9d1dee36bd3d698149e94fbe78a"
-  integrity sha512-cP6fIun+Zx8he4rbWvi+Oya6goKQDZK+Yq4hhlggwQBbrlOQ4qtZ+G4nxB6ZnzI9lyIb+JnvyiJnPC2AGbKSPA==
+"@vitest/mocker@3.2.4":
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/@vitest/mocker/-/mocker-3.2.4.tgz#4471c4efbd62db0d4fa203e65cc6b058a85cabd3"
+  integrity sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==
   dependencies:
-    "@vitest/spy" "3.2.3"
+    "@vitest/spy" "3.2.4"
     estree-walker "^3.0.3"
     magic-string "^0.30.17"
 
@@ -3100,28 +3116,28 @@
   dependencies:
     tinyrainbow "^1.2.0"
 
-"@vitest/pretty-format@3.2.3", "@vitest/pretty-format@^3.2.3":
-  version "3.2.3"
-  resolved "https://registry.yarnpkg.com/@vitest/pretty-format/-/pretty-format-3.2.3.tgz#ddd30f689fdd8191dbfd0cce8ae769e5de6b7f23"
-  integrity sha512-yFglXGkr9hW/yEXngO+IKMhP0jxyFw2/qys/CK4fFUZnSltD+MU7dVYGrH8rvPcK/O6feXQA+EU33gjaBBbAng==
+"@vitest/pretty-format@3.2.4", "@vitest/pretty-format@^3.2.4":
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/@vitest/pretty-format/-/pretty-format-3.2.4.tgz#3c102f79e82b204a26c7a5921bf47d534919d3b4"
+  integrity sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==
   dependencies:
     tinyrainbow "^2.0.0"
 
-"@vitest/runner@3.2.3":
-  version "3.2.3"
-  resolved "https://registry.yarnpkg.com/@vitest/runner/-/runner-3.2.3.tgz#e45318d833c8bf8b9f292a700fc06a011f70d542"
-  integrity sha512-83HWYisT3IpMaU9LN+VN+/nLHVBCSIUKJzGxC5RWUOsK1h3USg7ojL+UXQR3b4o4UBIWCYdD2fxuzM7PQQ1u8w==
+"@vitest/runner@3.2.4":
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/@vitest/runner/-/runner-3.2.4.tgz#5ce0274f24a971f6500f6fc166d53d8382430766"
+  integrity sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==
   dependencies:
-    "@vitest/utils" "3.2.3"
+    "@vitest/utils" "3.2.4"
     pathe "^2.0.3"
     strip-literal "^3.0.0"
 
-"@vitest/snapshot@3.2.3":
-  version "3.2.3"
-  resolved "https://registry.yarnpkg.com/@vitest/snapshot/-/snapshot-3.2.3.tgz#786dc1939174e1ac6b674d6fd3259bd4ea35a804"
-  integrity sha512-9gIVWx2+tysDqUmmM1L0hwadyumqssOL1r8KJipwLx5JVYyxvVRfxvMq7DaWbZZsCqZnu/dZedaZQh4iYTtneA==
+"@vitest/snapshot@3.2.4":
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/@vitest/snapshot/-/snapshot-3.2.4.tgz#40a8bc0346ac0aee923c0eefc2dc005d90bc987c"
+  integrity sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==
   dependencies:
-    "@vitest/pretty-format" "3.2.3"
+    "@vitest/pretty-format" "3.2.4"
     magic-string "^0.30.17"
     pathe "^2.0.3"
 
@@ -3132,10 +3148,10 @@
   dependencies:
     tinyspy "^3.0.0"
 
-"@vitest/spy@3.2.3":
-  version "3.2.3"
-  resolved "https://registry.yarnpkg.com/@vitest/spy/-/spy-3.2.3.tgz#c91715ca4db58a1f0dec636d393a76cf9945b695"
-  integrity sha512-JHu9Wl+7bf6FEejTCREy+DmgWe+rQKbK+y32C/k5f4TBIAlijhJbRBIRIOCEpVevgRsCQR2iHRUH2/qKVM/plw==
+"@vitest/spy@3.2.4":
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/@vitest/spy/-/spy-3.2.4.tgz#cc18f26f40f3f028da6620046881f4e4518c2599"
+  integrity sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==
   dependencies:
     tinyspy "^4.0.3"
 
@@ -3149,13 +3165,13 @@
     loupe "^3.1.1"
     tinyrainbow "^1.2.0"
 
-"@vitest/utils@3.2.3":
-  version "3.2.3"
-  resolved "https://registry.yarnpkg.com/@vitest/utils/-/utils-3.2.3.tgz#388afbed1fb3c25ca64c5846a9afb904e3d63bf2"
-  integrity sha512-4zFBCU5Pf+4Z6v+rwnZ1HU1yzOKKvDkMXZrymE2PBlbjKJRlrOxbvpfPSvJTGRIwGoahaOGvp+kbCoxifhzJ1Q==
+"@vitest/utils@3.2.4":
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/@vitest/utils/-/utils-3.2.4.tgz#c0813bc42d99527fb8c5b138c7a88516bca46fea"
+  integrity sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==
   dependencies:
-    "@vitest/pretty-format" "3.2.3"
-    loupe "^3.1.3"
+    "@vitest/pretty-format" "3.2.4"
+    loupe "^3.1.4"
     tinyrainbow "^2.0.0"
 
 "@vitest/utils@^2.1.1":
@@ -5692,7 +5708,7 @@ glob@11.0.1:
     package-json-from-dist "^1.0.0"
     path-scurry "^2.0.0"
 
-glob@^10.0.0, glob@^10.3.10:
+glob@^10.0.0, glob@^10.3.10, glob@^10.4.1:
   version "10.4.5"
   resolved "https://registry.yarnpkg.com/glob/-/glob-10.4.5.tgz#f4d9f0b90ffdbab09c9d77f5f29b4262517b0956"
   integrity sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==
@@ -6312,12 +6328,12 @@ isexe@^2.0.0:
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
   integrity sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==
 
-istanbul-lib-coverage@^3.0.0, istanbul-lib-coverage@^3.2.0:
+istanbul-lib-coverage@^3.0.0, istanbul-lib-coverage@^3.2.0, istanbul-lib-coverage@^3.2.2:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz#2d166c4b0644d43a39f04bf6c2edd1e585f31756"
   integrity sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==
 
-istanbul-lib-instrument@^6.0.0, istanbul-lib-instrument@^6.0.2:
+istanbul-lib-instrument@^6.0.0, istanbul-lib-instrument@^6.0.2, istanbul-lib-instrument@^6.0.3:
   version "6.0.3"
   resolved "https://registry.yarnpkg.com/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.3.tgz#fa15401df6c15874bcb2105f773325d78c666765"
   integrity sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q==
@@ -6328,7 +6344,7 @@ istanbul-lib-instrument@^6.0.0, istanbul-lib-instrument@^6.0.2:
     istanbul-lib-coverage "^3.2.0"
     semver "^7.5.4"
 
-istanbul-lib-report@^3.0.0:
+istanbul-lib-report@^3.0.0, istanbul-lib-report@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz#908305bac9a5bd175ac6a74489eafd0fc2445a7d"
   integrity sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==
@@ -6337,7 +6353,7 @@ istanbul-lib-report@^3.0.0:
     make-dir "^4.0.0"
     supports-color "^7.1.0"
 
-istanbul-lib-source-maps@^5.0.0:
+istanbul-lib-source-maps@^5.0.0, istanbul-lib-source-maps@^5.0.6:
   version "5.0.6"
   resolved "https://registry.yarnpkg.com/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz#acaef948df7747c8eb5fbf1265cb980f6353a441"
   integrity sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==
@@ -6346,7 +6362,7 @@ istanbul-lib-source-maps@^5.0.0:
     debug "^4.1.1"
     istanbul-lib-coverage "^3.0.0"
 
-istanbul-reports@^3.1.3:
+istanbul-reports@^3.1.3, istanbul-reports@^3.1.7:
   version "3.1.7"
   resolved "https://registry.yarnpkg.com/istanbul-reports/-/istanbul-reports-3.1.7.tgz#daed12b9e1dca518e15c056e1e537e741280fa0b"
   integrity sha512-BewmUXImeuRk2YY0PVbxgKAysvhRPUQE0h5QRM++nVWyubKGV0l8qQ5op8+B2DOmwSe63Jivj0BjkPQVf8fP5g==
@@ -7084,10 +7100,15 @@ loose-envify@^1.4.0:
   dependencies:
     js-tokens "^3.0.0 || ^4.0.0"
 
-loupe@^3.1.0, loupe@^3.1.1, loupe@^3.1.2, loupe@^3.1.3:
+loupe@^3.1.0, loupe@^3.1.1, loupe@^3.1.2:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/loupe/-/loupe-3.1.3.tgz#042a8f7986d77f3d0f98ef7990a2b2fef18b0fd2"
   integrity sha512-kkIp7XSkP78ZxJEsSxW3712C6teJVoeHHwgo9zJ380de7IYyJ2ISlxojcH2pC5OFLewESmnRi/+XCDIEEVyoug==
+
+loupe@^3.1.4:
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/loupe/-/loupe-3.1.4.tgz#784a0060545cb38778ffb19ccde44d7870d5fdd9"
+  integrity sha512-wJzkKwJrheKtknCOKNEtDK4iqg/MxmZheEMtSTYvnzRdEYaZzmgH976nenp8WdJRdx5Vc1X/9MO0Oszl6ezeXg==
 
 lru-cache@^10.2.0, lru-cache@^10.4.3:
   version "10.4.3"
@@ -7154,6 +7175,15 @@ magic-string@^0.27.0:
   integrity sha512-8UnnX2PeRAPZuN12svgR9j7M1uWMovg/CEnIwIG0LFkXSJJe4PdfUGiTGl8V9bsBHFUtfVINcSyYxd7q+kx9fA==
   dependencies:
     "@jridgewell/sourcemap-codec" "^1.4.13"
+
+magicast@^0.3.5:
+  version "0.3.5"
+  resolved "https://registry.yarnpkg.com/magicast/-/magicast-0.3.5.tgz#8301c3c7d66704a0771eb1bad74274f0ec036739"
+  integrity sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==
+  dependencies:
+    "@babel/parser" "^7.25.4"
+    "@babel/types" "^7.25.4"
+    source-map-js "^1.2.0"
 
 make-dir@^4.0.0:
   version "4.0.0"
@@ -8836,7 +8866,7 @@ slash@^4.0.0:
   resolved "https://registry.yarnpkg.com/slash/-/slash-4.0.0.tgz#2422372176c4c6c5addb5e2ada885af984b396a7"
   integrity sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==
 
-"source-map-js@>=0.6.2 <2.0.0", source-map-js@^1.2.1:
+"source-map-js@>=0.6.2 <2.0.0", source-map-js@^1.2.0, source-map-js@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.2.1.tgz#1ce5650fddd87abc099eda37dcff024c2667ae46"
   integrity sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==
@@ -9268,6 +9298,15 @@ test-exclude@^6.0.0:
     glob "^7.1.4"
     minimatch "^3.0.4"
 
+test-exclude@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/test-exclude/-/test-exclude-7.0.1.tgz#20b3ba4906ac20994e275bbcafd68d510264c2a2"
+  integrity sha512-pFYqmTw68LXVjeWJMST4+borgQP2AyMNbg1BpZh9LbyhUeNkeaPF9gzfPGUAnSMV3qPYdWUwDIjjCLiSDOl7vg==
+  dependencies:
+    "@istanbuljs/schema" "^0.1.2"
+    glob "^10.4.1"
+    minimatch "^9.0.4"
+
 tiny-invariant@^1.3.1, tiny-invariant@^1.3.3:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.3.3.tgz#46680b7a873a0d5d10005995eb90a70d74d60127"
@@ -9291,10 +9330,10 @@ tinyglobby@^0.2.13, tinyglobby@^0.2.14:
     fdir "^6.4.4"
     picomatch "^4.0.2"
 
-tinypool@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/tinypool/-/tinypool-1.1.0.tgz#4252913ec76ef8f728f2524e2118f3bef9cf23f4"
-  integrity sha512-7CotroY9a8DKsKprEy/a14aCCm8jYVmR7aFy4fpkZM8sdpNJbKkixuNjgM50yCmip2ezc8z4N7k3oe2+rfRJCQ==
+tinypool@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/tinypool/-/tinypool-1.1.1.tgz#059f2d042bd37567fbc017d3d426bdd2a2612591"
+  integrity sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==
 
 tinyrainbow@^1.2.0:
   version "1.2.0"
@@ -9769,10 +9808,10 @@ vary@^1, vary@^1.1.2:
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
   integrity sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==
 
-vite-node@3.2.3:
-  version "3.2.3"
-  resolved "https://registry.yarnpkg.com/vite-node/-/vite-node-3.2.3.tgz#1c5a2282fe100114c26fd221daf506e69d392a36"
-  integrity sha512-gc8aAifGuDIpZHrPjuHyP4dpQmYXqWw7D1GmDnWeNWP654UEXzVfQ5IHPSK5HaHkwB/+p1atpYpSdw/2kOv8iQ==
+vite-node@3.2.4:
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/vite-node/-/vite-node-3.2.4.tgz#f3676d94c4af1e76898c162c92728bca65f7bb07"
+  integrity sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==
   dependencies:
     cac "^6.7.14"
     debug "^4.4.1"
@@ -9794,19 +9833,19 @@ vite-node@3.2.3:
   optionalDependencies:
     fsevents "~2.3.3"
 
-vitest@^3.1.4:
-  version "3.2.3"
-  resolved "https://registry.yarnpkg.com/vitest/-/vitest-3.2.3.tgz#c2497733cf51f8ec2a3327f80789b269324edb1c"
-  integrity sha512-E6U2ZFXe3N/t4f5BwUaVCKRLHqUpk1CBWeMh78UT4VaTPH/2dyvH6ALl29JTovEPu9dVKr/K/J4PkXgrMbw4Ww==
+vitest@^3.2.4:
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/vitest/-/vitest-3.2.4.tgz#0637b903ad79d1539a25bc34c0ed54b5c67702ea"
+  integrity sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==
   dependencies:
     "@types/chai" "^5.2.2"
-    "@vitest/expect" "3.2.3"
-    "@vitest/mocker" "3.2.3"
-    "@vitest/pretty-format" "^3.2.3"
-    "@vitest/runner" "3.2.3"
-    "@vitest/snapshot" "3.2.3"
-    "@vitest/spy" "3.2.3"
-    "@vitest/utils" "3.2.3"
+    "@vitest/expect" "3.2.4"
+    "@vitest/mocker" "3.2.4"
+    "@vitest/pretty-format" "^3.2.4"
+    "@vitest/runner" "3.2.4"
+    "@vitest/snapshot" "3.2.4"
+    "@vitest/spy" "3.2.4"
+    "@vitest/utils" "3.2.4"
     chai "^5.2.0"
     debug "^4.4.1"
     expect-type "^1.2.1"
@@ -9817,10 +9856,10 @@ vitest@^3.1.4:
     tinybench "^2.9.0"
     tinyexec "^0.3.2"
     tinyglobby "^0.2.14"
-    tinypool "^1.1.0"
+    tinypool "^1.1.1"
     tinyrainbow "^2.0.0"
     vite "^5.0.0 || ^6.0.0 || ^7.0.0-0"
-    vite-node "3.2.3"
+    vite-node "3.2.4"
     why-is-node-running "^2.3.0"
 
 w3c-xmlserializer@^5.0.0:


### PR DESCRIPTION
- Replace `yarn test` with `yarn test:coverage` in CI workflow
- Add Codecov GitHub Action to upload both service and frontend reports
- Extract Jest config into dedicated files and enable coverage collection
- Introduce Vitest coverage setup for the frontend and bump Vitest deps to 3.2.4

