### PR TITLE
feat(auth): introduce TokenScope and centralize JWT signing

### DIFF
--- a/packages/common/src/models/authorities.enum.ts
+++ b/packages/common/src/models/authorities.enum.ts
@@ -4,11 +4,6 @@
  */
 export enum Authorities {
   /**
-   * Permission to allow use of the legacy client authentication.
-   */
-  LegacyAuth = 'LEGACY_AUTH',
-
-  /**
    * Permission to allow using a valid refresh token to obtain a new access token.
    */
   RefreshAuth = 'REFRESH_AUTH',

--- a/packages/common/src/models/token.dto.ts
+++ b/packages/common/src/models/token.dto.ts
@@ -1,6 +1,28 @@
 import { Authorities } from './authorities.enum'
 
 /**
+ * The functional area of the application that this token is intended for.
+ */
+export enum TokenScope {
+  /**
+   * Device scope—grants the same access as `User` tokens.
+   * This will eventually be removed in favor of the `User` scope.
+   */
+  Client = 'CLIENT',
+
+  /**
+   * Game scope—grants access to endpoints for hosting, joining, and
+   * managing ongoing quiz games.
+   */
+  Game = 'GAME',
+
+  /**
+   * User scope—grants access to all endpoints that require a signed‐in user.
+   */
+  User = 'USER',
+}
+
+/**
  * Represents a JSON Web Token (JWT) payload.
  */
 export interface TokenDto {
@@ -13,6 +35,11 @@ export interface TokenDto {
    * The expiration time of the token, represented as a UNIX timestamp.
    */
   exp: number
+
+  /**
+   * Which broad area of the API this token is allowed to interact with.
+   */
+  scope: TokenScope
 
   /**
    * The list of authorities (permissions or scopes) granted to the token holder.

--- a/packages/quiz-service/src/auth/services/utils/index.ts
+++ b/packages/quiz-service/src/auth/services/utils/index.ts
@@ -1,0 +1,1 @@
+export * from './token.utils'

--- a/packages/quiz-service/src/auth/services/utils/token.utils.ts
+++ b/packages/quiz-service/src/auth/services/utils/token.utils.ts
@@ -1,0 +1,52 @@
+import { Authorities, TokenScope } from '@quiz/common'
+
+/**
+ * Returns the list of Authorities that should be embedded in a token
+ * for the given scope and token type.
+ *
+ * @param scope - The logical API area (Client, Game, or User) for this token.
+ * @param isRefreshToken - Whether this token is a refresh token.
+ * @returns Array of Authorities to include in the JWT payload.
+ */
+export function getTokenAuthorities(
+  scope: TokenScope,
+  isRefreshToken: boolean,
+): Authorities[] {
+  if (isRefreshToken) {
+    return [Authorities.RefreshAuth]
+  }
+
+  switch (scope) {
+    case TokenScope.Client:
+      return []
+    case TokenScope.Game:
+      return []
+    case TokenScope.User:
+      return []
+  }
+}
+
+/**
+ * Determines the expiration duration string for a token of the given
+ * scope and type.
+ *
+ * @param scope - The logical API area (Client, Game, or User) for this token.
+ * @param isRefreshToken - Whether this token is a refresh token.
+ * @returns A string value (e.g. '15m', '1h', or '30d').
+ */
+export function getTokenExpiresIn(
+  scope: TokenScope,
+  isRefreshToken: boolean,
+): string {
+  if (isRefreshToken) {
+    return '30d'
+  }
+
+  switch (scope) {
+    case TokenScope.Client:
+      return '1h'
+    case TokenScope.Game:
+    case TokenScope.User:
+      return '15m'
+  }
+}


### PR DESCRIPTION
- Remove deprecated LegacyAuth authority from Authorities enum
- Add TokenScope enum (Client, Game, User) and include `scope` claim in TokenDto
- Refactor AuthService:
  - Replace ad-hoc jwtService.signAsync calls with a new private signToken(scope, isRefresh, subject) helper
  - signToken uses getTokenAuthorities() and getTokenExpiresIn() utilities
- Create token.utils with getTokenAuthorities() and getTokenExpiresIn()
- Update legacy authentication to use signToken(TokenScope.Client)
- Extend AuthService.signTokenPair to issue scoped access (15m) and refresh (30d) tokens
- Update e2e tests to assert on the new `scope` claim for both access and legacy tokens