### PR TITLE
feat(validation): add SkipValidation decorator and update ValidationPipe

### DIFF
--- a/packages/quiz-service/src/app/decorators/index.ts
+++ b/packages/quiz-service/src/app/decorators/index.ts
@@ -1,0 +1,1 @@
+export * from './skip-validation.decorator'

--- a/packages/quiz-service/src/app/decorators/skip-validation.decorator.ts
+++ b/packages/quiz-service/src/app/decorators/skip-validation.decorator.ts
@@ -1,0 +1,8 @@
+import { SetMetadata } from '@nestjs/common'
+
+import { SKIP_VALIDATION_KEY } from '../utils'
+
+/**
+ * Marks a class to be ignored by the ValidationPipe.
+ */
+export const SkipValidation = () => SetMetadata(SKIP_VALIDATION_KEY, true)

--- a/packages/quiz-service/src/app/pipes/validation.pipe.spec.ts
+++ b/packages/quiz-service/src/app/pipes/validation.pipe.spec.ts
@@ -1,6 +1,8 @@
 import { ArgumentMetadata } from '@nestjs/common'
+import { Reflector } from '@nestjs/core'
 import { validate } from 'class-validator'
 
+import { User } from '../../user/services/models/schemas'
 import { ValidationException } from '../exceptions'
 
 import { ValidationPipe } from './validation.pipe'
