### PR TITLE
feat(auth): enhance AuthGuard to attach full User and improve error handling

### DIFF
--- a/packages/quiz-service/src/auth/controllers/decorators/auth/index.ts
+++ b/packages/quiz-service/src/auth/controllers/decorators/auth/index.ts
@@ -1,3 +1,4 @@
+export * from './principal.decorator'
 export * from './public.decorator'
 export * from './required-authorities.decorator'
 export * from './required-scopes.decorator'

--- a/packages/quiz-service/src/auth/controllers/decorators/auth/principal.decorator.ts
+++ b/packages/quiz-service/src/auth/controllers/decorators/auth/principal.decorator.ts
@@ -1,0 +1,39 @@
+import {
+  createParamDecorator,
+  ExecutionContext,
+  UnauthorizedException,
+} from '@nestjs/common'
+
+import { User } from '../../../../user/services/models/schemas'
+import { AuthGuardRequest } from '../../../guards'
+
+/**
+ * Parameter decorator that injects the currently authenticated user (principal)
+ * into your controller handler.
+ *
+ * If the request has been successfully authenticated by AuthGuard and the
+ * user record was attached to `request.user`, this decorator returns it.
+ * Otherwise it throws an UnauthorizedException.
+ *
+ * @example
+ * ```typescript
+ * @Controller('widgets')
+ * export class WidgetController {
+ *   @Get()
+ *   async listWidgets(@Principal() user: User) {
+ *     // `user` is the full User document loaded by AuthGuard
+ *     console.log('current user:', user);
+ *     return this.widgetService.findAllForUser(user._id);
+ *   }
+ * }
+ * ```
+ */
+export const Principal = createParamDecorator(
+  (data: unknown, ctx: ExecutionContext): User => {
+    const request = ctx.switchToHttp().getRequest<AuthGuardRequest>()
+    if (!request.user) {
+      throw new UnauthorizedException('Unauthorized')
+    }
+    return request.user
+  },
+)

