### PR TITLE
test: refactor e2e auth & user controller tests

### DIFF
--- a/packages/quiz-service/src/media/controllers/media.controller.e2e-spec.ts
+++ b/packages/quiz-service/src/media/controllers/media.controller.e2e-spec.ts
@@ -126,8 +126,10 @@ describe('MediaController (e2e)', () => {
 
   describe('/api/media/uploads/photos/:photoId (DELETE)', () => {
     it('should succeed in deleting an uploaded photo', async () => {
-      const { accessToken, userId } =
-        await createDefaultUserAndAuthenticate(app)
+      const {
+        accessToken,
+        user: { _id: userId },
+      } = await createDefaultUserAndAuthenticate(app)
 
       const photoId = uuidv4()
 

--- a/packages/quiz-service/src/user/controllers/user.controller.e2e-spec.ts
+++ b/packages/quiz-service/src/user/controllers/user.controller.e2e-spec.ts
@@ -2,17 +2,14 @@ import { INestApplication } from '@nestjs/common'
 import supertest from 'supertest'
 
 import {
-  MOCK_DEFAULT_PLAYER_NICKNAME,
-  MOCK_DEFAULT_USER_EMAIL,
-  MOCK_DEFAULT_USER_FAMILY_NAME,
-  MOCK_DEFAULT_USER_GIVEN_NAME,
-  MOCK_DEFAULT_USER_HASHED_PASSWORD,
-  MOCK_DEFAULT_USER_PASSWORD,
+  MOCK_DEFAULT_HASHED_PASSWORD,
+  MOCK_DEFAULT_PASSWORD,
+  MOCK_PRIMARY_USER_DEFAULT_NICKNAME,
+  MOCK_PRIMARY_USER_EMAIL,
+  MOCK_PRIMARY_USER_FAMILY_NAME,
+  MOCK_PRIMARY_USER_GIVEN_NAME,
 } from '../../../test-utils/data'
-import {
-  closeTestApp,
-  createTestApp,
-} from '../../../test-utils/utils/bootstrap'
+import { closeTestApp, createTestApp } from '../../../test-utils/utils'
 import { UserRepository } from '../services'
 
 describe('UserController (e2e)', () => {
@@ -33,20 +30,20 @@ describe('UserController (e2e)', () => {
       return supertest(app.getHttpServer())
         .post(`/api/users`)
         .send({
-          email: MOCK_DEFAULT_USER_EMAIL,
-          password: MOCK_DEFAULT_USER_PASSWORD,
-          givenName: MOCK_DEFAULT_USER_GIVEN_NAME,
-          familyName: MOCK_DEFAULT_USER_FAMILY_NAME,
-          defaultNickname: MOCK_DEFAULT_PLAYER_NICKNAME,
+          email: MOCK_PRIMARY_USER_EMAIL,
+          password: MOCK_DEFAULT_PASSWORD,
+          givenName: MOCK_PRIMARY_USER_GIVEN_NAME,
+          familyName: MOCK_PRIMARY_USER_FAMILY_NAME,
+          defaultNickname: MOCK_PRIMARY_USER_DEFAULT_NICKNAME,
         })
         .expect(201)
         .expect((res) => {
           expect(res.body).toEqual({
             id: expect.any(String),
-            email: MOCK_DEFAULT_USER_EMAIL,
-            givenName: MOCK_DEFAULT_USER_GIVEN_NAME,
-            familyName: MOCK_DEFAULT_USER_FAMILY_NAME,
-            defaultNickname: MOCK_DEFAULT_PLAYER_NICKNAME,
+            email: MOCK_PRIMARY_USER_EMAIL,
+            givenName: MOCK_PRIMARY_USER_GIVEN_NAME,
+            familyName: MOCK_PRIMARY_USER_FAMILY_NAME,
+            defaultNickname: MOCK_PRIMARY_USER_DEFAULT_NICKNAME,
             created: expect.any(String),
             updated: expect.any(String),
           })
@@ -119,26 +116,26 @@ describe('UserController (e2e)', () => {
 
     it('should return 409 conflict error when user already exists', async () => {
       await userRepository.createLocalUser({
-        email: MOCK_DEFAULT_USER_EMAIL,
-        hashedPassword: MOCK_DEFAULT_USER_HASHED_PASSWORD,
-        givenName: MOCK_DEFAULT_USER_GIVEN_NAME,
-        familyName: MOCK_DEFAULT_USER_FAMILY_NAME,
-        defaultNickname: MOCK_DEFAULT_PLAYER_NICKNAME,
+        email: MOCK_PRIMARY_USER_EMAIL,
+        hashedPassword: MOCK_DEFAULT_HASHED_PASSWORD,
+        givenName: MOCK_PRIMARY_USER_GIVEN_NAME,
+        familyName: MOCK_PRIMARY_USER_FAMILY_NAME,
+        defaultNickname: MOCK_PRIMARY_USER_DEFAULT_NICKNAME,
       })
 
       return supertest(app.getHttpServer())
         .post(`/api/users`)
         .send({
-          email: MOCK_DEFAULT_USER_EMAIL,
-          password: MOCK_DEFAULT_USER_PASSWORD,
-          givenName: MOCK_DEFAULT_USER_GIVEN_NAME,
-          familyName: MOCK_DEFAULT_USER_FAMILY_NAME,
-          defaultNickname: MOCK_DEFAULT_PLAYER_NICKNAME,
+          email: MOCK_PRIMARY_USER_EMAIL,
+          password: MOCK_DEFAULT_PASSWORD,
+          givenName: MOCK_PRIMARY_USER_GIVEN_NAME,
+          familyName: MOCK_PRIMARY_USER_FAMILY_NAME,
+          defaultNickname: MOCK_PRIMARY_USER_DEFAULT_NICKNAME,
         })
         .expect(409)
         .expect((res) => {
           expect(res.body).toEqual({
-            message: `Email '${MOCK_DEFAULT_USER_EMAIL}' is not unique`,
+            message: `Email '${MOCK_PRIMARY_USER_EMAIL}' is not unique`,
             status: 409,
             timestamp: expect.any(String),
           })

--- a/packages/quiz-service/test-utils/data/data.utils.ts
+++ b/packages/quiz-service/test-utils/data/data.utils.ts
@@ -361,11 +361,3 @@ export function createMockQuitTaskDocument(
     ...(task ?? {}),
   }
 }
-
-export const MOCK_DEFAULT_USER_EMAIL = 'user@example.com'
-export const MOCK_DEFAULT_USER_PASSWORD = 'Super#SecretPa$$w0rd123'
-export const MOCK_DEFAULT_USER_INVALID_PASSWORD = 'Super#$ecretPassw0rd123'
-export const MOCK_DEFAULT_USER_HASHED_PASSWORD =
-  '$2b$10$.xzhAfwhLmb2Nbe5i2jRB.j4IUuWqnDvgUuQ/AZ/unHhOPJcJyVJ6'
-export const MOCK_DEFAULT_USER_GIVEN_NAME = 'John'
-export const MOCK_DEFAULT_USER_FAMILY_NAME = 'Appleseed'

--- a/packages/quiz-service/test-utils/data/index.ts
+++ b/packages/quiz-service/test-utils/data/index.ts
@@ -1,2 +1,3 @@
 export * from './data.utils'
 export * from './helpers.utils'
+export * from './user.data'

--- a/packages/quiz-service/test-utils/data/user.data.ts
+++ b/packages/quiz-service/test-utils/data/user.data.ts
@@ -1,0 +1,58 @@
+import { v4 as uuidv4 } from 'uuid'
+
+import {
+  AuthProvider,
+  LocalUser,
+  User,
+} from '../../src/user/services/models/schemas'
+
+export const MOCK_PRIMARY_USER_EMAIL = 'user@example.com'
+export const MOCK_PRIMARY_USER_GIVEN_NAME = 'John'
+export const MOCK_PRIMARY_USER_FAMILY_NAME = 'Appleseed'
+export const MOCK_PRIMARY_USER_DEFAULT_NICKNAME = 'FrostyBear'
+
+export const MOCK_SECONDARY_USER_EMAIL = 'user@example.com'
+export const MOCK_SECONDARY_USER_GIVEN_NAME = 'John'
+export const MOCK_SECONDARY_USER_FAMILY_NAME = 'Appleseed'
+export const MOCK_SECONDARY_USER_DEFAULT_NICKNAME = 'WhiskerFox'
+
+export const MOCK_DEFAULT_PASSWORD = 'Super#SecretPa$$w0rd123'
+export const MOCK_DEFAULT_INVALID_PASSWORD = 'Super#$ecretPassw0rd123'
+export const MOCK_DEFAULT_HASHED_PASSWORD =
+  '$2b$10$.xzhAfwhLmb2Nbe5i2jRB.j4IUuWqnDvgUuQ/AZ/unHhOPJcJyVJ6'
+
+export function buildMockPrimaryUser(
+  user?: Partial<User & LocalUser>,
+): User & LocalUser {
+  const now = new Date()
+  return {
+    _id: uuidv4(),
+    provider: AuthProvider.Local,
+    email: MOCK_PRIMARY_USER_EMAIL,
+    hashedPassword: MOCK_DEFAULT_HASHED_PASSWORD,
+    givenName: MOCK_PRIMARY_USER_GIVEN_NAME,
+    familyName: MOCK_PRIMARY_USER_FAMILY_NAME,
+    defaultNickname: MOCK_PRIMARY_USER_DEFAULT_NICKNAME,
+    createdAt: now,
+    updatedAt: now,
+    ...(user ?? {}),
+  }
+}
+
+export function buildMockSecondaryUser(
+  user?: Partial<User & LocalUser>,
+): User & LocalUser {
+  const now = new Date()
+  return {
+    _id: uuidv4(),
+    provider: AuthProvider.Local,
+    email: MOCK_SECONDARY_USER_EMAIL,
+    hashedPassword: MOCK_DEFAULT_HASHED_PASSWORD,
+    givenName: MOCK_SECONDARY_USER_GIVEN_NAME,
+    familyName: MOCK_SECONDARY_USER_FAMILY_NAME,
+    defaultNickname: MOCK_SECONDARY_USER_DEFAULT_NICKNAME,
+    createdAt: now,
+    updatedAt: now,
+    ...(user ?? {}),
+  }
+}

--- a/packages/quiz-service/test-utils/utils/auth.utils.ts
+++ b/packages/quiz-service/test-utils/utils/auth.utils.ts
@@ -1,29 +1,20 @@
 import { INestApplication } from '@nestjs/common'
 import { JwtService } from '@nestjs/jwt'
+import { getModelToken } from '@nestjs/mongoose'
 import { TokenScope } from '@quiz/common'
 
 import {
   DEFAULT_ACCESS_TOKEN_EXPIRATION_TIME,
   DEFAULT_USER_AUTHORITIES,
 } from '../../src/auth/services/utils'
-import { UserRepository } from '../../src/user/services'
-import {
-  MOCK_DEFAULT_USER_EMAIL,
-  MOCK_DEFAULT_USER_FAMILY_NAME,
-  MOCK_DEFAULT_USER_GIVEN_NAME,
-  MOCK_DEFAULT_USER_HASHED_PASSWORD,
-} from '../data'
+import { User, UserModel } from '../../src/user/services/models/schemas'
+import { buildMockPrimaryUser } from '../data'
 
 export async function createDefaultUserAndAuthenticate(
   app: INestApplication,
-): Promise<{ accessToken: string; userId: string }> {
-  const userRepository = app.get<UserRepository>(UserRepository)
-  const user = await userRepository.createLocalUser({
-    email: MOCK_DEFAULT_USER_EMAIL,
-    hashedPassword: MOCK_DEFAULT_USER_HASHED_PASSWORD,
-    givenName: MOCK_DEFAULT_USER_GIVEN_NAME,
-    familyName: MOCK_DEFAULT_USER_FAMILY_NAME,
-  })
+): Promise<{ accessToken: string; user: User }> {
+  const userModel = app.get<UserModel>(getModelToken(User.name))
+  const user = await userModel.create(buildMockPrimaryUser())
 
   const jwtService = app.get<JwtService>(JwtService)
   const accessToken = await jwtService.signAsync(
@@ -37,5 +28,5 @@ export async function createDefaultUserAndAuthenticate(
     },
   )
 
-  return { accessToken, userId: user._id }
+  return { accessToken, user }
 }


### PR DESCRIPTION
- Inject UserModel via getModelToken in AuthController e2e-spec
- Replace direct UserRepository usage with userModel.create(buildMockPrimaryUser())
- Update MEDIA controller e2e to destructure `user` from authentication helper
- Remove deprecated ClientQuizController and its tests
- Switch UserController e2e to shared test-utils (user.data.ts) for primary user constants and builder
- Consolidate test-utils: split data.utils, helpers.utils, and introduce user.data.ts & auth.utils.ts
- Simplify createDefaultUserAndAuthenticate to return full User instead of just userId