### PR TITLE
feat(user): add defaultNickname to user model and flows

### DIFF
--- a/packages/common/src/models/user.ts
+++ b/packages/common/src/models/user.ts
@@ -21,6 +21,11 @@ export interface CreateUserRequestDto {
    * Optional family name (last name) of the user.
    */
   readonly familyName?: string
+
+  /**
+   * Optional default nickname of the user used for when participating in games.
+   */
+  readonly defaultNickname?: string
 }
 
 /**
@@ -46,6 +51,11 @@ export interface CreateUserResponseDto {
    * The new user’s family name, if provided.
    */
   readonly familyName?: string
+
+  /**
+   * The new user’s default nickname, if provided.
+   */
+  readonly defaultNickname?: string
 
   /**
    * Timestamp when the user was created (ISO 8601 string).

--- a/packages/quiz-service/src/auth/services/auth.service.ts
+++ b/packages/quiz-service/src/auth/services/auth.service.ts
@@ -4,12 +4,12 @@ import {
   AuthLoginRequestDto,
   AuthLoginResponseDto,
   Authority,
+  AuthRefreshRequestDto,
   LegacyAuthRequestDto,
   LegacyAuthResponseDto,
   TokenDto,
   TokenScope,
 } from '@quiz/common'
-import { AuthRefreshRequestDto } from '@quiz/common/src'
 
 import { ClientService } from '../../client/services'
 import { UserService } from '../../user/services'

--- a/packages/quiz-service/src/game/services/utils/game-event.converter.ts
+++ b/packages/quiz-service/src/game/services/utils/game-event.converter.ts
@@ -8,6 +8,7 @@ import {
   GameEventQuestionResults,
   GameEventType,
   GameLeaderboardHostEvent,
+  GameLeaderboardPlayerEvent,
   GameLoadingEvent,
   GameLobbyHostEvent,
   GameLobbyPlayerEvent,
@@ -18,12 +19,12 @@ import {
   GameQuestionPlayerEvent,
   GameQuestionPreviewHostEvent,
   GameQuestionPreviewPlayerEvent,
+  GameQuitEvent,
   GameResultHostEvent,
   GameResultPlayerEvent,
   PaginationEvent,
   QuestionType,
 } from '@quiz/common'
-import { GameLeaderboardPlayerEvent, GameQuitEvent } from '@quiz/common/src'
 
 import {
   isMultiChoiceQuestion,

--- a/packages/quiz-service/src/user/controllers/models/create-user.request.ts
+++ b/packages/quiz-service/src/user/controllers/models/create-user.request.ts
@@ -13,6 +13,9 @@ import {
   PASSWORD_MAX_LENGTH,
   PASSWORD_MIN_LENGTH,
   PASSWORD_REGEX,
+  PLAYER_NICKNAME_MAX_LENGTH,
+  PLAYER_NICKNAME_MIN_LENGTH,
+  PLAYER_NICKNAME_REGEX,
 } from '@quiz/common'
 import { IsOptional, Matches, MaxLength, MinLength } from 'class-validator'
 
@@ -92,4 +95,26 @@ export class CreateUserRequest implements CreateUserRequestDto {
       'Family name must be 1–64 characters of letters/marks, and may include internal spaces, apostrophes or hyphens (no leading/trailing separators).',
   })
   readonly familyName?: string
+
+  /**
+   * Optional default nickname of the user used for when participating in games.
+   */
+  @ApiPropertyOptional({
+    title: 'Default Nickname',
+    description:
+      'A nickname chosen by the player, must be 2 to 20 characters long and contain only letters, numbers, or underscores.',
+    required: true,
+    type: String,
+    minLength: PLAYER_NICKNAME_MIN_LENGTH,
+    maxLength: PLAYER_NICKNAME_MAX_LENGTH,
+    pattern: PLAYER_NICKNAME_REGEX.source,
+    example: 'FrostyBear',
+  })
+  @IsOptional()
+  @MinLength(PLAYER_NICKNAME_MIN_LENGTH)
+  @MaxLength(PLAYER_NICKNAME_MAX_LENGTH)
+  @Matches(PLAYER_NICKNAME_REGEX, {
+    message: 'Nickname can only contain letters, numbers, and underscores.',
+  })
+  readonly defaultNickname?: string
 }