--- a/packages/quiz-service/src/auth/guards/auth.guard.spec.ts
+++ b/packages/quiz-service/src/auth/guards/auth.guard.spec.ts
@@ -1,0 +1,204 @@
+import {
+  ExecutionContext,
+  ForbiddenException,
+  UnauthorizedException,
+} from '@nestjs/common'
+import { Reflector } from '@nestjs/core'
+import { Test, TestingModule } from '@nestjs/testing'
+import { Authority, TokenDto, TokenScope } from '@quiz/common'
+
+import { ClientService } from '../../client/services'
+import { UserRepository } from '../../user/services'
+import {
+  REQUIRED_AUTHORITIES_KEY,
+  REQUIRED_SCOPES_KEY,
+} from '../controllers/decorators'
+import { AuthService } from '../services'
+
+import { AuthGuard, AuthGuardRequest } from './auth.guard'
+
+describe('AuthGuard', () => {
+  let guard: AuthGuard
+  let reflector: Reflector
+  let authService: Partial<AuthService>
+  let userRepository: Partial<UserRepository>
+  let clientService: Partial<ClientService>
+  const fakeHandler = () => {}
+  const fakeClass = class {}
+
+  function makeContext(req: Partial<AuthGuardRequest>): ExecutionContext {
+    return {
+      getHandler: () => fakeHandler,
+      getClass: () => fakeClass,
+      switchToHttp: () => ({ getRequest: () => req }),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any
+  }
+
+  beforeEach(async () => {
+    reflector = new Reflector()
+    authService = { verifyToken: jest.fn() }
+    userRepository = { findUserByIdOrThrow: jest.fn() }
+    clientService = { findByClientIdHashOrThrow: jest.fn() }
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AuthGuard,
+        { provide: Reflector, useValue: reflector },
+        { provide: AuthService, useValue: authService },
+        { provide: UserRepository, useValue: userRepository },
+        { provide: ClientService, useValue: clientService },
+      ],
+    }).compile()
+
+    guard = module.get(AuthGuard)
+  })
+
+  it('should allow public routes', async () => {
+    jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(true)
+    const ok = await guard.canActivate(makeContext({}))
+    expect(ok).toBe(true)
+    expect(authService.verifyToken).not.toHaveBeenCalled()
+  })
+
+  it('should throw if missing Authorization header', async () => {
+    jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(false)
+    await expect(
+      guard.canActivate(makeContext({ headers: {} })),
+    ).rejects.toThrow(UnauthorizedException)
+  })
+
+  it('should throw if token invalid', async () => {
+    jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(false)
+    ;(authService.verifyToken as jest.Mock).mockRejectedValue(new Error())
+
+    const req = { headers: { authorization: 'Bearer bad' } }
+    await expect(guard.canActivate(makeContext(req))).rejects.toThrow(
+      UnauthorizedException,
+    )
+  })
+
+  it('should throw when scope not allowed', async () => {
+    jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(false)
+    ;(authService.verifyToken as jest.Mock).mockResolvedValue({
+      sub: 'x',
+      scope: TokenScope.Game,
+      authorities: [],
+    } as TokenDto)
+
+    jest
+      .spyOn(reflector, 'getAllAndMerge')
+      .mockImplementation((key) =>
+        key === REQUIRED_SCOPES_KEY ? [TokenScope.User] : [],
+      )
+
+    const req = { headers: { authorization: 'Bearer ok' } }
+    await expect(guard.canActivate(makeContext(req))).rejects.toThrow(
+      ForbiddenException,
+    )
+  })
+
+  it('should throw when authorities missing', async () => {
+    jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(false)
+    ;(authService.verifyToken as jest.Mock).mockResolvedValue({
+      sub: 'x',
+      scope: TokenScope.User,
+      authorities: [],
+    } as TokenDto)
+    jest
+      .spyOn(reflector, 'getAllAndMerge')
+      .mockImplementation((key) =>
+        key === REQUIRED_SCOPES_KEY
+          ? []
+          : key === REQUIRED_AUTHORITIES_KEY
+            ? [Authority.RefreshAuth]
+            : [],
+      )
+    const req = { headers: { authorization: 'Bearer ok' } }
+    await expect(guard.canActivate(makeContext(req))).rejects.toThrow(
+      ForbiddenException,
+    )
+  })
+
+  it('should authenticate a User scope and attach user', async () => {
+    jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(false)
+    const token: TokenDto = {
+      sub: 'user-id',
+      scope: TokenScope.User,
+      authorities: [],
+      exp: Date.now() / 1000 + 60,
+    }
+
+    ;(authService.verifyToken as jest.Mock).mockResolvedValue(token)
+
+    jest.spyOn(reflector, 'getAllAndMerge').mockReturnValue([])
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const fakeUser = { _id: 'user-id', email: 'x' } as any
+    ;(userRepository.findUserByIdOrThrow as jest.Mock).mockResolvedValue(
+      fakeUser,
+    )
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const req: any = { headers: { authorization: 'Bearer ok' } }
+    const ok = await guard.canActivate(makeContext(req))
+    expect(ok).toBe(true)
+    expect(req.scope).toEqual(TokenScope.User)
+    expect(req.authorities).toEqual([])
+    expect(req.user).toBe(fakeUser)
+  })
+
+  it('should throw if user lookup fails in User scope', async () => {
+    jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(false)
+
+    const token: TokenDto = {
+      sub: 'no-such',
+      scope: TokenScope.User,
+      authorities: [],
+      exp: Date.now() / 1000 + 60,
+    }
+
+    ;(authService.verifyToken as jest.Mock).mockResolvedValue(token)
+
+    jest.spyOn(reflector, 'getAllAndMerge').mockReturnValue([])
+    ;(userRepository.findUserByIdOrThrow as jest.Mock).mockRejectedValue(
+      new Error('404'),
+    )
+
+    await expect(
+      guard.canActivate(
+        makeContext({
+          headers: { authorization: 'Bearer ok' },
+        }),
+      ),
+    ).rejects.toThrow(UnauthorizedException)
+  })
+
+  it('should authenticate a Client scope and attach client', async () => {
+    jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(false)
+    const token: TokenDto = {
+      sub: 'client-id',
+      scope: TokenScope.Client,
+      authorities: [],
+      exp: Date.now() / 1000 + 60,
+    }
+
+    ;(authService.verifyToken as jest.Mock).mockResolvedValue(token)
+
+    jest.spyOn(reflector, 'getAllAndMerge').mockReturnValue([])
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const fakeClient = { id: 'client-id', name: 'C' } as any
+
+    ;(clientService.findByClientIdHashOrThrow as jest.Mock).mockResolvedValue(
+      fakeClient,
+    )
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const req: any = { headers: { authorization: 'Bearer ok' } }
+    const ok = await guard.canActivate(makeContext(req))
+    expect(ok).toBe(true)
+    expect(req.scope).toEqual(TokenScope.Client)
+    expect(req.client).toBe(fakeClient)
+  })
+})

