### PR TITLE
refactor(media): switch media operations from client to user context

### DIFF
--- a/packages/quiz-service/src/media/controllers/media.controller.ts
+++ b/packages/quiz-service/src/media/controllers/media.controller.ts
@@ -24,9 +24,14 @@ import {
   ApiUnprocessableEntityResponse,
 } from '@nestjs/swagger'
 import { Throttle } from '@nestjs/throttler'
+import { Authority, TokenScope } from '@quiz/common'
 
-import { AuthorizedClientParam } from '../../client/controllers/decorators/auth'
-import { Client } from '../../client/services/models/schemas'
+import {
+  Principal,
+  RequiredAuthorities,
+  RequiresScopes,
+} from '../../auth/controllers/decorators'
+import { User } from '../../user/services/models/schemas'
 import { ParseImageFilePipe } from '../pipes'
 import { MediaService } from '../services'
 
@@ -43,6 +48,8 @@ import {
  */
 @ApiBearerAuth()
 @ApiTags('media')
+@RequiresScopes(TokenScope.User)
+@RequiredAuthorities(Authority.Media)
 @Controller('media')
 export class MediaController {
   /**
@@ -136,16 +143,16 @@ export class MediaController {
   }
 
   /**
-   * Deletes an uploaded photo for the authenticated client.
+   * Deletes an uploaded photo for the authenticated user.
    *
    * @param photoId - The unique ID of the uploaded photo to delete.
-   * @param client - The authenticated client requesting the deletion.
+   * @param user - The authenticated user requesting the deletion.
    */
   @Delete('/uploads/photos/:photoId')
   @ApiUploadedPhotoIdParam()
   @ApiOperation({
     summary: 'Delete an uploaded photo',
-    description: 'Deletes an uploaded photo owned by the authenticated client.',
+    description: 'Deletes an uploaded photo owned by the authenticated user.',
   })
   @ApiNoContentResponse({
     description: 'Successfully deleted the uploaded photo.',
@@ -159,8 +166,8 @@ export class MediaController {
   @HttpCode(HttpStatus.NO_CONTENT)
   public async deleteUploadedPhoto(
     @RouteUploadedPhotoIdParam() photoId: string,
-    @AuthorizedClientParam() client: Client,
+    @Principal() user: User,
   ): Promise<void> {
-    return this.mediaService.deleteUploadPhoto(photoId, client)
+    return this.mediaService.deleteUploadPhoto(photoId, user._id)
   }
 }

--- a/packages/quiz-service/src/media/services/media.service.ts
+++ b/packages/quiz-service/src/media/services/media.service.ts
@@ -8,7 +8,6 @@ import { PaginatedMediaPhotoSearchDto } from '@quiz/common'
 
 import { Cacheable } from '../../app/cache'
 import { EnvironmentVariables } from '../../app/config'
-import { Client } from '../../client/services/models/schemas'
 import { UploadedPhotoNotFoundException } from '../exceptions'
 
 import { PexelsMediaSearchService } from './pexels-media-search.service'
@@ -57,19 +56,19 @@ export class MediaService {
   }
 
   /**
-   * Deletes the uploaded photo file belonging to the given client.
+   * Deletes the uploaded photo file belonging to the given user.
    *
    * @param photoId - The ID of the photo to delete (without file extension).
-   * @param client - The client who owns the photo.
+   * @param userId - The ID of the user who owns the photo.
    *
    * @throws UploadedPhotoNotFoundException if the file does not exist.
    */
   public async deleteUploadPhoto(
     photoId: string,
-    client: Client,
+    userId: string,
   ): Promise<void> {
     const uploadDirectory = this.configService.get<string>('UPLOAD_DIRECTORY')
-    const filePath = join(uploadDirectory, `${client._id}/${photoId}.webp`)
+    const filePath = join(uploadDirectory, `${userId}/${photoId}.webp`)
 
     if (!(await MediaService.fileExists(filePath))) {
       throw new UploadedPhotoNotFoundException(photoId)


### PR DESCRIPTION
- Apply @RequiresScopes(TokenScope.User) and @RequiredAuthorities(Authority.Media) on MediaController
- Replace @AuthorizedClientParam() with @Principal() to inject authenticated User
- Update deleteUploadedPhoto signature to take userId and delete under user’s directory
- Change MediaService.deleteUploadPhoto to use userId for file path
- Modify ParseImageFilePipe to read request.user, remove client-based logic, and store uploads by userId
- Revise media controller e2e tests to use createDefaultUserAndAuthenticate helper and accessToken instead of legacy client tokens