### PR TITLE
feat(auth): introduce Authorities enum and migrate to legacyAuthenticate

### DIFF
--- a/packages/common/src/models/authorities.enum.ts
+++ b/packages/common/src/models/authorities.enum.ts
@@ -1,0 +1,10 @@
+/**
+ * Enumeration of granted authorities (permissions or scopes)
+ * that can be assigned to a JWT to control access to protected resources.
+ */
+export enum Authorities {
+  /**
+   * Permission to allow use of the legacy client authentication.
+   */
+  LegacyAuth = 'LEGACY_AUTH',
+}

--- a/packages/common/src/models/index.ts
+++ b/packages/common/src/models/index.ts
@@ -1,4 +1,5 @@
 export * from './auth'
+export * from './authorities.enum'
 export * from './find-game-response.dto'
 export * from './game.dto'
 export * from './game-event'

--- a/packages/common/src/models/token.dto.ts
+++ b/packages/common/src/models/token.dto.ts
@@ -1,3 +1,5 @@
+import { Authorities } from './authorities.enum'
+
 /**
  * Represents a JSON Web Token (JWT) payload.
  */
@@ -11,4 +13,10 @@ export interface TokenDto {
    * The expiration time of the token, represented as a UNIX timestamp.
    */
   exp: number
+
+  /**
+   * The list of authorities (permissions or scopes) granted to the token holder.
+   * Determines which actions or endpoints the bearer is allowed to access.
+   */
+  authorities: Authorities[]
 }

--- a/packages/quiz-service/src/auth/controllers/auth.controller.ts
+++ b/packages/quiz-service/src/auth/controllers/auth.controller.ts
@@ -136,6 +136,6 @@ export class AuthController {
     @Body()
     authRequest: LegacyAuthRequest,
   ): Promise<LegacyAuthResponse> {
-    return this.authService.authenticate(authRequest)
+    return this.authService.legacyAuthenticate(authRequest)
   }
 }

