### PR TITLE
feat(auth): centralize default token constants and extend authorities

### DIFF
--- a/packages/common/src/models/authority.enum.ts
+++ b/packages/common/src/models/authority.enum.ts
@@ -4,6 +4,23 @@
  */
 export enum Authority {
   /**
+   * Permission to host and manage quiz games, including creating new games,
+   * joining existing ones, and tracking game progress.
+   */
+  Game = 'GAME',
+
+  /**
+   * Permission to perform media-related operations, including
+   * searching for media, uploading new media assets, and deleting existing media.
+   */
+  Media = 'MEDIA',
+
+  /**
+   * Permission to search, create, edit, and delete quizzes.
+   */
+  Quiz = 'QUIZ',
+
+  /**
    * Permission to allow using a valid refresh token to obtain a new access token.
    */
   RefreshAuth = 'REFRESH_AUTH',

--- a/packages/quiz-service/src/auth/controllers/auth.controller.e2e-spec.ts
+++ b/packages/quiz-service/src/auth/controllers/auth.controller.e2e-spec.ts
@@ -1,6 +1,6 @@
 import { INestApplication } from '@nestjs/common'
 import { JwtService } from '@nestjs/jwt'
-import { Authority, TokenDto, TokenScope } from '@quiz/common'
+import { TokenDto, TokenScope } from '@quiz/common'
 import * as bcrypt from 'bcryptjs'
 import { Response } from 'superagent'
 import supertest from 'supertest'
@@ -14,13 +14,14 @@ import {
   MOCK_DEFAULT_USER_INVALID_PASSWORD,
   MOCK_DEFAULT_USER_PASSWORD,
 } from '../../../test-utils/data'
-import {
-  closeTestApp,
-  createTestApp,
-} from '../../../test-utils/utils/bootstrap'
+import { closeTestApp, createTestApp } from '../../../test-utils/utils'
 import { ClientService } from '../../client/services'
 import { UserRepository } from '../../user/services'
 import { AuthService } from '../services'
+import {
+  DEFAULT_REFRESH_AUTHORITIES,
+  DEFAULT_USER_AUTHORITIES,
+} from '../services/utils'
 
 describe('AuthController (e2e)', () => {
   let app: INestApplication
@@ -161,7 +162,7 @@ describe('AuthController (e2e)', () => {
 
     it('should return 400 bad request when token has expired', async () => {
       const refreshToken = await jwtService.signAsync(
-        { authorities: [Authority.RefreshAuth] },
+        { authorities: DEFAULT_REFRESH_AUTHORITIES },
         { subject: uuidv4(), expiresIn: '-1d' },
       )
 
@@ -326,14 +327,14 @@ describe('AuthController (e2e)', () => {
     )
     expect(accessTokenDto.sub).toEqual(userId)
     expect(accessTokenDto.scope).toEqual(TokenScope.User)
-    expect(accessTokenDto.authorities).toEqual([])
+    expect(accessTokenDto.authorities).toEqual(DEFAULT_USER_AUTHORITIES)
 
     const refreshTokenDto = jwtService.verify<TokenDto>(
       response.body.refreshToken,
     )
     expect(refreshTokenDto.sub).toEqual(userId)
     expect(refreshTokenDto.scope).toEqual(TokenScope.User)
-    expect(refreshTokenDto.authorities).toEqual([Authority.RefreshAuth])
+    expect(refreshTokenDto.authorities).toEqual(DEFAULT_REFRESH_AUTHORITIES)
   }
 
   function expectLegacyAuthResponseDto(

--- a/packages/quiz-service/src/auth/guards/auth.guard.spec.ts
+++ b/packages/quiz-service/src/auth/guards/auth.guard.spec.ts
@@ -5,7 +5,7 @@ import {
 } from '@nestjs/common'
 import { Reflector } from '@nestjs/core'
 import { Test, TestingModule } from '@nestjs/testing'
-import { Authority, TokenDto, TokenScope } from '@quiz/common'
+import { TokenDto, TokenScope } from '@quiz/common'
 
 import { ClientService } from '../../client/services'
 import { UserRepository } from '../../user/services'
@@ -14,6 +14,7 @@ import {
   REQUIRED_SCOPES_KEY,
 } from '../controllers/decorators'
 import { AuthService } from '../services'
+import { DEFAULT_USER_AUTHORITIES } from '../services/utils'
 
 import { AuthGuard, AuthGuardRequest } from './auth.guard'
 
@@ -111,7 +112,7 @@ describe('AuthGuard', () => {
         key === REQUIRED_SCOPES_KEY
           ? []
           : key === REQUIRED_AUTHORITIES_KEY
-            ? [Authority.RefreshAuth]
+            ? DEFAULT_USER_AUTHORITIES
             : [],
       )
     const req = { headers: { authorization: 'Bearer ok' } }

--- a/packages/quiz-service/src/auth/services/utils/index.ts
+++ b/packages/quiz-service/src/auth/services/utils/index.ts
@@ -1,1 +1,2 @@
+export * from './token.constants'
 export * from './token.utils'

--- a/packages/quiz-service/src/auth/services/utils/token.constants.ts
+++ b/packages/quiz-service/src/auth/services/utils/token.constants.ts
@@ -1,0 +1,13 @@
+import { Authority } from '@quiz/common'
+
+export const DEFAULT_REFRESH_TOKEN_EXPIRATION_TIME = '15m'
+export const DEFAULT_ACCESS_TOKEN_EXPIRATION_TIME = '15m'
+
+export const DEFAULT_CLIENT_AUTHORITIES: Authority[] = []
+export const DEFAULT_GAME_AUTHORITIES: Authority[] = []
+export const DEFAULT_USER_AUTHORITIES: Authority[] = [
+  Authority.Game,
+  Authority.Media,
+  Authority.Quiz,
+]
+export const DEFAULT_REFRESH_AUTHORITIES: Authority[] = [Authority.RefreshAuth]

--- a/packages/quiz-service/src/auth/services/utils/token.utils.ts
+++ b/packages/quiz-service/src/auth/services/utils/token.utils.ts
@@ -1,5 +1,14 @@
 import { Authority, TokenScope } from '@quiz/common'
 
+import {
+  DEFAULT_ACCESS_TOKEN_EXPIRATION_TIME,
+  DEFAULT_CLIENT_AUTHORITIES,
+  DEFAULT_GAME_AUTHORITIES,
+  DEFAULT_REFRESH_AUTHORITIES,
+  DEFAULT_REFRESH_TOKEN_EXPIRATION_TIME,
+  DEFAULT_USER_AUTHORITIES,
+} from './token.constants'
+
 /**
  * Returns the list of Authority that should be embedded in a token
  * for the given scope and token type.
@@ -13,16 +22,16 @@ export function getTokenAuthorities(
   isRefreshToken: boolean,
 ): Authority[] {
   if (isRefreshToken) {
-    return [Authority.RefreshAuth]
+    return DEFAULT_REFRESH_AUTHORITIES
   }
 
   switch (scope) {
     case TokenScope.Client:
-      return []
+      return DEFAULT_CLIENT_AUTHORITIES
     case TokenScope.Game:
-      return []
+      return DEFAULT_GAME_AUTHORITIES
     case TokenScope.User:
-      return []
+      return DEFAULT_USER_AUTHORITIES
   }
 }
 
@@ -39,7 +48,7 @@ export function getTokenExpiresIn(
   isRefreshToken: boolean,
 ): string {
   if (isRefreshToken) {
-    return '30d'
+    return DEFAULT_REFRESH_TOKEN_EXPIRATION_TIME
   }
 
   switch (scope) {
@@ -47,6 +56,6 @@ export function getTokenExpiresIn(
       return '1h'
     case TokenScope.Game:
     case TokenScope.User:
-      return '15m'
+      return DEFAULT_ACCESS_TOKEN_EXPIRATION_TIME
   }
 }

--- a/packages/quiz-service/test-utils/utils/auth.utils.ts
+++ b/packages/quiz-service/test-utils/utils/auth.utils.ts
@@ -1,0 +1,41 @@
+import { INestApplication } from '@nestjs/common'
+import { JwtService } from '@nestjs/jwt'
+import { TokenScope } from '@quiz/common'
+
+import {
+  DEFAULT_ACCESS_TOKEN_EXPIRATION_TIME,
+  DEFAULT_USER_AUTHORITIES,
+} from '../../src/auth/services/utils'
+import { UserRepository } from '../../src/user/services'
+import {
+  MOCK_DEFAULT_USER_EMAIL,
+  MOCK_DEFAULT_USER_FAMILY_NAME,
+  MOCK_DEFAULT_USER_GIVEN_NAME,
+  MOCK_DEFAULT_USER_HASHED_PASSWORD,
+} from '../data'
+
+export async function createDefaultUserAndAuthenticate(
+  app: INestApplication,
+): Promise<{ accessToken: string; userId: string }> {
+  const userRepository = app.get<UserRepository>(UserRepository)
+  const user = await userRepository.createLocalUser({
+    email: MOCK_DEFAULT_USER_EMAIL,
+    hashedPassword: MOCK_DEFAULT_USER_HASHED_PASSWORD,
+    givenName: MOCK_DEFAULT_USER_GIVEN_NAME,
+    familyName: MOCK_DEFAULT_USER_FAMILY_NAME,
+  })
+
+  const jwtService = app.get<JwtService>(JwtService)
+  const accessToken = await jwtService.signAsync(
+    {
+      scope: TokenScope.User,
+      authorities: DEFAULT_USER_AUTHORITIES,
+    },
+    {
+      subject: user._id,
+      expiresIn: DEFAULT_ACCESS_TOKEN_EXPIRATION_TIME,
+    },
+  )
+
+  return { accessToken, userId: user._id }
+}

--- a/packages/quiz-service/test-utils/utils/index.ts
+++ b/packages/quiz-service/test-utils/utils/index.ts
@@ -1,0 +1,2 @@
+export * from './auth.utils'
+export * from './bootstrap'


### PR DESCRIPTION
- Add Game, Media, and Quiz entries (with docs) to the Authority enum
- Extract DEFAULT_* constants (authorities & token expirations) into token.constants.ts
- Refactor getTokenAuthorities() and getTokenExpiresIn() to use these constants
- Update e2e tests in AuthController and AuthGuard to reference DEFAULT_USER_AUTHORITIES and DEFAULT_REFRESH_AUTHORITIES
- Introduce createDefaultUserAndAuthenticate() helper in test-utils for signing default user tokens
- Wire up new test-utils exports in utils/index.ts