### PR TITLE
chore(ci): add Codecov configuration

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,24 @@
+comment:
+  layout: "reach, diff, flags, coverage"
+  behavior: default
+  require_changes: true
+
+component_management:
+  individual_components:
+    - component_id: quiz
+      name: quiz
+      paths:
+        - packages/quiz/**
+    - component_id: quiz-service
+      name: quiz-service
+      paths:
+        - packages/quiz-service/**
+
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true


### PR DESCRIPTION
- Introduce codecov.yml with PR comment layout (reach, diff, flags, coverage) and require changes on comments.
- Define component management for 'quiz' and 'quiz-service' packages.
- Set coverage status flags (project & patch) to informational.