--- a/packages/quiz-service/src/auth/services/auth.service.ts
+++ b/packages/quiz-service/src/auth/services/auth.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, UnauthorizedException } from '@nestjs/common'
 import { JwtService } from '@nestjs/jwt'
 import {
+  Authorities,
   LegacyAuthRequestDto,
   LegacyAuthResponseDto,
   TokenDto,
@@ -33,7 +34,7 @@ export class AuthService {
    * @returns {Promise<LegacyAuthResponseDto>} A promise resolving to an `LegacyAuthResponseDto`, which includes
    *          the generated JWT token, client information, and player information.
    */
-  public async authenticate(
+  public async legacyAuthenticate(
     authRequest: LegacyAuthRequestDto,
   ): Promise<LegacyAuthResponseDto> {
     const {
@@ -43,7 +44,7 @@ export class AuthService {
     } = await this.clientService.findOrCreateClient(authRequest.clientId)
 
     const token = await this.jwtService.signAsync(
-      {},
+      { authorities: [Authorities.LegacyAuth] },
       { subject: clientIdHash, expiresIn: '1h' },
     )
 

--- a/packages/quiz-service/test/client-game.controller.e2e-spec.ts
+++ b/packages/quiz-service/test/client-game.controller.e2e-spec.ts
@@ -48,7 +48,7 @@ describe('ClientGameController (e2e)', () => {
         createMockClientDocument({ player }),
       )
 
-      const { token } = await authService.authenticate({
+      const { token } = await authService.legacyAuthenticate({
         clientId,
       })
 
@@ -120,7 +120,7 @@ describe('ClientGameController (e2e)', () => {
         createMockClientDocument({ player }),
       )
 
-      const { token } = await authService.authenticate({
+      const { token } = await authService.legacyAuthenticate({
         clientId,
       })
 
@@ -172,7 +172,7 @@ describe('ClientGameController (e2e)', () => {
         createMockClientDocument({ player }),
       )
 
-      const { token } = await authService.authenticate({ clientId })
+      const { token } = await authService.legacyAuthenticate({ clientId })
 
       return supertest(app.getHttpServer())
         .get('/api/client/games')

--- a/packages/quiz-service/test/client-player.controller.e2e-spec.ts
+++ b/packages/quiz-service/test/client-player.controller.e2e-spec.ts
@@ -47,7 +47,7 @@ describe('ClientPlayerController (e2e)', () => {
       const {
         token,
         player: { id, nickname },
-      } = await authService.authenticate({ clientId: client._id })
+      } = await authService.legacyAuthenticate({ clientId: client._id })
 
       return supertest(app.getHttpServer())
         .get('/api/client/player')
@@ -64,7 +64,9 @@ describe('ClientPlayerController (e2e)', () => {
     })
 
     it('should succeed in retrieving the associated player from an existing authenticated client', async () => {
-      const { token } = await authService.authenticate({ clientId: client._id })
+      const { token } = await authService.legacyAuthenticate({
+        clientId: client._id,
+      })
 
       return supertest(app.getHttpServer())
         .get('/api/client/player')
@@ -96,7 +98,9 @@ describe('ClientPlayerController (e2e)', () => {
 
   describe('/api/client/player (PUT)', () => {
     it('should update player nickname successfully', async () => {
-      const { token } = await authService.authenticate({ clientId: client._id })
+      const { token } = await authService.legacyAuthenticate({
+        clientId: client._id,
+      })
 
       return supertest(app.getHttpServer())
         .put('/api/client/player')
@@ -114,7 +118,9 @@ describe('ClientPlayerController (e2e)', () => {
     })
 
     it('should update player nickname containing emojis successfully', async () => {
-      const { token } = await authService.authenticate({ clientId: client._id })
+      const { token } = await authService.legacyAuthenticate({
+        clientId: client._id,
+      })
 
       return supertest(app.getHttpServer())
         .put('/api/client/player')
@@ -132,7 +138,9 @@ describe('ClientPlayerController (e2e)', () => {
     })
 
     it('should handle validation errors for invalid nickname', async () => {
-      const { token } = await authService.authenticate({ clientId: client._id })
+      const { token } = await authService.legacyAuthenticate({
+        clientId: client._id,
+      })
 
       return supertest(app.getHttpServer())
         .put('/api/client/player')
@@ -178,7 +186,9 @@ describe('ClientPlayerController (e2e)', () => {
 
   describe('/api/client/player/link (GET)', () => {
     it('should succeed in retrieving the client associated players link code', async () => {
-      const { token } = await authService.authenticate({ clientId: client._id })
+      const { token } = await authService.legacyAuthenticate({
+        clientId: client._id,
+      })
 
       return supertest(app.getHttpServer())
         .get('/api/client/player/link')
@@ -208,7 +218,9 @@ describe('ClientPlayerController (e2e)', () => {
 
   describe('/api/client/player/link (POST)', () => {
     it('should succeed in associating a player from a valid link code', async () => {
-      const { token } = await authService.authenticate({ clientId: client._id })
+      const { token } = await authService.legacyAuthenticate({
+        clientId: client._id,
+      })
 
       const anotherPlayer = await playerModel.create(
         createMockPlayerDocument({
@@ -244,7 +256,9 @@ describe('ClientPlayerController (e2e)', () => {
     })
 
     it('should fail in associating a player from an unknown link code', async () => {
-      const { token } = await authService.authenticate({ clientId: client._id })
+      const { token } = await authService.legacyAuthenticate({
+        clientId: client._id,
+      })
 
       return supertest(app.getHttpServer())
         .post('/api/client/player/link')
@@ -261,7 +275,9 @@ describe('ClientPlayerController (e2e)', () => {
     })
 
     it('should fail in associating a player from an invalid link code', async () => {
-      const { token } = await authService.authenticate({ clientId: client._id })
+      const { token } = await authService.legacyAuthenticate({
+        clientId: client._id,
+      })
 
       return supertest(app.getHttpServer())
         .post('/api/client/player/link')

--- a/packages/quiz-service/test/client-quiz.controller.e2e-spec.ts
+++ b/packages/quiz-service/test/client-quiz.controller.e2e-spec.ts
@@ -38,7 +38,7 @@ describe('ClientQuizController (e2e)', () => {
     it('should succeed in retrieving an empty page of associated quizzes from a new authenticated client', async () => {
       const clientId = uuidv4()
 
-      const { token } = await authService.authenticate({ clientId })
+      const { token } = await authService.legacyAuthenticate({ clientId })
 
       return supertest(app.getHttpServer())
         .get('/api/client/quizzes')
@@ -125,7 +125,7 @@ describe('ClientQuizController (e2e)', () => {
         client2.player,
       )
 
-      const { token } = await authService.authenticate({
+      const { token } = await authService.legacyAuthenticate({
         clientId: client1._id,
       })
 

--- a/packages/quiz-service/test/game-result.controller.e2e-spec.ts
+++ b/packages/quiz-service/test/game-result.controller.e2e-spec.ts
@@ -48,7 +48,7 @@ describe('GameResultController (e2e)', () => {
 
   describe('/api/games/:gameID/results (GET)', () => {
     it('should succeed in retrieving game results for a classic mode game', async () => {
-      const { token } = await authService.authenticate({
+      const { token } = await authService.legacyAuthenticate({
         clientId: hostClient._id,
       })
 
@@ -133,7 +133,7 @@ describe('GameResultController (e2e)', () => {
     })
 
     it('should succeed in retrieving game results for a zero to one hundred mode game', async () => {
-      const { token } = await authService.authenticate({
+      const { token } = await authService.legacyAuthenticate({
         clientId: hostClient._id,
       })
 
@@ -213,7 +213,7 @@ describe('GameResultController (e2e)', () => {
     })
 
     it('should return a 404 error when a game result was not found', async () => {
-      const { token } = await authService.authenticate({
+      const { token } = await authService.legacyAuthenticate({
         clientId: hostClient._id,
       })
 
@@ -235,7 +235,7 @@ describe('GameResultController (e2e)', () => {
     })
 
     it('should return a 404 error when a game was not found', async () => {
-      const { token } = await authService.authenticate({
+      const { token } = await authService.legacyAuthenticate({
         clientId: hostClient._id,
       })
 
@@ -256,7 +256,7 @@ describe('GameResultController (e2e)', () => {
 
     it('should return a 403 forbidden error when player is not a participant of an existing game', async () => {
       const anotherClientId = uuidv4()
-      const { token } = await authService.authenticate({
+      const { token } = await authService.legacyAuthenticate({
         clientId: anotherClientId,
       })
 

--- a/packages/quiz-service/test/game.e2e-spec.ts
+++ b/packages/quiz-service/test/game.e2e-spec.ts
@@ -81,14 +81,14 @@ describe('GameController (e2e)', () => {
 
     const hostClientId = uuidv4()
     hostClient = await clientService.findOrCreateClient(hostClientId)
-    const hostAuthResponse = await authService.authenticate({
+    const hostAuthResponse = await authService.legacyAuthenticate({
       clientId: hostClientId,
     })
     hostClientToken = hostAuthResponse.token
 
     const playerClientId = uuidv4()
     playerClient = await clientService.findOrCreateClient(playerClientId)
-    const playerAuthResponse = await authService.authenticate({
+    const playerAuthResponse = await authService.legacyAuthenticate({
       clientId: playerClientId,
     })
     playerClientToken = playerAuthResponse.token
@@ -1635,7 +1635,7 @@ describe('GameController (e2e)', () => {
         }),
       )
 
-      const { token } = await authService.authenticate({
+      const { token } = await authService.legacyAuthenticate({
         clientId: uuidv4(),
       })
 
@@ -2206,7 +2206,7 @@ describe('GameController (e2e)', () => {
         }),
       )
 
-      const { token } = await authService.authenticate({
+      const { token } = await authService.legacyAuthenticate({
         clientId: uuidv4(),
       })
 

--- a/packages/quiz-service/test/media.controller.e2e-spec.ts
+++ b/packages/quiz-service/test/media.controller.e2e-spec.ts
@@ -26,7 +26,7 @@ describe('MediaController (e2e)', () => {
     it('should succeed in retrieving photos', async () => {
       const clientId = uuidv4()
 
-      const { token } = await authService.authenticate({ clientId })
+      const { token } = await authService.legacyAuthenticate({ clientId })
 
       return supertest(app.getHttpServer())
         .get('/api/media/photos?search=nature&limit=10&offset=0')
@@ -68,7 +68,9 @@ describe('MediaController (e2e)', () => {
     test.each([['gif'], ['jpeg'], ['jpg'], ['png'], ['tiff'], ['webp']])(
       'should succeed in uploading a %s image',
       async (extension) => {
-        const { token } = await authService.authenticate({ clientId: uuidv4() })
+        const { token } = await authService.legacyAuthenticate({
+          clientId: uuidv4(),
+        })
 
         await supertest(app.getHttpServer())
           .post('/api/media/uploads/photos')
@@ -93,7 +95,9 @@ describe('MediaController (e2e)', () => {
     )
 
     it('should fail in uploading a non image file', async () => {
-      const { token } = await authService.authenticate({ clientId: uuidv4() })
+      const { token } = await authService.legacyAuthenticate({
+        clientId: uuidv4(),
+      })
 
       return supertest(app.getHttpServer())
         .post('/api/media/uploads/photos')
@@ -126,7 +130,7 @@ describe('MediaController (e2e)', () => {
   describe('/api/media/uploads/photos/:photoId (DELETE)', () => {
     it('should succeed in deleting an uploaded photo', async () => {
       const clientId = uuidv4()
-      const { token } = await authService.authenticate({ clientId })
+      const { token } = await authService.legacyAuthenticate({ clientId })
 
       const photoId = uuidv4()
 
@@ -151,7 +155,9 @@ describe('MediaController (e2e)', () => {
     })
 
     it('should fail in deleting a non existing uploaded photo', async () => {
-      const { token } = await authService.authenticate({ clientId: uuidv4() })
+      const { token } = await authService.legacyAuthenticate({
+        clientId: uuidv4(),
+      })
 
       const photoId = uuidv4()
 

--- a/packages/quiz-service/test/quiz-game.controller.e2e-spec.ts
+++ b/packages/quiz-service/test/quiz-game.controller.e2e-spec.ts
@@ -152,7 +152,7 @@ describe('QuizGameController (e2e)', () => {
 
       const client = await clientService.findOrCreateClient(clientId)
 
-      const { token } = await authService.authenticate({ clientId })
+      const { token } = await authService.legacyAuthenticate({ clientId })
 
       const originalQuiz = await quizService.createQuiz(
         classicQuizRequest,
@@ -173,7 +173,7 @@ describe('QuizGameController (e2e)', () => {
 
       const client = await clientService.findOrCreateClient(clientId)
 
-      const { token } = await authService.authenticate({ clientId })
+      const { token } = await authService.legacyAuthenticate({ clientId })
 
       const originalQuiz = await quizService.createQuiz(
         zeroToOneHundredQuizRequest,
@@ -193,7 +193,7 @@ describe('QuizGameController (e2e)', () => {
       const clientId = uuidv4()
       const quizId = uuidv4()
 
-      const { token } = await authService.authenticate({ clientId })
+      const { token } = await authService.legacyAuthenticate({ clientId })
 
       return supertest(app.getHttpServer())
         .post(`/api/quizzes/${quizId}/games`)
@@ -216,7 +216,9 @@ describe('QuizGameController (e2e)', () => {
         client.player,
       )
 
-      const { token } = await authService.authenticate({ clientId: uuidv4() })
+      const { token } = await authService.legacyAuthenticate({
+        clientId: uuidv4(),
+      })
 
       return supertest(app.getHttpServer())
         .post(`/api/quizzes/${id}/games`)
@@ -234,7 +236,9 @@ describe('QuizGameController (e2e)', () => {
         client.player,
       )
 
-      const { token } = await authService.authenticate({ clientId: uuidv4() })
+      const { token } = await authService.legacyAuthenticate({
+        clientId: uuidv4(),
+      })
 
       return supertest(app.getHttpServer())
         .post(`/api/quizzes/${id}/games`)

--- a/packages/quiz-service/test/quiz.controller.e2e-spec.ts
+++ b/packages/quiz-service/test/quiz.controller.e2e-spec.ts
@@ -151,7 +151,7 @@ describe('QuizController (e2e)', () => {
     it('should succeed in creating a new quiz', async () => {
       const clientId = uuidv4()
 
-      const { token } = await authService.authenticate({ clientId })
+      const { token } = await authService.legacyAuthenticate({ clientId })
 
       return supertest(app.getHttpServer())
         .post('/api/quizzes')
@@ -187,7 +187,7 @@ describe('QuizController (e2e)', () => {
 
       const client = await clientService.findOrCreateClient(clientId)
 
-      const { token } = await authService.authenticate({ clientId })
+      const { token } = await authService.legacyAuthenticate({ clientId })
 
       const publicQuizzes: QuizResponseDto[] = []
       for (let i = 0; i < 10; i++) {
@@ -228,7 +228,7 @@ describe('QuizController (e2e)', () => {
 
       const client = await clientService.findOrCreateClient(clientId)
 
-      const { token } = await authService.authenticate({ clientId })
+      const { token } = await authService.legacyAuthenticate({ clientId })
 
       await Promise.all([
         ...[...Array(10).keys()].map(() =>
@@ -264,7 +264,7 @@ describe('QuizController (e2e)', () => {
 
       const client = await clientService.findOrCreateClient(clientId)
 
-      const { token } = await authService.authenticate({ clientId })
+      const { token } = await authService.legacyAuthenticate({ clientId })
 
       await Promise.all(
         [...Array(10).keys()].map(() =>
@@ -307,7 +307,7 @@ describe('QuizController (e2e)', () => {
 
       const client = await clientService.findOrCreateClient(clientId)
 
-      const { token } = await authService.authenticate({ clientId })
+      const { token } = await authService.legacyAuthenticate({ clientId })
 
       const publicQuizzes: QuizResponseDto[] = []
       for (let i = 0; i < 10; i++) {
@@ -339,7 +339,7 @@ describe('QuizController (e2e)', () => {
 
       const client = await clientService.findOrCreateClient(clientId)
 
-      const { token } = await authService.authenticate({ clientId })
+      const { token } = await authService.legacyAuthenticate({ clientId })
 
       const publicQuizzes: QuizResponseDto[] = []
       for (let i = 0; i < 10; i++) {
@@ -372,7 +372,7 @@ describe('QuizController (e2e)', () => {
 
       const client = await clientService.findOrCreateClient(clientId)
 
-      const { token } = await authService.authenticate({ clientId })
+      const { token } = await authService.legacyAuthenticate({ clientId })
 
       const publicQuizzes: QuizResponseDto[] = []
       for (let i = 0; i < 10; i++) {
@@ -403,7 +403,7 @@ describe('QuizController (e2e)', () => {
     it('should return an empty list when no quizzes exists', async () => {
       const clientId = uuidv4()
 
-      const { token } = await authService.authenticate({ clientId })
+      const { token } = await authService.legacyAuthenticate({ clientId })
 
       return supertest(app.getHttpServer())
         .get('/api/quizzes')
@@ -435,7 +435,7 @@ describe('QuizController (e2e)', () => {
     it('should validate query parameters and return a 400 error for invalid input', async () => {
       const clientId = uuidv4()
 
-      const { token } = await authService.authenticate({ clientId })
+      const { token } = await authService.legacyAuthenticate({ clientId })
 
       return supertest(app.getHttpServer())
         .get('/api/quizzes?limit=X&offset=X&mode=X&sort=X&order=X')
@@ -495,7 +495,7 @@ describe('QuizController (e2e)', () => {
 
       const client = await clientService.findOrCreateClient(clientId)
 
-      const { token } = await authService.authenticate({ clientId })
+      const { token } = await authService.legacyAuthenticate({ clientId })
 
       const originalQuiz = await quizService.createQuiz(
         originalData,
@@ -539,7 +539,7 @@ describe('QuizController (e2e)', () => {
       const clientId = uuidv4()
       const quizId = uuidv4()
 
-      const { token } = await authService.authenticate({ clientId })
+      const { token } = await authService.legacyAuthenticate({ clientId })
 
       return supertest(app.getHttpServer())
         .get(`/api/quizzes/${quizId}`)
@@ -570,7 +570,9 @@ describe('QuizController (e2e)', () => {
         updated,
       } = await quizService.createQuiz(originalData, client.player)
 
-      const { token } = await authService.authenticate({ clientId: uuidv4() })
+      const { token } = await authService.legacyAuthenticate({
+        clientId: uuidv4(),
+      })
 
       return supertest(app.getHttpServer())
         .get(`/api/quizzes/${id}`)
@@ -604,7 +606,9 @@ describe('QuizController (e2e)', () => {
         client.player,
       )
 
-      const { token } = await authService.authenticate({ clientId: uuidv4() })
+      const { token } = await authService.legacyAuthenticate({
+        clientId: uuidv4(),
+      })
 
       return supertest(app.getHttpServer())
         .get(`/api/quizzes/${id}`)
@@ -624,7 +628,7 @@ describe('QuizController (e2e)', () => {
 
       const client = await clientService.findOrCreateClient(clientId)
 
-      const { token } = await authService.authenticate({ clientId })
+      const { token } = await authService.legacyAuthenticate({ clientId })
 
       const originalQuiz = await quizService.createQuiz(
         originalData,
@@ -665,7 +669,7 @@ describe('QuizController (e2e)', () => {
       const clientId = uuidv4()
       const quizId = uuidv4()
 
-      const { token } = await authService.authenticate({ clientId })
+      const { token } = await authService.legacyAuthenticate({ clientId })
 
       return supertest(app.getHttpServer())
         .put(`/api/quizzes/${quizId}`)
@@ -686,7 +690,9 @@ describe('QuizController (e2e)', () => {
       const client = await clientService.findOrCreateClient(uuidv4())
       const { id } = await quizService.createQuiz(originalData, client.player)
 
-      const { token } = await authService.authenticate({ clientId: uuidv4() })
+      const { token } = await authService.legacyAuthenticate({
+        clientId: uuidv4(),
+      })
 
       return supertest(app.getHttpServer())
         .put(`/api/quizzes/${id}`)
@@ -707,7 +713,7 @@ describe('QuizController (e2e)', () => {
 
       const client = await clientService.findOrCreateClient(clientId)
 
-      const { token } = await authService.authenticate({ clientId })
+      const { token } = await authService.legacyAuthenticate({ clientId })
 
       const originalQuiz = await quizService.createQuiz(
         originalData,
@@ -727,7 +733,7 @@ describe('QuizController (e2e)', () => {
       const clientId = uuidv4()
       const quizId = uuidv4()
 
-      const { token } = await authService.authenticate({ clientId })
+      const { token } = await authService.legacyAuthenticate({ clientId })
 
       return supertest(app.getHttpServer())
         .delete(`/api/quizzes/${quizId}`)
@@ -747,7 +753,9 @@ describe('QuizController (e2e)', () => {
       const client = await clientService.findOrCreateClient(uuidv4())
       const { id } = await quizService.createQuiz(originalData, client.player)
 
-      const { token } = await authService.authenticate({ clientId: uuidv4() })
+      const { token } = await authService.legacyAuthenticate({
+        clientId: uuidv4(),
+      })
 
       return supertest(app.getHttpServer())
         .delete(`/api/quizzes/${id}`)
@@ -767,7 +775,7 @@ describe('QuizController (e2e)', () => {
 
       const client = await clientService.findOrCreateClient(clientId)
 
-      const { token } = await authService.authenticate({ clientId })
+      const { token } = await authService.legacyAuthenticate({ clientId })
 
       const quiz = await quizService.createQuiz(originalData, client.player)
 
@@ -785,7 +793,7 @@ describe('QuizController (e2e)', () => {
 
       const client = await clientService.findOrCreateClient(clientId)
 
-      const { token } = await authService.authenticate({ clientId })
+      const { token } = await authService.legacyAuthenticate({ clientId })
 
       const quiz = await quizService.createQuiz(updatedData, client.player)
 
@@ -801,7 +809,9 @@ describe('QuizController (e2e)', () => {
     it('should fail in retrieving all questions for a non existing quiz', async () => {
       const unknownQuizId = uuidv4()
 
-      const { token } = await authService.authenticate({ clientId: uuidv4() })
+      const { token } = await authService.legacyAuthenticate({
+        clientId: uuidv4(),
+      })
 
       return supertest(app.getHttpServer())
         .get(`/api/quizzes/${unknownQuizId}/questions`)
@@ -824,7 +834,9 @@ describe('QuizController (e2e)', () => {
 
       const quiz = await quizService.createQuiz(originalData, client.player)
 
-      const { token } = await authService.authenticate({ clientId: uuidv4() })
+      const { token } = await authService.legacyAuthenticate({
+        clientId: uuidv4(),
+      })
 
       return supertest(app.getHttpServer())
         .get(`/api/quizzes/${quiz.id}/questions`)


### PR DESCRIPTION
- add Authorities enum (LEGACY_AUTH) in common models and export from index
- extend TokenDto with `authorities: Authorities[]`
- rename AuthService.authenticate → legacyAuthenticate and update AuthController accordingly
- include `authorities: [Authorities.LegacyAuth]` claim when signing JWT
- update all e2e tests to call `legacyAuthenticate` instead of `authenticate`