@@ -12,10 +14,12 @@ class TestDto {
 }
 
 describe('ValidationPipe', () => {
+  let reflector: Reflector
   let pipe: ValidationPipe
 
   beforeEach(() => {
-    pipe = new ValidationPipe()
+    reflector = new Reflector()
+    pipe = new ValidationPipe(reflector)
   })
 
   it('should return the value if no metatype is provided', async () => {
@@ -31,11 +35,26 @@ describe('ValidationPipe', () => {
     expect(result).toBe(value)
   })
 
-  it('should return the value if metatype is a native type', async () => {
+  it('should return the value if metatype is a primitive type', async () => {
     const value = { property: 'value' }
     const metadata: ArgumentMetadata = {
       type: 'body',
       metatype: String,
+      data: '',
+    }
+
+    const result = await pipe.transform(value, metadata)
+
+    expect(result).toBe(value)
+  })
+
+  it('should return the value if validation should be skipped', async () => {
+    jest.spyOn(reflector, 'get').mockReturnValue(true)
+
+    const value = { property: 'value' }
+    const metadata: ArgumentMetadata = {
+      type: 'body',
+      metatype: User,
       data: '',
     }
 

--- a/packages/quiz-service/src/app/pipes/validation.pipe.ts
+++ b/packages/quiz-service/src/app/pipes/validation.pipe.ts
@@ -1,26 +1,72 @@
-/* eslint-disable @typescript-eslint/no-explicit-any,@typescript-eslint/no-unsafe-function-type */
 import {
   ArgumentMetadata,
   BadRequestException,
   Injectable,
   PipeTransform,
 } from '@nestjs/common'
+import { Reflector } from '@nestjs/core'
 import { plainToInstance } from 'class-transformer'
 import { validate } from 'class-validator'
 
-import { Client } from '../../client/services/models/schemas'
 import { ValidationException } from '../exceptions'
+import { SKIP_VALIDATION_KEY } from '../utils'
 
+/**
+ * A global NestJS validation pipe that:
+ * - Converts plain objects into typed class instances.
+ * - Performs `class-validator` validation on them.
+ * - Throws a `BadRequestException` if the incoming payload is missing or not an object.
+ * - Throws a `ValidationException` if any constraint violations are found.
+ * - Automatically skips validation for:
+ *   1. Missing `metatype`.
+ *   2. Primitive types (String, Boolean, Number, Array, Object).
+ *   3. Classes decorated with `@SkipValidation()`.
+ */
 @Injectable()
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export class ValidationPipe implements PipeTransform<any> {
+  /**
+   * Creates a new instance of the ValidationPipe.
+   *
+   * @param reflector - Used to retrieve metadata (e.g. `SKIP_VALIDATION_KEY`)
+   *                    in order to determine if validation should be skipped
+   *                    for a particular class.
+   */
+  constructor(private readonly reflector: Reflector) {}
+
+  /**
+   * Transforms and validates the given value according to the provided metadata.
+   *
+   * Steps:
+   * 1. If no `metatype` is provided, or it’s a primitive, or skip metadata is set,
+   *    the value is returned unchanged.
+   * 2. Otherwise, the value is converted to an instance of `metatype` using
+   *    `plainToInstance()`.
+   * 3. If the resulting object is not a plain object, throws `BadRequestException`.
+   * 4. Runs `class-validator`’s `validate()`. If any errors are found,
+   *    throws a `ValidationException` containing the error details.
+   *
+   * @param value      The original value to transform (e.g., request body).
+   * @param metadata   The argument metadata, containing the `metatype`.
+   * @returns The original value if validation is skipped or passes successfully.
+   * @throws {BadRequestException}   If the payload is missing or not an object.
+   * @throws {ValidationException}   If one or more validation constraints fail.
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   async transform(value: any, { metatype }: ArgumentMetadata) {
-    if (!metatype || !this.toValidate(metatype)) {
+    if (
+      !metatype ||
+      this.isPrimitive(metatype) ||
+      this.shouldSkipValidation(metatype)
+    ) {
       return value
     }
+
     const object = plainToInstance(metatype, value)
     if (!object || typeof object !== 'object') {
       throw new BadRequestException('Missing request payload')
     }
+
     const errors = await validate(object)
     if (errors.length > 0) {
       throw new ValidationException(errors)
@@ -28,8 +74,31 @@ export class ValidationPipe implements PipeTransform<any> {
     return value
   }
 
-  private toValidate(metatype: Function): boolean {
-    const types: Function[] = [String, Boolean, Number, Array, Object, Client]
-    return !types.includes(metatype)
+  /**
+   * Determines whether the given `metatype` is considered a primitive type
+   * that should bypass validation.
+   *
+   * Recognized primitive types are: String, Boolean, Number, Array, and Object.
+   *
+   * @param metatype  The constructor function to check.
+   * @returns `true` if `metatype` is one of the primitive types; `false` otherwise.
+   */
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
+  private isPrimitive(metatype: Function): boolean {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
+    const types: Function[] = [String, Boolean, Number, Array, Object]
+    return types.includes(metatype)
+  }
+
+  /**
+   * Checks whether the `@SkipValidation()` decorator was applied to the given class.
+   *
+   * @param metatype  The constructor function to check.
+   * @returns `true` if the `SKIP_VALIDATION_KEY` metadata is present on `metatype`;
+   *          `false` otherwise.
+   */
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
+  private shouldSkipValidation(metatype: Function): boolean {
+    return this.reflector.get<boolean>(SKIP_VALIDATION_KEY, metatype)
   }
 }

--- a/packages/quiz-service/src/app/utils/index.ts
+++ b/packages/quiz-service/src/app/utils/index.ts
@@ -1,2 +1,3 @@
 export * from './bootstrap'
+export * from './validation.constants'
 export * from './validation.utils'

--- a/packages/quiz-service/src/app/utils/validation.constants.ts
+++ b/packages/quiz-service/src/app/utils/validation.constants.ts
@@ -1,0 +1,1 @@
+export const SKIP_VALIDATION_KEY = 'skip_validation'

--- a/packages/quiz-service/src/client/services/models/schemas/client.schema.ts
+++ b/packages/quiz-service/src/client/services/models/schemas/client.schema.ts
@@ -1,11 +1,13 @@
 import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose'
 import { Model } from 'mongoose'
 
+import { SkipValidation } from '../../../../app/decorators'
 import { Player } from '../../../../player/services/models/schemas'
 
 /**
  * Mongoose schema for the Client collection.
  */
+@SkipValidation()
 @Schema({ _id: true, collection: 'clients' })
 export class Client {
   /**

--- a/packages/quiz-service/src/user/services/models/schemas/user.schema.ts
+++ b/packages/quiz-service/src/user/services/models/schemas/user.schema.ts
@@ -1,8 +1,10 @@
 import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose'
 import { Model, now } from 'mongoose'
 
+import { SkipValidation } from '../../../../app/decorators'
+
 /**
- * Which authentication provider created this account. *
+ * Which authentication provider created this account.
  * Values:
  * - `LOCAL`: email/password stored locally
  */
@@ -13,6 +15,7 @@ export enum AuthProvider {
 /**
  * Mongoose schema for the User collection.
  */
+@SkipValidation()
 @Schema({
   _id: true,
   collection: 'users',


### PR DESCRIPTION
- Introduce `@SkipValidation()` decorator (app/decorators/skip-validation.decorator.ts) to opt out of class-validator checks.
- Wire `SkipValidation` into `ValidationPipe` via `Reflector`, skip when metadata key is present.
- Rename pipe helper to `isPrimitive()`, skip for primitives.
- Add unit test in validation.pipe.spec.ts for the “skip validation” scenario.
- Annotate `Client` and `User` Mongoose schemas with `@SkipValidation()` so they bypass request‐body validation.