--- a/packages/quiz-service/src/user/controllers/models/create-user.response.ts
+++ b/packages/quiz-service/src/user/controllers/models/create-user.response.ts
@@ -4,6 +4,9 @@ import {
   EMAIL_REGEX,
   FAMILY_NAME_REGEX,
   GIVEN_NAME_REGEX,
+  PLAYER_NICKNAME_MAX_LENGTH,
+  PLAYER_NICKNAME_MIN_LENGTH,
+  PLAYER_NICKNAME_REGEX,
 } from '@quiz/common'
 
 /**
@@ -56,6 +59,22 @@ export class CreateUserResponse implements CreateUserResponseDto {
     example: 'Appleseed',
   })
   readonly familyName?: string
+
+  /**
+   * The new user’s default nickname, if provided.
+   */
+  @ApiPropertyOptional({
+    title: 'Default Nickname',
+    description:
+      'A nickname chosen by the player, must be 2 to 20 characters long and contain only letters, numbers, or underscores.',
+    required: true,
+    type: String,
+    minLength: PLAYER_NICKNAME_MIN_LENGTH,
+    maxLength: PLAYER_NICKNAME_MAX_LENGTH,
+    pattern: PLAYER_NICKNAME_REGEX.source,
+    example: 'FrostyBear',
+  })
+  readonly defaultNickname?: string
 
   /**
    * ISO 8601 timestamp when the user was created.

--- a/packages/quiz-service/src/user/services/models/schemas/user.schema.ts
+++ b/packages/quiz-service/src/user/services/models/schemas/user.schema.ts
@@ -57,6 +57,12 @@ export class User {
   familyName?: string
 
   /**
+   * Optional default nickname of the user used for when participating in games.
+   */
+  @Prop({ type: String, required: false })
+  defaultNickname?: string
+
+  /**
    * Timestamp when the user was created (ISO-8601 string).
    */
   @Prop({ type: Date, default: now() })

