### PR TITLE
feat(auth): implement user login & refresh token flows

### DIFF
--- a/packages/common/src/models/authorities.enum.ts
+++ b/packages/common/src/models/authorities.enum.ts
@@ -7,4 +7,9 @@ export enum Authorities {
    * Permission to allow use of the legacy client authentication.
    */
   LegacyAuth = 'LEGACY_AUTH',
+
+  /**
+   * Permission to allow using a valid refresh token to obtain a new access token.
+   */
+  RefreshAuth = 'REFRESH_AUTH',
 }

--- a/packages/quiz-service/src/auth/auth.module.ts
+++ b/packages/quiz-service/src/auth/auth.module.ts
@@ -8,6 +8,7 @@ import * as jwt from 'jsonwebtoken'
 
 import { EnvironmentVariables } from '../app/config'
 import { ClientModule } from '../client'
+import { UserModule } from '../user'
 
 import { AuthController } from './controllers'
 import { AuthGuard } from './guards'
@@ -46,6 +47,7 @@ import { AuthService } from './services'
       },
     }),
     ClientModule,
+    UserModule,
   ],
   controllers: [AuthController],
   providers: [

--- a/packages/quiz-service/src/auth/controllers/auth.controller.ts
+++ b/packages/quiz-service/src/auth/controllers/auth.controller.ts
@@ -1,17 +1,11 @@
-import {
-  Body,
-  Controller,
-  HttpCode,
-  HttpStatus,
-  NotImplementedException,
-  Post,
-} from '@nestjs/common'
+import { Body, Controller, HttpCode, HttpStatus, Post } from '@nestjs/common'
 import {
   ApiBadRequestResponse,
   ApiBody,
   ApiOkResponse,
   ApiOperation,
   ApiTags,
+  ApiUnauthorizedResponse,
 } from '@nestjs/swagger'
 
 import { AuthService } from '../services'
@@ -65,10 +59,9 @@ export class AuthController {
   })
   @HttpCode(HttpStatus.OK)
   public async login(
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     @Body() authLoginRequest: AuthLoginRequest,
   ): Promise<AuthLoginResponse> {
-    throw new NotImplementedException()
+    return this.authService.login(authLoginRequest)
   }
 
   /**
@@ -95,14 +88,16 @@ export class AuthController {
     type: AuthLoginResponse,
   })
   @ApiBadRequestResponse({
-    description: 'Validation failed or refresh token is invalid/expired.',
+    description: 'Validation failed.',
+  })
+  @ApiUnauthorizedResponse({
+    description: 'Refresh token is invalid/expired.',
   })
   @HttpCode(HttpStatus.OK)
   public async refresh(
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     @Body() authRefreshRequest: AuthRefreshRequest,
   ): Promise<AuthLoginResponse> {
-    throw new NotImplementedException()
+    return this.authService.refresh(authRefreshRequest)
   }
 
   /**

--- a/packages/quiz-service/src/auth/controllers/models/auth-login.request.ts
+++ b/packages/quiz-service/src/auth/controllers/models/auth-login.request.ts
@@ -40,7 +40,7 @@ export class AuthLoginRequest implements AuthLoginRequestDto {
       'User password; 8–128 chars, min 2 uppercase, 2 lowercase, 2 digits, 2 symbols.',
     type: String,
     pattern: `${PASSWORD_REGEX}`,
-    example: 'Super#SecretPassw0rd123',
+    example: 'Super#SecretPa$$w0rd123',
   })
   @MinLength(PASSWORD_MIN_LENGTH)
   @MaxLength(PASSWORD_MAX_LENGTH)

--- a/packages/quiz-service/src/auth/services/auth.service.ts
+++ b/packages/quiz-service/src/auth/services/auth.service.ts
@@ -1,30 +1,110 @@
-import { Injectable, UnauthorizedException } from '@nestjs/common'
+import { Injectable, Logger, UnauthorizedException } from '@nestjs/common'
 import { JwtService } from '@nestjs/jwt'
 import {
+  AuthLoginRequestDto,
+  AuthLoginResponseDto,
   Authorities,
   LegacyAuthRequestDto,
   LegacyAuthResponseDto,
   TokenDto,
 } from '@quiz/common'
+import { AuthRefreshRequestDto } from '@quiz/common/src'
 
 import { ClientService } from '../../client/services'
+import { UserService } from '../../user/services'
 
 /**
- * Service responsible for handling JWT operations for game participants,
- * including token generation and verification.
+ * Service responsible for authenticating users and clients
+ * and managing JWT token issuance (login, legacy auth, and refresh).
  */
 @Injectable()
 export class AuthService {
+  // Logger instance for recording service operations.
+  private readonly logger: Logger = new Logger(AuthService.name)
+
   /**
    * Initializes the AuthService.
    *
-   * @param {ClientService} clientService - Service to manage client data.
-   * @param {JwtService} jwtService - Service for generating and verifying JWT tokens.
+   * @param userService - Service for user credential verification.
+   * @param clientService - Service to manage client data.
+   * @param jwtService - Service for generating and verifying JWT tokens.
    */
   constructor(
+    private readonly userService: UserService,
     private clientService: ClientService,
     private jwtService: JwtService,
   ) {}
+
+  /**
+   * Authenticates a user by email and password, then issues a new pair of JWTs.
+   *
+   * @param authLoginRequestDto - DTO containing the user's email and password.
+   * @returns Promise resolving to an AuthLoginResponseDto with access & refresh tokens.
+   * @throws BadCredentialsException if credentials are invalid.
+   */
+  public async login(
+    authLoginRequestDto: AuthLoginRequestDto,
+  ): Promise<AuthLoginResponseDto> {
+    const user = await this.userService.verifyUserCredentialsOrThrow(
+      authLoginRequestDto.email,
+      authLoginRequestDto.password,
+    )
+    return this.signTokenPair(user._id)
+  }
+
+  /**
+   * Validates the provided refresh token and issues a new pair of JWTs.
+   *
+   * @param authRefreshRequestDto - DTO containing the refresh token.
+   * @returns Promise resolving to an AuthLoginResponseDto with fresh tokens.
+   * @throws UnauthorizedException if token is invalid or missing REFRESH_AUTH authority.
+   */
+  public async refresh(
+    authRefreshRequestDto: AuthRefreshRequestDto,
+  ): Promise<AuthLoginResponseDto> {
+    let result: Pick<TokenDto, 'sub' | 'authorities'>
+
+    try {
+      result = await this.jwtService.verifyAsync<TokenDto>(
+        authRefreshRequestDto.refreshToken,
+      )
+    } catch (error) {
+      const { message, stack } = error as Error
+      this.logger.debug(`Failed to verify refresh token: '${message}'.`, stack)
+      throw new UnauthorizedException()
+    }
+
+    if (!result.authorities.includes(Authorities.RefreshAuth)) {
+      this.logger.debug(
+        `Failed to refresh token since missing '${Authorities.RefreshAuth}' authority.`,
+      )
+      throw new UnauthorizedException()
+    }
+
+    this.logger.debug(`Refreshing token with userId '${result.sub}'.`)
+    return this.signTokenPair(result.sub)
+  }
+
+  /**
+   * Generates a new access token (15m) and refresh token (30d) for the given user.
+   *
+   * @param userId - The subject (user ID) for whom to sign the tokens.
+   * @returns Promise resolving to AuthLoginResponseDto with both tokens.
+   * @private
+   */
+  private async signTokenPair(userId: string): Promise<AuthLoginResponseDto> {
+    const accessToken = await this.jwtService.signAsync(
+      { authorities: [] },
+      { subject: userId, expiresIn: '15m' },
+    )
+
+    const refreshToken = await this.jwtService.signAsync(
+      { authorities: [Authorities.RefreshAuth] },
+      { subject: userId, expiresIn: '30d' },
+    )
+
+    return { accessToken, refreshToken }
+  }
 
   /**
    * Authenticates a client by generating a JWT token.

--- a/packages/quiz-service/src/user/controllers/models/create-user.request.ts
+++ b/packages/quiz-service/src/user/controllers/models/create-user.request.ts
@@ -45,7 +45,7 @@ export class CreateUserRequest implements CreateUserRequestDto {
     description: 'Strong password meeting complexity requirements.',
     type: String,
     pattern: PASSWORD_REGEX.source,
-    example: 'Super#SecretPassw0rd123',
+    example: 'Super#SecretPa$$w0rd123',
   })
   @MinLength(PASSWORD_MIN_LENGTH)
   @MaxLength(PASSWORD_MAX_LENGTH)

--- a/packages/quiz-service/src/user/exceptions/bad-credentials.exception.ts
+++ b/packages/quiz-service/src/user/exceptions/bad-credentials.exception.ts
@@ -1,0 +1,12 @@
+import { BadRequestException } from '@nestjs/common'
+
+/**
+ * Thrown when the email or password is incorrect (HTTP 400).
+ *
+ * @extends {BadRequestException}
+ */
+export class BadCredentialsException extends BadRequestException {
+  constructor() {
+    super('Bad credentials')
+  }
+}

--- a/packages/quiz-service/src/user/exceptions/index.ts
+++ b/packages/quiz-service/src/user/exceptions/index.ts
@@ -1,1 +1,2 @@
+export * from './bad-credentials.exception'
 export * from './email-not-unique.exception'

--- a/packages/quiz-service/src/user/services/utils/index.ts
+++ b/packages/quiz-service/src/user/services/utils/index.ts
@@ -1,0 +1,1 @@
+export * from './user.utils'

--- a/packages/quiz-service/src/user/services/utils/user.utils.ts
+++ b/packages/quiz-service/src/user/services/utils/user.utils.ts
@@ -1,0 +1,13 @@
+import { AuthProvider, LocalUser, User } from '../models/schemas'
+
+/**
+ * Type guard to check whether a User document is a local‐auth user.
+ *
+ * @param user - The User document to inspect.
+ * @returns True if `user.provider === AuthProvider.Local`, narrowing to LocalUser.
+ */
+export function isLocalUser(
+  user: User,
+): user is User & LocalUser & { provider: AuthProvider.Local } {
+  return user.provider === AuthProvider.Local
+}

--- a/packages/quiz-service/test/auth.controller.e2e-spec.ts
+++ b/packages/quiz-service/test/auth.controller.e2e-spec.ts
@@ -1,29 +1,230 @@
 import { INestApplication } from '@nestjs/common'
 import { JwtService } from '@nestjs/jwt'
+import { Authorities, TokenDto } from '@quiz/common'
 import * as bcrypt from 'bcryptjs'
+import { Response } from 'superagent'
 import supertest from 'supertest'
 import { v4 as uuidv4 } from 'uuid'
 
+import { AuthService } from '../src/auth/services'
 import { ClientService } from '../src/client/services'
+import { UserRepository } from '../src/user/services'
 
+import {
+  MOCK_DEFAULT_USER_EMAIL,
+  MOCK_DEFAULT_USER_FAMILY_NAME,
+  MOCK_DEFAULT_USER_GIVEN_NAME,
+  MOCK_DEFAULT_USER_HASHED_PASSWORD,
+  MOCK_DEFAULT_USER_INVALID_PASSWORD,
+  MOCK_DEFAULT_USER_PASSWORD,
+} from './data'
 import { closeTestApp, createTestApp } from './utils/bootstrap'
 
 describe('AuthController (e2e)', () => {
   let app: INestApplication
   let jwtService: JwtService
   let clientService: ClientService
+  let userRepository: UserRepository
+  let authService: AuthService
 
   beforeEach(async () => {
     app = await createTestApp()
     jwtService = app.get(JwtService)
     clientService = app.get(ClientService)
+    userRepository = app.get<UserRepository>(UserRepository)
+    authService = app.get<AuthService>(AuthService)
   })
 
   afterEach(async () => {
     await closeTestApp(app)
   })
 
-  describe('/api/games (POST)', () => {
+  describe('/api/login (POST)', () => {
+    it('should succeed in authenticating a user', async () => {
+      const user = await userRepository.createLocalUser({
+        email: MOCK_DEFAULT_USER_EMAIL,
+        hashedPassword: MOCK_DEFAULT_USER_HASHED_PASSWORD,
+        givenName: MOCK_DEFAULT_USER_GIVEN_NAME,
+        familyName: MOCK_DEFAULT_USER_FAMILY_NAME,
+      })
+
+      return supertest(app.getHttpServer())
+        .post('/api/auth/login')
+        .send({
+          email: MOCK_DEFAULT_USER_EMAIL,
+          password: MOCK_DEFAULT_USER_PASSWORD,
+        })
+        .expect(200)
+        .expect((res) => {
+          expectAuthLoginRequestDto(user._id, res)
+        })
+    })
+
+    it('should return 400 bad request when email not found', async () => {
+      return supertest(app.getHttpServer())
+        .post('/api/auth/login')
+        .send({
+          email: MOCK_DEFAULT_USER_EMAIL,
+          password: MOCK_DEFAULT_USER_PASSWORD,
+        })
+        .expect(400)
+        .expect((res) => {
+          expect(res.body).toEqual({
+            message: 'Bad credentials',
+            status: 400,
+            timestamp: expect.any(String),
+          })
+        })
+    })
+
+    it('should return 400 bad request when password is invalid', async () => {
+      return supertest(app.getHttpServer())
+        .post('/api/auth/login')
+        .send({
+          email: MOCK_DEFAULT_USER_EMAIL,
+          password: MOCK_DEFAULT_USER_INVALID_PASSWORD,
+        })
+        .expect(400)
+        .expect((res) => {
+          expect(res.body).toEqual({
+            message: 'Bad credentials',
+            status: 400,
+            timestamp: expect.any(String),
+          })
+        })
+    })
+
+    it('should return 400 bad request when validation fails', async () => {
+      return supertest(app.getHttpServer())
+        .post('/api/auth/login')
+        .send({})
+        .expect(400)
+        .expect((res) => {
+          expect(res.body).toEqual({
+            message: 'Validation failed',
+            status: 400,
+            timestamp: expect.any(String),
+            validationErrors: [
+              {
+                constraints: {
+                  matches: 'Email must be a valid address.',
+                  maxLength:
+                    'email must be shorter than or equal to 128 characters',
+                  minLength:
+                    'email must be longer than or equal to 6 characters',
+                },
+                property: 'email',
+              },
+              {
+                constraints: {
+                  matches:
+                    'Password must include ≥2 uppercase, ≥2 lowercase, ≥2 digits, ≥2 symbols.',
+                  maxLength:
+                    'password must be shorter than or equal to 128 characters',
+                  minLength:
+                    'password must be longer than or equal to 8 characters',
+                },
+                property: 'password',
+              },
+            ],
+          })
+        })
+    })
+  })
+
+  describe('/api/refresh (POST)', () => {
+    it('should succeed in refresh an existing authentication', async () => {
+      const user = await userRepository.createLocalUser({
+        email: MOCK_DEFAULT_USER_EMAIL,
+        hashedPassword: MOCK_DEFAULT_USER_HASHED_PASSWORD,
+        givenName: MOCK_DEFAULT_USER_GIVEN_NAME,
+        familyName: MOCK_DEFAULT_USER_FAMILY_NAME,
+      })
+
+      const { refreshToken } = await authService.login({
+        email: MOCK_DEFAULT_USER_EMAIL,
+        password: MOCK_DEFAULT_USER_PASSWORD,
+      })
+
+      return supertest(app.getHttpServer())
+        .post('/api/auth/refresh')
+        .send({
+          refreshToken,
+        })
+        .expect(200)
+        .expect((res) => {
+          expectAuthLoginRequestDto(user._id, res)
+        })
+    })
+
+    it('should return 400 bad request when token has expired', async () => {
+      const refreshToken = await jwtService.signAsync(
+        { authorities: [Authorities.RefreshAuth] },
+        { subject: uuidv4(), expiresIn: '-1d' },
+      )
+
+      return supertest(app.getHttpServer())
+        .post('/api/auth/refresh')
+        .send({
+          refreshToken,
+        })
+        .expect(401)
+        .expect((res) => {
+          expect(res.body).toEqual({
+            message: 'Unauthorized',
+            status: 401,
+            timestamp: expect.any(String),
+          })
+        })
+    })
+
+    it('should return 400 bad request when token is missing REFRESH_AUTH authority.', async () => {
+      const refreshToken = await jwtService.signAsync(
+        { authorities: [] },
+        { subject: uuidv4(), expiresIn: '30d' },
+      )
+
+      return supertest(app.getHttpServer())
+        .post('/api/auth/refresh')
+        .send({
+          refreshToken,
+        })
+        .expect(401)
+        .expect((res) => {
+          expect(res.body).toEqual({
+            message: 'Unauthorized',
+            status: 401,
+            timestamp: expect.any(String),
+          })
+        })
+    })
+
+    it('should return 400 bad request when validation fails', async () => {
+      return supertest(app.getHttpServer())
+        .post('/api/auth/refresh')
+        .send({
+          refreshToken: 'invalid_jwt',
+        })
+        .expect(400)
+        .expect((res) => {
+          expect(res.body).toEqual({
+            message: 'Validation failed',
+            status: 400,
+            timestamp: expect.any(String),
+            validationErrors: [
+              {
+                constraints: {
+                  isJwt: 'refreshToken must be a jwt string',
+                },
+                property: 'refreshToken',
+              },
+            ],
+          })
+        })
+    })
+  })
+
+  describe('/api/auth (POST)', () => {
     it('should succeed in authenticating a new client', () => {
       const clientId = uuidv4()
 
@@ -125,4 +326,23 @@ describe('AuthController (e2e)', () => {
         })
     })
   })
+
+  function expectAuthLoginRequestDto(userId: string, response: Response) {
+    expect(response.body).toEqual({
+      accessToken: expect.any(String),
+      refreshToken: expect.any(String),
+    })
+
+    const accessTokenDto = jwtService.verify<TokenDto>(
+      response.body.accessToken,
+    )
+    expect(accessTokenDto.sub).toEqual(userId)
+    expect(accessTokenDto.authorities).toEqual([])
+
+    const refreshTokenDto = jwtService.verify<TokenDto>(
+      response.body.refreshToken,
+    )
+    expect(refreshTokenDto.sub).toEqual(userId)
+    expect(refreshTokenDto.authorities).toEqual([Authorities.RefreshAuth])
+  }
 })

--- a/packages/quiz-service/test/data/data.utils.ts
+++ b/packages/quiz-service/test/data/data.utils.ts
@@ -363,6 +363,9 @@ export function createMockQuitTaskDocument(
 }
 
 export const MOCK_DEFAULT_USER_EMAIL = 'user@example.com'
-export const MOCK_DEFAULT_USER_PASSWORD = '%AD2W!o#iGPoa7wd'
+export const MOCK_DEFAULT_USER_PASSWORD = 'Super#SecretPa$$w0rd123'
+export const MOCK_DEFAULT_USER_INVALID_PASSWORD = 'Super#$ecretPassw0rd123'
+export const MOCK_DEFAULT_USER_HASHED_PASSWORD =
+  '$2b$10$.xzhAfwhLmb2Nbe5i2jRB.j4IUuWqnDvgUuQ/AZ/unHhOPJcJyVJ6'
 export const MOCK_DEFAULT_USER_GIVEN_NAME = 'John'
 export const MOCK_DEFAULT_USER_FAMILY_NAME = 'Appleseed'

--- a/packages/quiz-service/test/user.controller.e2e-spec.ts
+++ b/packages/quiz-service/test/user.controller.e2e-spec.ts
@@ -7,6 +7,7 @@ import {
   MOCK_DEFAULT_USER_EMAIL,
   MOCK_DEFAULT_USER_FAMILY_NAME,
   MOCK_DEFAULT_USER_GIVEN_NAME,
+  MOCK_DEFAULT_USER_HASHED_PASSWORD,
   MOCK_DEFAULT_USER_PASSWORD,
 } from './data'
 import { closeTestApp, createTestApp } from './utils/bootstrap'
@@ -104,7 +105,7 @@ describe('GameResultController (e2e)', () => {
     it('should return 409 conflict error when user already exists', async () => {
       await userRepository.createLocalUser({
         email: MOCK_DEFAULT_USER_EMAIL,
-        hashedPassword: MOCK_DEFAULT_USER_PASSWORD,
+        hashedPassword: MOCK_DEFAULT_USER_HASHED_PASSWORD,
         givenName: MOCK_DEFAULT_USER_GIVEN_NAME,
         familyName: MOCK_DEFAULT_USER_FAMILY_NAME,
       })


### PR DESCRIPTION
- add RefreshAuth authority to Authorities enum
- update TokenDto to include authorities array
- implement AuthService.login (email/password) and AuthService.refresh (refresh token)
- issue access (15m) and refresh (30d) JWTs with correct authority scopes
- wire AuthController to call new login/refresh methods and document 401 responses
- inject UserModule into AuthModule for credential verification
- add BadCredentialsException and isLocalUser type guard in UserService
- update create-user and auth DTO examples for stronger passwords
- add comprehensive e2e tests for /api/auth/login and /api/auth/refresh
- update test data with valid/invalid password constants and pre-hashed password