### PR TITLE
chore(docker): update Redis and MongoDB image versions

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.8'
 
 services:
   redis:
-    image: redis:7.4-alpine
+    image: redis:8.0.1
     container_name: redis
     hostname: redis
     restart: always
@@ -12,7 +12,7 @@ services:
       - redis:/data
 
   mongodb:
-    image: mongo:8.0.1-noble
+    image: mongo:8.0.9
     container_name: mongodb
     hostname: mongodb
     restart: always


### PR DESCRIPTION
- Bumped Redis image from 7.4-alpine to 8.0.1 for latest feature and security updates.
- Updated MongoDB image from 8.0.1-noble to 8.0.9 to stay aligned with the latest stable release.

Ensures container services are using up-to-date versions.