### PR TITLE
feat(user): enhance signup endpoint with proper HTTP statuses and add e2e tests

### DIFF
--- a/packages/quiz-service/src/user/controllers/user.controller.ts
+++ b/packages/quiz-service/src/user/controllers/user.controller.ts
@@ -3,6 +3,7 @@ import {
   ApiBadRequestResponse,
   ApiBearerAuth,
   ApiBody,
+  ApiConflictResponse,
   ApiOkResponse,
   ApiOperation,
   ApiTags,
@@ -49,9 +50,12 @@ export class UserController {
     type: CreateUserResponse,
   })
   @ApiBadRequestResponse({
-    description: 'Invalid input or user already exists.',
+    description: 'Invalid input.',
   })
-  @HttpCode(HttpStatus.OK)
+  @ApiConflictResponse({
+    description: 'User already exists.',
+  })
+  @HttpCode(HttpStatus.CREATED)
   public async createUser(
     @Body() createUserRequest: CreateUserRequest,
   ): Promise<CreateUserResponse> {

--- a/packages/quiz-service/src/user/exceptions/email-not-unique.exception.ts
+++ b/packages/quiz-service/src/user/exceptions/email-not-unique.exception.ts
@@ -7,6 +7,6 @@ import { ConflictException } from '@nestjs/common'
  */
 export class EmailNotUniqueException extends ConflictException {
   constructor(email: string) {
-    super(`Email "${email}" is not unique`)
+    super(`Email '${email}' is not unique`)
   }
 }

--- a/packages/quiz-service/test/data/data.utils.ts
+++ b/packages/quiz-service/test/data/data.utils.ts
@@ -361,3 +361,8 @@ export function createMockQuitTaskDocument(
     ...(task ?? {}),
   }
 }
+
+export const MOCK_DEFAULT_USER_EMAIL = 'user@example.com'
+export const MOCK_DEFAULT_USER_PASSWORD = '%AD2W!o#iGPoa7wd'
+export const MOCK_DEFAULT_USER_GIVEN_NAME = 'John'
+export const MOCK_DEFAULT_USER_FAMILY_NAME = 'Appleseed'

--- a/packages/quiz-service/test/user.controller.e2e-spec.ts
+++ b/packages/quiz-service/test/user.controller.e2e-spec.ts
@@ -1,0 +1,130 @@
+import { INestApplication } from '@nestjs/common'
+import supertest from 'supertest'
+
+import { UserRepository } from '../src/user/services'
+
+import {
+  MOCK_DEFAULT_USER_EMAIL,
+  MOCK_DEFAULT_USER_FAMILY_NAME,
+  MOCK_DEFAULT_USER_GIVEN_NAME,
+  MOCK_DEFAULT_USER_PASSWORD,
+} from './data'
+import { closeTestApp, createTestApp } from './utils/bootstrap'
+
+describe('GameResultController (e2e)', () => {
+  let app: INestApplication
+  let userRepository: UserRepository
+
+  beforeEach(async () => {
+    app = await createTestApp()
+    userRepository = app.get<UserRepository>(UserRepository)
+  })
+
+  afterEach(async () => {
+    await closeTestApp(app)
+  })
+
+  describe('/api/users (POST)', () => {
+    it('should succeed in creating a new user', async () => {
+      return supertest(app.getHttpServer())
+        .post(`/api/users`)
+        .send({
+          email: MOCK_DEFAULT_USER_EMAIL,
+          password: MOCK_DEFAULT_USER_PASSWORD,
+          givenName: MOCK_DEFAULT_USER_GIVEN_NAME,
+          familyName: MOCK_DEFAULT_USER_FAMILY_NAME,
+        })
+        .expect(201)
+        .expect((res) => {
+          expect(res.body).toEqual({
+            id: expect.any(String),
+            email: MOCK_DEFAULT_USER_EMAIL,
+            givenName: MOCK_DEFAULT_USER_GIVEN_NAME,
+            familyName: MOCK_DEFAULT_USER_FAMILY_NAME,
+            created: expect.any(String),
+            updated: expect.any(String),
+          })
+        })
+    })
+
+    it('should return 400 bad request error when failing validation', async () => {
+      return supertest(app.getHttpServer())
+        .post(`/api/users`)
+        .send({
+          givenName: '#',
+          familyName: '#',
+        })
+        .expect(400)
+        .expect((res) => {
+          expect(res.body).toEqual({
+            message: 'Validation failed',
+            status: 400,
+            timestamp: expect.any(String),
+            validationErrors: [
+              {
+                constraints: {
+                  matches: 'Email must be a valid address.',
+                  maxLength:
+                    'email must be shorter than or equal to 128 characters',
+                  minLength:
+                    'email must be longer than or equal to 6 characters',
+                },
+                property: 'email',
+              },
+              {
+                constraints: {
+                  matches:
+                    'Password must include ≥2 uppercase, ≥2 lowercase, ≥2 digits, ≥2 symbols.',
+                  maxLength:
+                    'password must be shorter than or equal to 128 characters',
+                  minLength:
+                    'password must be longer than or equal to 8 characters',
+                },
+                property: 'password',
+              },
+              {
+                constraints: {
+                  matches:
+                    'Given name must be 1–64 characters of letters/marks, and may include internal spaces, apostrophes or hyphens (no leading/trailing separators).',
+                },
+                property: 'givenName',
+              },
+              {
+                constraints: {
+                  matches:
+                    'Family name must be 1–64 characters of letters/marks, and may include internal spaces, apostrophes or hyphens (no leading/trailing separators).',
+                },
+                property: 'familyName',
+              },
+            ],
+          })
+        })
+    })
+
+    it('should return 409 conflict error when user already exists', async () => {
+      await userRepository.createLocalUser({
+        email: MOCK_DEFAULT_USER_EMAIL,
+        hashedPassword: MOCK_DEFAULT_USER_PASSWORD,
+        givenName: MOCK_DEFAULT_USER_GIVEN_NAME,
+        familyName: MOCK_DEFAULT_USER_FAMILY_NAME,
+      })
+
+      return supertest(app.getHttpServer())
+        .post(`/api/users`)
+        .send({
+          email: MOCK_DEFAULT_USER_EMAIL,
+          password: MOCK_DEFAULT_USER_PASSWORD,
+          givenName: MOCK_DEFAULT_USER_GIVEN_NAME,
+          familyName: MOCK_DEFAULT_USER_FAMILY_NAME,
+        })
+        .expect(409)
+        .expect((res) => {
+          expect(res.body).toEqual({
+            message: `Email '${MOCK_DEFAULT_USER_EMAIL}' is not unique`,
+            status: 409,
+            timestamp: expect.any(String),
+          })
+        })
+    })
+  })
+})


### PR DESCRIPTION
- add @ApiConflictResponse to POST /users and document 409 for existing emails
- tighten @ApiBadRequestResponse to only cover validation errors
- update createUser to return HTTP 201 (Created) instead of 200
- refine EmailNotUniqueException to use single quotes in its message
- introduce MOCK_DEFAULT_USER_* constants in test data utils
- add user.controller.e2e-spec.ts with tests