--- a/packages/quiz-service/src/user/exceptions/index.ts
+++ b/packages/quiz-service/src/user/exceptions/index.ts
@@ -1,2 +1,3 @@
 export * from './bad-credentials.exception'
 export * from './email-not-unique.exception'
+export * from './user-not-found.exception'

--- a/packages/quiz-service/src/user/exceptions/user-not-found.exception.ts
+++ b/packages/quiz-service/src/user/exceptions/user-not-found.exception.ts
@@ -1,0 +1,12 @@
+import { NotFoundException } from '@nestjs/common'
+
+/**
+ * Thrown when the user was not found by its unique identifier (HTTP 404).
+ *
+ * @extends {NotFoundException}
+ */
+export class UserNotFoundException extends NotFoundException {
+  constructor(id: string) {
+    super(`User '${id}' was not found`)
+  }
+}

--- a/packages/quiz-service/src/user/services/user.repository.ts
+++ b/packages/quiz-service/src/user/services/user.repository.ts
@@ -2,7 +2,7 @@ import { Injectable, Logger } from '@nestjs/common'
 import { InjectModel } from '@nestjs/mongoose'
 import { v4 as uuidv4 } from 'uuid'
 
-import { EmailNotUniqueException } from '../exceptions'
+import { EmailNotUniqueException, UserNotFoundException } from '../exceptions'
 
 import { AuthProvider, User, UserModel } from './models/schemas'
 
@@ -22,6 +22,31 @@ export class UserRepository {
   public constructor(
     @InjectModel(User.name) private readonly userModel: UserModel,
   ) {}
+
+  /**
+   * Retrieves a user document by its unique identifier.
+   *
+   * @param id – The unique identifier to search for.
+   * @returns The matching User document, or `null` if none exists.
+   */
+  public async findUserById(id: string): Promise<User> {
+    return this.userModel.findById(id).exec()
+  }
+
+  /**
+   * Retrieves a user document by its unique identifier, or throws if not found.
+   *
+   * @param id – The unique identifier to search for.
+   * @returns The matching User document.
+   * @throws UserNotFoundException if no user exists with the given `id`.
+   */
+  public async findUserByIdOrThrow(id: string): Promise<User> {
+    const user = await this.findUserById(id)
+    if (!user) {
+      throw new UserNotFoundException(id)
+    }
+    return user
+  }
 
   /**
    * Finds a user document by email.

--- a/packages/quiz-service/src/user/user.module.ts
+++ b/packages/quiz-service/src/user/user.module.ts
@@ -25,6 +25,6 @@ import {
   ],
   controllers: [UserController],
   providers: [UserService, UserRepository],
-  exports: [UserService],
+  exports: [UserService, UserRepository],
 })
 export class UserModule {}


### PR DESCRIPTION
- Inject UserRepository into AuthGuard
- Replace userId field with full `user` loaded via findUserByIdOrThrow
- Wrap user lookup in try/catch to translate “not found” into Unauthorized
- Switch to reflector.getAllAndMerge for combining handler+class metadata
- Add UserNotFoundException (404) and export it alongside other user exceptions
- Implement UserRepository.findUserById and findUserByIdOrThrow with proper JSDoc
- Export UserRepository from UserModule