### PR TITLE
feat(config): add ENVIRONMENT var and use it for JWT audience

### DIFF
--- a/packages/quiz-service/.env.development
+++ b/packages/quiz-service/.env.development
@@ -1,3 +1,5 @@
+ENVIRONMENT=local
+
 SERVER_PORT=8080
 SERVER_ALLOW_ORIGIN=http://localhost:3000
 

--- a/packages/quiz-service/.env.test
+++ b/packages/quiz-service/.env.test
@@ -1,3 +1,5 @@
+ENVIRONMENT=test
+
 SERVER_ALLOW_ORIGIN=http://localhost:3000
 
 REDIS_HOST=localhost

--- a/packages/quiz-service/src/app/app.module.ts
+++ b/packages/quiz-service/src/app/app.module.ts
@@ -43,6 +43,9 @@ const isTestEnv = process.env.NODE_ENV === 'test'
         NODE_ENV: Joi.string()
           .valid('development', 'production', 'test')
           .default('development'),
+        ENVIRONMENT: Joi.string()
+          .valid('local', 'beta', 'prod', 'test')
+          .required(),
         SERVER_PORT: Joi.number().port().default(8080),
         SERVER_ALLOW_ORIGIN: Joi.string().required(),
         REDIS_HOST: Joi.string().required(),

--- a/packages/quiz-service/src/app/config/environment.ts
+++ b/packages/quiz-service/src/app/config/environment.ts
@@ -1,4 +1,5 @@
 export interface EnvironmentVariables {
+  ENVIRONMENT: string
   SERVER_PORT: number
   SERVER_ALLOW_ORIGIN: string
   REDIS_HOST: string

--- a/packages/quiz-service/src/auth/auth.module.ts
+++ b/packages/quiz-service/src/auth/auth.module.ts
@@ -13,12 +13,6 @@ import { AuthController } from './controllers'
 import { AuthGuard } from './guards'
 import { AuthService } from './services'
 
-const COMMON_JWT_OPTIONS: jwt.VerifyOptions | jwt.SignOptions = {
-  algorithm: 'HS256',
-  issuer: 'quiz',
-  audience: process.env.NODE_ENV || 'development',
-}
-
 @Module({
   imports: [
     JwtModule.registerAsync({
@@ -30,6 +24,12 @@ const COMMON_JWT_OPTIONS: jwt.VerifyOptions | jwt.SignOptions = {
         const jwtSecret = configService.get('JWT_SECRET')
         const jwtPrivateKeyPath = configService.get('JWT_PRIVATE_KEY_PATH')
         const jwtPublicKeyPath = configService.get('JWT_PUBLIC_KEY_PATH')
+
+        const COMMON_JWT_OPTIONS: jwt.VerifyOptions | jwt.SignOptions = {
+          algorithm: 'HS256',
+          issuer: 'quiz',
+          audience: `${configService.get('ENVIRONMENT')}-quiz`,
+        }
 
         return {
           global: true,


### PR DESCRIPTION
- add ENVIRONMENT=local to .env.development
- add ENVIRONMENT=test to .env.test
- update AppModule Joi schema to require ENVIRONMENT (local|beta|prod|test)
- extend EnvironmentVariables interface to include ENVIRONMENT
- refactor AuthModule to build JWT audience from ENVIRONMENT (“${ENVIRONMENT}-quiz”) instead of NODE_ENV