--- a/packages/quiz-service/src/user/services/user.repository.ts
+++ b/packages/quiz-service/src/user/services/user.repository.ts
@@ -59,6 +59,7 @@ export class UserRepository {
     hashedPassword: string
     givenName?: string
     familyName?: string
+    defaultNickname?: string
   }): Promise<User> {
     return new this.userModel({
       _id: uuidv4(),

--- a/packages/quiz-service/src/user/services/user.service.ts
+++ b/packages/quiz-service/src/user/services/user.service.ts
@@ -69,7 +69,8 @@ export class UserService {
   public async createUser(
     requestDto: CreateUserRequestDto,
   ): Promise<CreateUserResponseDto> {
-    const { email, password, givenName, familyName } = requestDto
+    const { email, password, givenName, familyName, defaultNickname } =
+      requestDto
 
     this.logger.debug(`Creating new user with email: '${email}'.`)
 
@@ -78,12 +79,19 @@ export class UserService {
     const salt = await bcrypt.genSalt(10)
     const hashedPassword = await bcrypt.hash(password, salt)
 
-    const createdUser = await this.userRepository.createLocalUser({
+    const details: Pick<
+      CreateUserRequestDto,
+      'email' | 'givenName' | 'familyName' | 'defaultNickname'
+    > &
+      Pick<LocalUser, 'hashedPassword'> = {
       email,
       hashedPassword,
       givenName,
       familyName,
-    })
+      defaultNickname,
+    }
+
+    const createdUser = await this.userRepository.createLocalUser(details)
 
     this.logger.log(`Created a new user with email: '${email}'.`)
 
@@ -101,14 +109,22 @@ export class UserService {
   private static toCreateUserResponse(
     createdUser: User,
   ): CreateUserResponseDto {
-    const { _id, email, givenName, familyName, createdAt, updatedAt } =
-      createdUser
+    const {
+      _id,
+      email,
+      givenName,
+      familyName,
+      defaultNickname,
+      createdAt,
+      updatedAt,
+    } = createdUser
 
     return {
       id: _id,
       email,
       givenName,
       familyName,
+      defaultNickname,
       created: createdAt,
       updated: updatedAt,
     }

--- a/packages/quiz-service/test/user.controller.e2e-spec.ts
+++ b/packages/quiz-service/test/user.controller.e2e-spec.ts
@@ -4,6 +4,7 @@ import supertest from 'supertest'
 import { UserRepository } from '../src/user/services'
 
 import {
+  MOCK_DEFAULT_PLAYER_NICKNAME,
   MOCK_DEFAULT_USER_EMAIL,
   MOCK_DEFAULT_USER_FAMILY_NAME,
   MOCK_DEFAULT_USER_GIVEN_NAME,
@@ -12,7 +13,7 @@ import {
 } from './data'
 import { closeTestApp, createTestApp } from './utils/bootstrap'
 
-describe('GameResultController (e2e)', () => {
+describe('UserController (e2e)', () => {
   let app: INestApplication
   let userRepository: UserRepository
 
@@ -34,6 +35,7 @@ describe('GameResultController (e2e)', () => {
           password: MOCK_DEFAULT_USER_PASSWORD,
           givenName: MOCK_DEFAULT_USER_GIVEN_NAME,
           familyName: MOCK_DEFAULT_USER_FAMILY_NAME,
+          defaultNickname: MOCK_DEFAULT_PLAYER_NICKNAME,
         })
         .expect(201)
         .expect((res) => {
@@ -42,6 +44,7 @@ describe('GameResultController (e2e)', () => {
             email: MOCK_DEFAULT_USER_EMAIL,
             givenName: MOCK_DEFAULT_USER_GIVEN_NAME,
             familyName: MOCK_DEFAULT_USER_FAMILY_NAME,
+            defaultNickname: MOCK_DEFAULT_PLAYER_NICKNAME,
             created: expect.any(String),
             updated: expect.any(String),
           })
@@ -54,6 +57,7 @@ describe('GameResultController (e2e)', () => {
         .send({
           givenName: '#',
           familyName: '#',
+          defaultNickname: '#',
         })
         .expect(400)
         .expect((res) => {
@@ -97,6 +101,15 @@ describe('GameResultController (e2e)', () => {
                 },
                 property: 'familyName',
               },
+              {
+                constraints: {
+                  matches:
+                    'Nickname can only contain letters, numbers, and underscores.',
+                  minLength:
+                    'defaultNickname must be longer than or equal to 2 characters',
+                },
+                property: 'defaultNickname',
+              },
             ],
           })
         })
@@ -108,6 +121,7 @@ describe('GameResultController (e2e)', () => {
         hashedPassword: MOCK_DEFAULT_USER_HASHED_PASSWORD,
         givenName: MOCK_DEFAULT_USER_GIVEN_NAME,
         familyName: MOCK_DEFAULT_USER_FAMILY_NAME,
+        defaultNickname: MOCK_DEFAULT_PLAYER_NICKNAME,
       })
 
       return supertest(app.getHttpServer())
@@ -117,6 +131,7 @@ describe('GameResultController (e2e)', () => {
           password: MOCK_DEFAULT_USER_PASSWORD,
           givenName: MOCK_DEFAULT_USER_GIVEN_NAME,
           familyName: MOCK_DEFAULT_USER_FAMILY_NAME,
+          defaultNickname: MOCK_DEFAULT_PLAYER_NICKNAME,
         })
         .expect(409)
         .expect((res) => {

--- a/packages/quiz/src/components/ProgressBar/ProgressBar.tsx
+++ b/packages/quiz/src/components/ProgressBar/ProgressBar.tsx
@@ -1,4 +1,4 @@
-import { CountdownEvent } from '@quiz/common/src'
+import { CountdownEvent } from '@quiz/common'
 import React, { FC, useEffect, useRef, useState } from 'react'
 
 import styles from './ProgressBar.module.scss'


### PR DESCRIPTION
- extend CreateUserRequestDto & CreateUserResponseDto with optional defaultNickname
- update NestJS request/response DTOs to validate and document defaultNickname (2–20 chars, alphanum/underscore)
- add defaultNickname property to Mongoose User schema and include in createLocalUser repository method
- propagate defaultNickname in UserService.createUser and response mapping
- enhance e2e UserController tests to cover defaultNickname happy path and validation errors
- clean up AuthService imports and GameEvent converter imports
- fix ProgressBar import to use public @quiz/common package
