### PR TITLE
Rename Authorities enum to Authority and reorganize auth decorators

### DIFF
--- a/packages/common/src/models/authority.enum.ts
+++ b/packages/common/src/models/authority.enum.ts
@@ -2,7 +2,7 @@
  * Enumeration of granted authorities (permissions or scopes)
  * that can be assigned to a JWT to control access to protected resources.
  */
-export enum Authorities {
+export enum Authority {
   /**
    * Permission to allow using a valid refresh token to obtain a new access token.
    */

--- a/packages/common/src/models/index.ts
+++ b/packages/common/src/models/index.ts
@@ -1,5 +1,5 @@
 export * from './auth'
-export * from './authorities.enum'
+export * from './authority.enum'
 export * from './find-game-response.dto'
 export * from './game.dto'
 export * from './game-event'

--- a/packages/common/src/models/token.dto.ts
+++ b/packages/common/src/models/token.dto.ts
@@ -1,4 +1,4 @@
-import { Authorities } from './authorities.enum'
+import { Authority } from './authority.enum'
 
 /**
  * The functional area of the application that this token is intended for.
@@ -45,5 +45,5 @@ export interface TokenDto {
    * The list of authorities (permissions or scopes) granted to the token holder.
    * Determines which actions or endpoints the bearer is allowed to access.
    */
-  authorities: Authorities[]
+  authorities: Authority[]
 }

--- a/packages/quiz-service/src/auth/controllers/decorators/auth/index.ts
+++ b/packages/quiz-service/src/auth/controllers/decorators/auth/index.ts
@@ -1,0 +1,3 @@
+export * from './public.decorator'
+export * from './required-authorities.decorator'
+export * from './required-scopes.decorator'

--- a/packages/quiz-service/src/auth/controllers/decorators/auth/public.decorator.ts
+++ b/packages/quiz-service/src/auth/controllers/decorators/auth/public.decorator.ts
@@ -1,0 +1,16 @@
+import { SetMetadata } from '@nestjs/common'
+
+/**
+ * Metadata key used to mark a route or controller as publicly accessible,
+ * i.e. no authentication or authorization checks will be applied.
+ */
+export const IS_PUBLIC_KEY = 'isPublic'
+
+/**
+ * Decorator that marks a route or controller as public, opt-out of
+ * authentication and authorization checks. When applied, the AuthGuard
+ * will allow requests through without requiring a valid JWT.
+ *
+ * @returns A decorator function that sets `IS_PUBLIC_KEY` metadata to `true`.
+ */
+export const Public = () => SetMetadata(IS_PUBLIC_KEY, true)

--- a/packages/quiz-service/src/auth/controllers/decorators/auth/required-authorities.decorator.ts
+++ b/packages/quiz-service/src/auth/controllers/decorators/auth/required-authorities.decorator.ts
@@ -1,0 +1,18 @@
+import { SetMetadata } from '@nestjs/common'
+import { Authority } from '@quiz/common'
+
+/**
+ * Metadata key under which the required authorities for a route/controller are stored.
+ */
+export const REQUIRED_AUTHORITIES_KEY = 'required_authorities'
+
+/**
+ * Decorator that specifies which authorities (permissions) a request must have
+ * in its JWT in order to access the decorated route or controller.
+ * The AuthGuard will read this metadata and throw a ForbiddenException if
+ * the token’s authorities do not include *all* of the listed values.
+ *
+ * @param authorities  One or more Authority enum values required for access.
+ */
+export const RequiredAuthorities = (...authorities: Authority[]) =>
+  SetMetadata(REQUIRED_AUTHORITIES_KEY, authorities)

--- a/packages/quiz-service/src/auth/controllers/decorators/auth/required-scopes.decorator.ts
+++ b/packages/quiz-service/src/auth/controllers/decorators/auth/required-scopes.decorator.ts
@@ -1,0 +1,18 @@
+import { SetMetadata } from '@nestjs/common'
+import { TokenScope } from '@quiz/common'
+
+/**
+ * Metadata key under which the required token scopes for a route/controller are stored.
+ */
+export const REQUIRED_SCOPES_KEY = 'required_scopes'
+
+/**
+ * Decorator that specifies which broad token scopes a request must carry
+ * in order to access the decorated route or controller. The AuthGuard will
+ * read this metadata and throw a ForbiddenException if the token’s scope
+ * is not one of the listed values.
+ *
+ * @param scopes  One or more TokenScope enum values allowed for access.
+ */
+export const RequiresScopes = (...scopes: TokenScope[]) =>
+  SetMetadata(REQUIRED_SCOPES_KEY, scopes)

--- a/packages/quiz-service/src/auth/controllers/decorators/index.ts
+++ b/packages/quiz-service/src/auth/controllers/decorators/index.ts
@@ -1,1 +1,1 @@
-export * from './public.decorator'
+export * from './auth'

--- a/packages/quiz-service/src/auth/controllers/decorators/public.decorator.ts
+++ b/packages/quiz-service/src/auth/controllers/decorators/public.decorator.ts
@@ -1,4 +1,0 @@
-import { SetMetadata } from '@nestjs/common'
-
-export const IS_PUBLIC_KEY = 'isPublic'
-export const Public = () => SetMetadata(IS_PUBLIC_KEY, true)

--- a/packages/quiz-service/src/auth/guards/auth.guard.ts
+++ b/packages/quiz-service/src/auth/guards/auth.guard.ts
@@ -1,22 +1,71 @@
 import {
   CanActivate,
   ExecutionContext,
+  ForbiddenException,
   Injectable,
   UnauthorizedException,
 } from '@nestjs/common'
 import { Reflector } from '@nestjs/core'
+import { Authority, TokenDto, TokenScope } from '@quiz/common'
 import { Request } from 'express'
 
 import { ClientService } from '../../client/services'
+import { Client } from '../../client/services/models/schemas'
 import { IS_PUBLIC_KEY } from '../controllers/decorators'
+import {
+  REQUIRED_AUTHORITIES_KEY,
+  REQUIRED_SCOPES_KEY,
+} from '../controllers/decorators'
 import { AuthService } from '../services'
 
 /**
- * Custom authorization guard that ensures requests are authenticated.
+ * Extended Express Request that includes authentication state
+ * set by the AuthGuard.
+ */
+export interface AuthGuardRequest extends Request {
+  /**
+   * The broad API area this request is operating under,
+   * taken from the JWT’s `scope` claim.
+   */
+  scope: TokenScope
+
+  /**
+   * The list of authorities (permissions) granted by the JWT,
+   * taken from the JWT’s `authorities` claim.
+   */
+  authorities: Authority[]
+
+  /**
+   * The authenticated user’s ID, populated when `scope` is
+   * `User` or `Game`.
+   */
+  userId?: string
+
+  /**
+   * The authenticated client record, populated when `scope`
+   * is `Client`. Loaded by clientService.findByClientIdHashOrThrow().
+   */
+  client?: Client
+}
+
+/**
+ * Guard that enforces JWT‐based authentication and authorization.
  *
- * This guard checks if the request contains a valid JWT token in the
- * Authorization header. For public routes marked with the `@Public`
- * decorator, the guard allows access without requiring authentication.
+ * - Skips auth for routes marked `@Public()`.
+ * - Extracts & validates a Bearer JWT.
+ * - Reads `{ sub, scope, authorities }` from token.
+ * - Verifies route‐level `@RequiresScopes()` and `@RequiresAuthorities()`.
+ * - Attaches to the request:
+ *    - `scope: TokenScope`
+ *    - `authorities: Authority[]`
+ *    - `userId` (if scope is User or Game)
+ *    - `client` (if scope is Client)
+ *
+ * The incoming `Request` is assumed to be an `AuthGuardRequest`.
+ *
+ * @throws {UnauthorizedException} if missing/invalid token or client lookup fails.
+ * @throws {ForbiddenException} if the token’s scope or authorities don’t match
+ *         the route’s requirements.
  */
 @Injectable()
 export class AuthGuard implements CanActivate {
@@ -35,17 +84,21 @@ export class AuthGuard implements CanActivate {
   ) {}
 
   /**
-   * Determines whether the current request is authorized.
+   * Determines whether a request is allowed to proceed.
    *
-   * If the route is public, the method allows access without further checks.
-   * Otherwise, it verifies the JWT token and ensures the client exists in the system.
+   * Steps:
+   * 1. If `@Public()` metadata is present, allow immediately.
+   * 2. Extract and verify the Bearer token.
+   * 3. Check that `scope` from token is allowed for this handler.
+   * 4. Check that `authorities` from token include any required authorities.
+   * 5. Attach `scope` and `authorities` to `request`.
+   * 6. If `scope` is `User` or `Game`, attach `request.userId = sub`.
+   * 7. If `scope` is `Client`, look up and attach `request.client`.
    *
-   * @param context - The execution context of the current request.
-   * @returns A promise that resolves to `true` if the request is authorized,
-   *          otherwise throws an `UnauthorizedException`.
-   *
-   * @throws UnauthorizedException if the token is missing, invalid, or
-   *         if the associated client cannot be found.
+   * @param context  The current request execution context.
+   * @returns `true` if all checks pass.
+   * @throws {UnauthorizedException} if authentication fails.
+   * @throws {ForbiddenException} if authorization fails.
    */
   async canActivate(context: ExecutionContext): Promise<boolean> {
     const isPublic = this.reflector.getAllAndOverride<boolean>(IS_PUBLIC_KEY, [
@@ -56,32 +109,107 @@ export class AuthGuard implements CanActivate {
       return true
     }
 
-    const request = context.switchToHttp().getRequest()
+    const request = context.switchToHttp().getRequest<AuthGuardRequest>()
+    const { sub, scope, authorities } = await this.verifyTokenOrThrow(request)
 
-    const token = this.extractTokenFromHeader(request)
+    this.verifyAuthorizedScopesOrThrows(scope, context)
+    this.verifyAuthorizedAuthoritiesOrThrows(authorities, context)
 
-    if (!token) {
-      throw new UnauthorizedException()
+    request.scope = scope
+    request.authorities = authorities
+
+    if (scope === TokenScope.User || scope === TokenScope.Game) {
+      request.userId = sub
     }
 
-    try {
-      const { sub } = await this.authService.verifyToken(token)
-
-      request['client'] =
-        await this.clientService.findByClientIdHashOrThrow(sub)
-    } catch {
-      throw new UnauthorizedException()
+    if (scope === TokenScope.Client) {
+      request.client = await this.clientService.findByClientIdHashOrThrow(sub)
     }
 
     return true
   }
 
   /**
-   * Extracts the JWT token from the Authorization header of the HTTP request.
+   * Ensures that the token’s authorities meet any `@RequiresAuthorities(...)` metadata.
    *
-   * @param request - The incoming HTTP request.
-   * @returns The extracted token as a string if the header is present and valid;
-   *          otherwise, `undefined`.
+   * @param authorities  The list from the decoded token.
+   * @param context      The execution context (to read metadata).
+   * @throws {UnauthorizedException} if the token did not include any authorities.
+   * @throws {ForbiddenException}    if the token is missing any required authority.
+   * @private
+   */
+  private verifyAuthorizedAuthoritiesOrThrows(
+    authorities: Authority[],
+    context: ExecutionContext,
+  ): void {
+    if (!authorities) {
+      throw new UnauthorizedException('No authorities in token')
+    }
+
+    const required = this.reflector.get<Authority[]>(
+      REQUIRED_AUTHORITIES_KEY,
+      context.getHandler(),
+    )
+
+    if (required?.length && !required.every((r) => authorities.includes(r))) {
+      throw new ForbiddenException('Insufficient authorities')
+    }
+  }
+
+  /**
+   * Ensures that the token’s scope meets any `@RequiresScopes(...)` metadata.
+   *
+   * @param scope    The scope from the decoded token.
+   * @param context  The execution context (to read metadata).
+   * @throws {UnauthorizedException} if no scope is present.
+   * @throws {ForbiddenException}    if the token’s scope is not one of the required scopes.
+   * @private
+   */
+  private verifyAuthorizedScopesOrThrows(
+    scope: TokenScope,
+    context: ExecutionContext,
+  ): void {
+    if (!scope) {
+      throw new UnauthorizedException('No scope in token')
+    }
+
+    const required = this.reflector.get<TokenScope[]>(
+      REQUIRED_SCOPES_KEY,
+      context.getHandler(),
+    )
+
+    if (required?.length && !required.includes(scope)) {
+      throw new ForbiddenException(`Scope '${scope}' not allowed`)
+    }
+  }
+
+  /**
+   * Extracts and verifies the JWT from the request.
+   *
+   * @param request  The incoming HTTP request.
+   * @returns The decoded TokenDto.
+   * @throws {UnauthorizedException} if the token is missing or invalid.
+   * @private
+   */
+  private async verifyTokenOrThrow(request: Request): Promise<TokenDto> {
+    const token = this.extractTokenFromHeader(request)
+    if (!token) {
+      throw new UnauthorizedException('Missing Authorization header')
+    }
+
+    try {
+      return await this.authService.verifyToken(token)
+    } catch {
+      throw new UnauthorizedException('Invalid or expired token')
+    }
+  }
+
+  /**
+   * Pulls the Bearer token out of the `Authorization` header.
+   *
+   * @param request  The incoming HTTP request.
+   * @returns The raw token string, or `undefined` if not present or malformed.
+   * @private
    */
   private extractTokenFromHeader(request: Request): string | undefined {
     const [type, token] = request.headers.authorization?.split(' ') ?? []

--- a/packages/quiz-service/src/auth/services/auth.service.ts
+++ b/packages/quiz-service/src/auth/services/auth.service.ts
@@ -3,7 +3,7 @@ import { JwtService } from '@nestjs/jwt'
 import {
   AuthLoginRequestDto,
   AuthLoginResponseDto,
-  Authorities,
+  Authority,
   LegacyAuthRequestDto,
   LegacyAuthResponseDto,
   TokenDto,
@@ -77,9 +77,9 @@ export class AuthService {
       throw new UnauthorizedException()
     }
 
-    if (!result.authorities.includes(Authorities.RefreshAuth)) {
+    if (!result.authorities.includes(Authority.RefreshAuth)) {
       this.logger.debug(
-        `Failed to refresh token since missing '${Authorities.RefreshAuth}' authority.`,
+        `Failed to refresh token since missing '${Authority.RefreshAuth}' authority.`,
       )
       throw new UnauthorizedException()
     }

--- a/packages/quiz-service/src/auth/services/utils/token.utils.ts
+++ b/packages/quiz-service/src/auth/services/utils/token.utils.ts
@@ -1,19 +1,19 @@
-import { Authorities, TokenScope } from '@quiz/common'
+import { Authority, TokenScope } from '@quiz/common'
 
 /**
- * Returns the list of Authorities that should be embedded in a token
+ * Returns the list of Authority that should be embedded in a token
  * for the given scope and token type.
  *
  * @param scope - The logical API area (Client, Game, or User) for this token.
  * @param isRefreshToken - Whether this token is a refresh token.
- * @returns Array of Authorities to include in the JWT payload.
+ * @returns Array of Authority to include in the JWT payload.
  */
 export function getTokenAuthorities(
   scope: TokenScope,
   isRefreshToken: boolean,
-): Authorities[] {
+): Authority[] {
   if (isRefreshToken) {
-    return [Authorities.RefreshAuth]
+    return [Authority.RefreshAuth]
   }
 
   switch (scope) {

--- a/packages/quiz-service/test/auth.controller.e2e-spec.ts
+++ b/packages/quiz-service/test/auth.controller.e2e-spec.ts
@@ -1,6 +1,6 @@
 import { INestApplication } from '@nestjs/common'
 import { JwtService } from '@nestjs/jwt'
-import { Authorities, TokenDto, TokenScope } from '@quiz/common'
+import { Authority, TokenDto, TokenScope } from '@quiz/common'
 import * as bcrypt from 'bcryptjs'
 import { Response } from 'superagent'
 import supertest from 'supertest'
@@ -159,7 +159,7 @@ describe('AuthController (e2e)', () => {
 
     it('should return 400 bad request when token has expired', async () => {
       const refreshToken = await jwtService.signAsync(
-        { authorities: [Authorities.RefreshAuth] },
+        { authorities: [Authority.RefreshAuth] },
         { subject: uuidv4(), expiresIn: '-1d' },
       )
 
@@ -331,7 +331,7 @@ describe('AuthController (e2e)', () => {
     )
     expect(refreshTokenDto.sub).toEqual(userId)
     expect(refreshTokenDto.scope).toEqual(TokenScope.User)
-    expect(refreshTokenDto.authorities).toEqual([Authorities.RefreshAuth])
+    expect(refreshTokenDto.authorities).toEqual([Authority.RefreshAuth])
   }
 
   function expectLegacyAuthResponseDto(

--- a/packages/quiz-service/test/client-game.controller.e2e-spec.ts
+++ b/packages/quiz-service/test/client-game.controller.e2e-spec.ts
@@ -196,7 +196,7 @@ describe('ClientGameController (e2e)', () => {
         .expect(401)
         .expect((res) => {
           expect(res.body).toEqual({
-            message: 'Unauthorized',
+            message: 'Missing Authorization header',
             status: 401,
             timestamp: expect.anything(),
           })

--- a/packages/quiz-service/test/client-player.controller.e2e-spec.ts
+++ b/packages/quiz-service/test/client-player.controller.e2e-spec.ts
@@ -88,7 +88,7 @@ describe('ClientPlayerController (e2e)', () => {
         .expect(401)
         .expect((res) => {
           expect(res.body).toEqual({
-            message: 'Unauthorized',
+            message: 'Missing Authorization header',
             status: 401,
             timestamp: expect.anything(),
           })
@@ -176,7 +176,7 @@ describe('ClientPlayerController (e2e)', () => {
         .expect(401)
         .expect((res) => {
           expect(res.body).toEqual({
-            message: 'Unauthorized',
+            message: 'Missing Authorization header',
             status: 401,
             timestamp: expect.anything(),
           })
@@ -208,7 +208,7 @@ describe('ClientPlayerController (e2e)', () => {
         .expect(401)
         .expect((res) => {
           expect(res.body).toEqual({
-            message: 'Unauthorized',
+            message: 'Missing Authorization header',
             status: 401,
             timestamp: expect.anything(),
           })
@@ -309,7 +309,7 @@ describe('ClientPlayerController (e2e)', () => {
         .expect(401)
         .expect((res) => {
           expect(res.body).toEqual({
-            message: 'Unauthorized',
+            message: 'Missing Authorization header',
             status: 401,
             timestamp: expect.anything(),
           })

--- a/packages/quiz-service/test/client-quiz.controller.e2e-spec.ts
+++ b/packages/quiz-service/test/client-quiz.controller.e2e-spec.ts
@@ -174,7 +174,10 @@ describe('ClientQuizController (e2e)', () => {
         .get('/api/client/quizzes')
         .expect(401)
         .expect((res) => {
-          expect(res.body).toHaveProperty('message', 'Unauthorized')
+          expect(res.body).toHaveProperty(
+            'message',
+            'Missing Authorization header',
+          )
           expect(res.body).toHaveProperty('status', 401)
           expect(res.body).toHaveProperty('timestamp')
         })

--- a/packages/quiz-service/test/game-result.controller.e2e-spec.ts
+++ b/packages/quiz-service/test/game-result.controller.e2e-spec.ts
@@ -285,7 +285,7 @@ describe('GameResultController (e2e)', () => {
         .expect(401)
         .expect((res) => {
           expect(res.body).toEqual({
-            message: 'Unauthorized',
+            message: 'Missing Authorization header',
             status: 401,
             timestamp: expect.anything(),
           })

--- a/packages/quiz-service/test/game.e2e-spec.ts
+++ b/packages/quiz-service/test/game.e2e-spec.ts
@@ -707,7 +707,10 @@ describe('GameController (e2e)', () => {
         .get(`/api/games/${gameID}/events`)
         .expect(401)
         .expect((res) => {
-          expect(res.body).toHaveProperty('message', 'Unauthorized')
+          expect(res.body).toHaveProperty(
+            'message',
+            'Missing Authorization header',
+          )
           expect(res.body).toHaveProperty('status', 401)
           expect(res.body).toHaveProperty('timestamp')
         })
@@ -916,7 +919,10 @@ describe('GameController (e2e)', () => {
         .post(`/api/games/${gameID}/tasks/current/complete`)
         .expect(401)
         .expect((res) => {
-          expect(res.body).toHaveProperty('message', 'Unauthorized')
+          expect(res.body).toHaveProperty(
+            'message',
+            'Missing Authorization header',
+          )
           expect(res.body).toHaveProperty('status', 401)
           expect(res.body).toHaveProperty('timestamp')
         })
@@ -1670,7 +1676,7 @@ describe('GameController (e2e)', () => {
         .expect(401)
         .expect((res) => {
           expect(res.body).toEqual({
-            message: 'Unauthorized',
+            message: 'Missing Authorization header',
             status: 401,
             timestamp: expect.anything(),
           })
@@ -2241,7 +2247,7 @@ describe('GameController (e2e)', () => {
         .expect(401)
         .expect((res) => {
           expect(res.body).toEqual({
-            message: 'Unauthorized',
+            message: 'Missing Authorization header',
             status: 401,
             timestamp: expect.anything(),
           })

--- a/packages/quiz-service/test/media.controller.e2e-spec.ts
+++ b/packages/quiz-service/test/media.controller.e2e-spec.ts
@@ -56,7 +56,7 @@ describe('MediaController (e2e)', () => {
         .expect(401)
         .expect((res) => {
           expect(res.body).toEqual({
-            message: 'Unauthorized',
+            message: 'Missing Authorization header',
             status: 401,
             timestamp: expect.anything(),
           })
@@ -119,7 +119,7 @@ describe('MediaController (e2e)', () => {
         .expect(401)
         .expect((res) => {
           expect(res.body).toEqual({
-            message: 'Unauthorized',
+            message: 'Missing Authorization header',
             status: 401,
             timestamp: expect.anything(),
           })
@@ -182,7 +182,7 @@ describe('MediaController (e2e)', () => {
         .expect(401)
         .expect((res) => {
           expect(res.body).toEqual({
-            message: 'Unauthorized',
+            message: 'Missing Authorization header',
             status: 401,
             timestamp: expect.anything(),
           })

--- a/packages/quiz-service/test/quiz.controller.e2e-spec.ts
+++ b/packages/quiz-service/test/quiz.controller.e2e-spec.ts
@@ -425,7 +425,7 @@ describe('QuizController (e2e)', () => {
         .expect(401)
         .expect((res) => {
           expect(res.body).toEqual({
-            message: 'Unauthorized',
+            message: 'Missing Authorization header',
             status: 401,
             timestamp: expect.anything(),
           })


### PR DESCRIPTION
- Rename `packages/common/src/models/authorities.enum.ts` → `authority.enum.ts`, change enum name from `Authorities` → `Authority`
- Update all imports and the `TokenDto.authorities` type to use `Authority[]`
- Move `Public`, `RequiredAuthorities`, and `RequiresScopes` decorators into `src/auth/controllers/decorators/auth/` and re-export from `decorators/auth/index.ts`
- Update `AuthGuard` to use new metadata keys (`required_authorities` / `required_scopes`), import `Authority`, and attach cleaner error messages (`Missing Authorization header`)
- Refactor `AuthService` and `token.utils` to reference `Authority.RefreshAuth`
- Adjust end-to-end tests to import `Authority` and expect the new unauthorized message