### PR TITLE
feat(auth): migrate quiz endpoints and tests to user‐based auth

### DIFF
--- a/packages/quiz-service/src/main.ts
+++ b/packages/quiz-service/src/main.ts
@@ -22,6 +22,7 @@ async function bootstrap() {
     .addTag('health', 'Operations determining service health.')
     .addTag('media', 'Operations for uploading and retrieving media assets.')
     .addTag('player', 'Operations for managing players.')
+    .addTag('profile', 'Operations for managing current user profiles.')
     .addTag('quiz', 'Operations for creating and managing quiz content.')
     .addTag('user', 'Operations for creating and managing users.')
     .addBearerAuth({ type: 'http', name: 'Authorization', in: 'header' })

--- a/packages/quiz-service/src/quiz/controllers/index.ts
+++ b/packages/quiz-service/src/quiz/controllers/index.ts
@@ -1,2 +1,2 @@
-export * from './client-quiz.controller'
+export * from './profile-quiz.controller'
 export * from './quiz.controller'

--- a/packages/quiz-service/src/quiz/controllers/profile-quiz.controller.ts
+++ b/packages/quiz-service/src/quiz/controllers/profile-quiz.controller.ts
@@ -6,56 +6,63 @@ import {
   ApiTags,
   ApiUnauthorizedResponse,
 } from '@nestjs/swagger'
+import { Authority, TokenScope } from '@quiz/common'
 
-import { AuthorizedClientParam } from '../../client/controllers/decorators/auth'
-import { Client } from '../../client/services/models/schemas'
+import {
+  Principal,
+  RequiredAuthorities,
+  RequiresScopes,
+} from '../../auth/controllers/decorators'
+import { User } from '../../user/services/models/schemas'
 import { QuizService } from '../services'
 
 import { PaginatedQuizResponse, QuizPageQueryFilter } from './models'
 
 /**
- * Controller for managing client-related operations.
+ * Controller for managing profile quiz-related operations.
  */
 @ApiBearerAuth()
-@ApiTags('client', 'quiz')
-@Controller('client')
-export class ClientQuizController {
+@ApiTags('profile', 'quiz')
+@RequiresScopes(TokenScope.User)
+@RequiredAuthorities(Authority.Quiz)
+@Controller('profile')
+export class ProfileQuizController {
   /**
-   * Initializes the ClientQuizController.
+   * Initializes the ProfileQuizController.
    *
-   * @param {QuizService} quizService - Service responsible for managing quiz-related operations.
+   * @param quizService - Service responsible for managing quiz-related operations.
    */
   constructor(private readonly quizService: QuizService) {}
 
   /**
-   * Retrieves the quizzes associated with the authenticated client.
+   * Retrieves the quizzes associated with the authenticated user.
    *
-   * @param {Client} client - The authenticated client making the request.
+   * @param user - The authenticated user making the request.
    *
-   * @param {QuizPageQueryFilter} queryParams - The pagination and filtering query parameters for retrieving quizzes.
+   * @param queryParams - The pagination and filtering query parameters for retrieving quizzes.
    *
-   * @returns {Promise<PaginatedQuizResponse>} A paginated response containing the client's associated quizzes.
+   * @returns A paginated response containing the user's associated quizzes.
    */
   @Get('/quizzes')
   @ApiOperation({
     summary: 'Retrieve associated quizzes',
     description:
-      'Fetches a paginated list of quizzes associated with the authenticated client.',
+      'Fetches a paginated list of quizzes associated with the authenticated user.',
   })
   @ApiOkResponse({
-    description: "Successfully retrieved the associated client's quizzes.",
+    description: "Successfully retrieved the associated user's quizzes.",
     type: PaginatedQuizResponse,
   })
   @ApiUnauthorizedResponse({
     description: 'Unauthorized access to the endpoint.',
   })
-  public async getClientAssociatedQuizzes(
-    @AuthorizedClientParam() client: Client,
+  public async getUserAssociatedQuizzes(
+    @Principal() user: User,
     @Query(new ValidationPipe({ transform: true }))
     queryParams: QuizPageQueryFilter,
   ): Promise<PaginatedQuizResponse> {
     return this.quizService.findQuizzesByOwnerId(
-      client.player._id,
+      user._id,
       queryParams.search,
       queryParams.mode,
       queryParams.visibility,

--- a/packages/quiz-service/src/quiz/controllers/quiz.controller.e2e-spec.ts
+++ b/packages/quiz-service/src/quiz/controllers/quiz.controller.e2e-spec.ts
@@ -1,4 +1,5 @@
 import { INestApplication } from '@nestjs/common'
+import { getModelToken } from '@nestjs/mongoose'
 import {
   GameMode,
   LanguageCode,
@@ -18,12 +19,10 @@ import {
 import supertest from 'supertest'
 import { v4 as uuidv4 } from 'uuid'
 
-import {
-  closeTestApp,
-  createTestApp,
-} from '../../../test-utils/utils/bootstrap'
-import { AuthService } from '../../auth/services'
-import { ClientService } from '../../client/services'
+import { buildMockSecondaryUser } from '../../../test-utils/data'
+import { createDefaultUserAndAuthenticate } from '../../../test-utils/utils'
+import { closeTestApp, createTestApp } from '../../../test-utils/utils'
+import { User, UserModel } from '../../user/services/models/schemas'
 import { QuizService } from '../services'
 
 const multiChoiceQuestion: QuestionMultiChoiceDto = {
@@ -134,15 +133,13 @@ const updatedData: QuizRequestDto = {
 
 describe('QuizController (e2e)', () => {
   let app: INestApplication
-  let authService: AuthService
   let quizService: QuizService
-  let clientService: ClientService
+  let userModel: UserModel
 
   beforeEach(async () => {
     app = await createTestApp()
-    authService = app.get(AuthService)
     quizService = app.get(QuizService)
-    clientService = app.get(ClientService)
+    userModel = app.get<UserModel>(getModelToken(User.name))
   })
 
   afterEach(async () => {
@@ -151,13 +148,11 @@ describe('QuizController (e2e)', () => {
 
   describe('/api/quizzes (POST)', () => {
     it('should succeed in creating a new quiz', async () => {
-      const clientId = uuidv4()
-
-      const { token } = await authService.legacyAuthenticate({ clientId })
+      const { accessToken } = await createDefaultUserAndAuthenticate(app)
 
       return supertest(app.getHttpServer())
         .post('/api/quizzes')
-        .set({ Authorization: `Bearer ${token}` })
+        .set({ Authorization: `Bearer ${accessToken}` })
         .send(originalData)
         .expect(201)
         .expect((res) => {
@@ -185,24 +180,18 @@ describe('QuizController (e2e)', () => {
 
   describe('/api/quizzes (GET)', () => {
     it('should return a paginated list of public quizzes', async () => {
-      const clientId = uuidv4()
-
-      const client = await clientService.findOrCreateClient(clientId)
-
-      const { token } = await authService.legacyAuthenticate({ clientId })
+      const { accessToken, user } = await createDefaultUserAndAuthenticate(app)
 
       const publicQuizzes: QuizResponseDto[] = []
       for (let i = 0; i < 10; i++) {
-        publicQuizzes.push(
-          await quizService.createQuiz(originalData, client.player),
-        )
+        publicQuizzes.push(await quizService.createQuiz(originalData, user))
       }
 
       await Promise.all(
         [...Array(5).keys()].map(() =>
           quizService.createQuiz(
             { ...originalData, visibility: QuizVisibility.Private },
-            client.player,
+            user,
           ),
         ),
       )
@@ -213,7 +202,7 @@ describe('QuizController (e2e)', () => {
 
       return supertest(app.getHttpServer())
         .get('/api/quizzes')
-        .set({ Authorization: `Bearer ${token}` })
+        .set({ Authorization: `Bearer ${accessToken}` })
         .expect(200)
         .expect((res) => {
           expect(res.body).toEqual({
@@ -226,21 +215,17 @@ describe('QuizController (e2e)', () => {
     })
 
     it('should return quizzes filtered by search term', async () => {
-      const clientId = uuidv4()
-
-      const client = await clientService.findOrCreateClient(clientId)
-
-      const { token } = await authService.legacyAuthenticate({ clientId })
+      const { accessToken, user } = await createDefaultUserAndAuthenticate(app)
 
       await Promise.all([
         ...[...Array(10).keys()].map(() =>
-          quizService.createQuiz({ ...originalData }, client.player),
+          quizService.createQuiz({ ...originalData }, user),
         ),
       ])
 
       const uniqueQuiz = await quizService.createQuiz(
         { ...originalData, title: 'Unique Quiz Title' },
-        client.player,
+        user,
       )
 
       const uniqueQuizTitleResultsSortedByCreatedDate = [uniqueQuiz].map(
@@ -249,7 +234,7 @@ describe('QuizController (e2e)', () => {
 
       return supertest(app.getHttpServer())
         .get('/api/quizzes?search=Unique%20Quiz%20Title')
-        .set({ Authorization: `Bearer ${token}` })
+        .set({ Authorization: `Bearer ${accessToken}` })
         .expect(200)
         .expect((res) => {
           expect(res.body).toEqual({
@@ -262,15 +247,11 @@ describe('QuizController (e2e)', () => {
     })
 
     it('should return quizzes filtered by mode', async () => {
-      const clientId = uuidv4()
-
-      const client = await clientService.findOrCreateClient(clientId)
-
-      const { token } = await authService.legacyAuthenticate({ clientId })
+      const { accessToken, user } = await createDefaultUserAndAuthenticate(app)
 
       await Promise.all(
         [...Array(10).keys()].map(() =>
-          quizService.createQuiz({ ...originalData }, client.player),
+          quizService.createQuiz({ ...originalData }, user),
         ),
       )
 
@@ -279,7 +260,7 @@ describe('QuizController (e2e)', () => {
         zeroToOneHundredQuizzes.push(
           await quizService.createQuiz(
             { ...updatedData, visibility: QuizVisibility.Public },
-            client.player,
+            user,
           ),
         )
       }
@@ -292,7 +273,7 @@ describe('QuizController (e2e)', () => {
 
       return supertest(app.getHttpServer())
         .get('/api/quizzes?mode=ZERO_TO_ONE_HUNDRED')
-        .set({ Authorization: `Bearer ${token}` })
+        .set({ Authorization: `Bearer ${accessToken}` })
         .expect(200)
         .expect((res) => {
           expect(res.body).toEqual({
@@ -305,17 +286,11 @@ describe('QuizController (e2e)', () => {
     })
 
     it('should return quizzes sort by updated in ascending order', async () => {
-      const clientId = uuidv4()
-
-      const client = await clientService.findOrCreateClient(clientId)
-
-      const { token } = await authService.legacyAuthenticate({ clientId })
+      const { accessToken, user } = await createDefaultUserAndAuthenticate(app)
 
       const publicQuizzes: QuizResponseDto[] = []
       for (let i = 0; i < 10; i++) {
-        publicQuizzes.push(
-          await quizService.createQuiz(originalData, client.player),
-        )
+        publicQuizzes.push(await quizService.createQuiz(originalData, user))
       }
 
       const allResultsSortedByUpdatedAscendingDate = publicQuizzes
@@ -324,7 +299,7 @@ describe('QuizController (e2e)', () => {
 
       return supertest(app.getHttpServer())
         .get('/api/quizzes?sort=updated&order=asc')
-        .set({ Authorization: `Bearer ${token}` })
+        .set({ Authorization: `Bearer ${accessToken}` })
         .expect(200)
         .expect((res) => {
           expect(res.body).toEqual({
@@ -337,17 +312,11 @@ describe('QuizController (e2e)', () => {
     })
 
     it('should return the correct number of quizzes based on the limit', async () => {
-      const clientId = uuidv4()
-
-      const client = await clientService.findOrCreateClient(clientId)
-
-      const { token } = await authService.legacyAuthenticate({ clientId })
+      const { accessToken, user } = await createDefaultUserAndAuthenticate(app)
 
       const publicQuizzes: QuizResponseDto[] = []
       for (let i = 0; i < 10; i++) {
-        publicQuizzes.push(
-          await quizService.createQuiz(originalData, client.player),
-        )
+        publicQuizzes.push(await quizService.createQuiz(originalData, user))
       }
 
       const firstFiveResultsSortedByCreatedDate = publicQuizzes
@@ -357,7 +326,7 @@ describe('QuizController (e2e)', () => {
 
       return supertest(app.getHttpServer())
         .get('/api/quizzes?limit=5')
-        .set({ Authorization: `Bearer ${token}` })
+        .set({ Authorization: `Bearer ${accessToken}` })
         .expect(200)
         .expect((res) => {
           expect(res.body).toEqual({
@@ -370,17 +339,11 @@ describe('QuizController (e2e)', () => {
     })
 
     it('should return quizzes with the correct offset', async () => {
-      const clientId = uuidv4()
-
-      const client = await clientService.findOrCreateClient(clientId)
-
-      const { token } = await authService.legacyAuthenticate({ clientId })
+      const { accessToken, user } = await createDefaultUserAndAuthenticate(app)
 
       const publicQuizzes: QuizResponseDto[] = []
       for (let i = 0; i < 10; i++) {
-        publicQuizzes.push(
-          await quizService.createQuiz(originalData, client.player),
-        )
+        publicQuizzes.push(await quizService.createQuiz(originalData, user))
       }
 
       const secondFiveResultsSortedByCreatedDate = publicQuizzes
@@ -390,7 +353,7 @@ describe('QuizController (e2e)', () => {
 
       return supertest(app.getHttpServer())
         .get('/api/quizzes?limit=5&offset=5')
-        .set({ Authorization: `Bearer ${token}` })
+        .set({ Authorization: `Bearer ${accessToken}` })
         .expect(200)
         .expect((res) => {
           expect(res.body).toEqual({
@@ -403,13 +366,11 @@ describe('QuizController (e2e)', () => {
     })
 
     it('should return an empty list when no quizzes exists', async () => {
-      const clientId = uuidv4()
-
-      const { token } = await authService.legacyAuthenticate({ clientId })
+      const { accessToken } = await createDefaultUserAndAuthenticate(app)
 
       return supertest(app.getHttpServer())
         .get('/api/quizzes')
-        .set({ Authorization: `Bearer ${token}` })
+        .set({ Authorization: `Bearer ${accessToken}` })
         .expect(200)
         .expect((res) => {
           expect(res.body).toEqual({
@@ -435,13 +396,11 @@ describe('QuizController (e2e)', () => {
     })
 
     it('should validate query parameters and return a 400 error for invalid input', async () => {
-      const clientId = uuidv4()
-
-      const { token } = await authService.legacyAuthenticate({ clientId })
+      const { accessToken } = await createDefaultUserAndAuthenticate(app)
 
       return supertest(app.getHttpServer())
         .get('/api/quizzes?limit=X&offset=X&mode=X&sort=X&order=X')
-        .set({ Authorization: `Bearer ${token}` })
+        .set({ Authorization: `Bearer ${accessToken}` })
         .expect(400)
         .expect((res) => {
           expect(res.body).toEqual({
@@ -493,20 +452,13 @@ describe('QuizController (e2e)', () => {
 
   describe('/api/quizzes/:quizId (GET)', () => {
     it('should succeed in retrieving an existing quiz', async () => {
-      const clientId = uuidv4()
+      const { accessToken, user } = await createDefaultUserAndAuthenticate(app)
 
-      const client = await clientService.findOrCreateClient(clientId)
-
-      const { token } = await authService.legacyAuthenticate({ clientId })
-
-      const originalQuiz = await quizService.createQuiz(
-        originalData,
-        client.player,
-      )
+      const originalQuiz = await quizService.createQuiz(originalData, user)
 
       return supertest(app.getHttpServer())
         .get(`/api/quizzes/${originalQuiz.id}`)
-        .set({ Authorization: `Bearer ${token}` })
+        .set({ Authorization: `Bearer ${accessToken}` })
         .expect(200)
         .expect((res) => {
           expect(res.body).toHaveProperty('id', originalQuiz.id)
@@ -538,14 +490,13 @@ describe('QuizController (e2e)', () => {
     })
 
     it('should fail in retrieving a non existing quiz', async () => {
-      const clientId = uuidv4()
       const quizId = uuidv4()
 
-      const { token } = await authService.legacyAuthenticate({ clientId })
+      const { accessToken } = await createDefaultUserAndAuthenticate(app)
 
       return supertest(app.getHttpServer())
         .get(`/api/quizzes/${quizId}`)
-        .set({ Authorization: `Bearer ${token}` })
+        .set({ Authorization: `Bearer ${accessToken}` })
         .expect(404)
         .expect((res) => {
           expect(res.body).toHaveProperty(
@@ -558,7 +509,8 @@ describe('QuizController (e2e)', () => {
     })
 
     it('should succeed in retrieving a public quiz', async () => {
-      const client = await clientService.findOrCreateClient(uuidv4())
+      const { accessToken, user } = await createDefaultUserAndAuthenticate(app)
+
       const {
         id,
         title,
@@ -570,15 +522,11 @@ describe('QuizController (e2e)', () => {
         imageCoverURL,
         created,
         updated,
-      } = await quizService.createQuiz(originalData, client.player)
-
-      const { token } = await authService.legacyAuthenticate({
-        clientId: uuidv4(),
-      })
+      } = await quizService.createQuiz(originalData, user)
 
       return supertest(app.getHttpServer())
         .get(`/api/quizzes/${id}`)
-        .set({ Authorization: `Bearer ${token}` })
+        .set({ Authorization: `Bearer ${accessToken}` })
         .expect(200)
         .expect((res) => {
           expect(res.body).toEqual({
@@ -592,8 +540,8 @@ describe('QuizController (e2e)', () => {
             imageCoverURL,
             numberOfQuestions: originalData.questions.length,
             author: {
-              id: client.player._id,
-              name: client.player.nickname,
+              id: user._id,
+              name: user.defaultNickname,
             },
             created: created.toISOString(),
             updated: updated.toISOString(),
@@ -602,19 +550,18 @@ describe('QuizController (e2e)', () => {
     })
 
     it('should fail in retrieving a private quiz', async () => {
-      const client = await clientService.findOrCreateClient(uuidv4())
+      const user = await userModel.create(buildMockSecondaryUser())
+
       const { id } = await quizService.createQuiz(
         { ...originalData, visibility: QuizVisibility.Private },
-        client.player,
+        user,
       )
 
-      const { token } = await authService.legacyAuthenticate({
-        clientId: uuidv4(),
-      })
+      const { accessToken } = await createDefaultUserAndAuthenticate(app)
 
       return supertest(app.getHttpServer())
         .get(`/api/quizzes/${id}`)
-        .set({ Authorization: `Bearer ${token}` })
+        .set({ Authorization: `Bearer ${accessToken}` })
         .expect(403)
         .expect((res) => {
           expect(res.body).toHaveProperty('message', 'Forbidden')
@@ -626,20 +573,13 @@ describe('QuizController (e2e)', () => {
 
   describe('/api/quizzes/:quizId (PUT)', () => {
     it('should succeed in updating an existing quiz', async () => {
-      const clientId = uuidv4()
+      const { accessToken, user } = await createDefaultUserAndAuthenticate(app)
 
-      const client = await clientService.findOrCreateClient(clientId)
-
-      const { token } = await authService.legacyAuthenticate({ clientId })
-
-      const originalQuiz = await quizService.createQuiz(
-        originalData,
-        client.player,
-      )
+      const originalQuiz = await quizService.createQuiz(originalData, user)
 
       return supertest(app.getHttpServer())
         .put(`/api/quizzes/${originalQuiz.id}`)
-        .set({ Authorization: `Bearer ${token}` })
+        .set({ Authorization: `Bearer ${accessToken}` })
         .send(updatedData)
         .expect(200)
         .expect((res) => {
@@ -668,14 +608,12 @@ describe('QuizController (e2e)', () => {
     })
 
     it('should fail in updating a non existing quiz', async () => {
-      const clientId = uuidv4()
       const quizId = uuidv4()
-
-      const { token } = await authService.legacyAuthenticate({ clientId })
+      const { accessToken } = await createDefaultUserAndAuthenticate(app)
 
       return supertest(app.getHttpServer())
         .put(`/api/quizzes/${quizId}`)
-        .set({ Authorization: `Bearer ${token}` })
+        .set({ Authorization: `Bearer ${accessToken}` })
         .send(updatedData)
         .expect(404)
         .expect((res) => {
@@ -689,16 +627,15 @@ describe('QuizController (e2e)', () => {
     })
 
     it('should fail in updating a non authorized quiz', async () => {
-      const client = await clientService.findOrCreateClient(uuidv4())
-      const { id } = await quizService.createQuiz(originalData, client.player)
+      const user = await userModel.create(buildMockSecondaryUser())
 
-      const { token } = await authService.legacyAuthenticate({
-        clientId: uuidv4(),
-      })
+      const { id } = await quizService.createQuiz(originalData, user)
+
+      const { accessToken } = await createDefaultUserAndAuthenticate(app)
 
       return supertest(app.getHttpServer())
         .put(`/api/quizzes/${id}`)
-        .set({ Authorization: `Bearer ${token}` })
+        .set({ Authorization: `Bearer ${accessToken}` })
         .send(updatedData)
         .expect(403)
         .expect((res) => {
@@ -711,20 +648,13 @@ describe('QuizController (e2e)', () => {
 
   describe('/api/quizzes/:quizId (DELETE)', () => {
     it('should succeed in deleting an existing quiz', async () => {
-      const clientId = uuidv4()
+      const { accessToken, user } = await createDefaultUserAndAuthenticate(app)
 
-      const client = await clientService.findOrCreateClient(clientId)
-
-      const { token } = await authService.legacyAuthenticate({ clientId })
-
-      const originalQuiz = await quizService.createQuiz(
-        originalData,
-        client.player,
-      )
+      const originalQuiz = await quizService.createQuiz(originalData, user)
 
       return supertest(app.getHttpServer())
         .delete(`/api/quizzes/${originalQuiz.id}`)
-        .set({ Authorization: `Bearer ${token}` })
+        .set({ Authorization: `Bearer ${accessToken}` })
         .expect(204)
         .expect((res) => {
           expect(res.body).toEqual({})
@@ -732,14 +662,13 @@ describe('QuizController (e2e)', () => {
     })
 
     it('should fail in deleting a non existing quiz', async () => {
-      const clientId = uuidv4()
       const quizId = uuidv4()
 
-      const { token } = await authService.legacyAuthenticate({ clientId })
+      const { accessToken } = await createDefaultUserAndAuthenticate(app)
 
       return supertest(app.getHttpServer())
         .delete(`/api/quizzes/${quizId}`)
-        .set({ Authorization: `Bearer ${token}` })
+        .set({ Authorization: `Bearer ${accessToken}` })
         .expect(404)
         .expect((res) => {
           expect(res.body).toHaveProperty(
@@ -752,16 +681,15 @@ describe('QuizController (e2e)', () => {
     })
 
     it('should fail in deleting a non authorized quiz', async () => {
-      const client = await clientService.findOrCreateClient(uuidv4())
-      const { id } = await quizService.createQuiz(originalData, client.player)
+      const user = await userModel.create(buildMockSecondaryUser())
 
-      const { token } = await authService.legacyAuthenticate({
-        clientId: uuidv4(),
-      })
+      const { id } = await quizService.createQuiz(originalData, user)
+
+      const { accessToken } = await createDefaultUserAndAuthenticate(app)
 
       return supertest(app.getHttpServer())
         .delete(`/api/quizzes/${id}`)
-        .set({ Authorization: `Bearer ${token}` })
+        .set({ Authorization: `Bearer ${accessToken}` })
         .expect(403)
         .expect((res) => {
           expect(res.body).toHaveProperty('message', 'Forbidden')
@@ -773,17 +701,13 @@ describe('QuizController (e2e)', () => {
 
   describe('/api/quizzes/:quizId/questions (GET)', () => {
     it('should succeed in retrieving all questions for a classic mode quiz', async () => {
-      const clientId = uuidv4()
+      const { accessToken, user } = await createDefaultUserAndAuthenticate(app)
 
-      const client = await clientService.findOrCreateClient(clientId)
-
-      const { token } = await authService.legacyAuthenticate({ clientId })
-
-      const quiz = await quizService.createQuiz(originalData, client.player)
+      const quiz = await quizService.createQuiz(originalData, user)
 
       return supertest(app.getHttpServer())
         .get(`/api/quizzes/${quiz.id}/questions`)
-        .set({ Authorization: `Bearer ${token}` })
+        .set({ Authorization: `Bearer ${accessToken}` })
         .expect(200)
         .expect((res) => {
           expect(res.body).toEqual(originalData.questions)
@@ -791,17 +715,13 @@ describe('QuizController (e2e)', () => {
     })
 
     it('should succeed in retrieving all questions for a zero to one hundred mode quiz', async () => {
-      const clientId = uuidv4()
+      const { accessToken, user } = await createDefaultUserAndAuthenticate(app)
 
-      const client = await clientService.findOrCreateClient(clientId)
-
-      const { token } = await authService.legacyAuthenticate({ clientId })
-
-      const quiz = await quizService.createQuiz(updatedData, client.player)
+      const quiz = await quizService.createQuiz(updatedData, user)
 
       return supertest(app.getHttpServer())
         .get(`/api/quizzes/${quiz.id}/questions`)
-        .set({ Authorization: `Bearer ${token}` })
+        .set({ Authorization: `Bearer ${accessToken}` })
         .expect(200)
         .expect((res) => {
           expect(res.body).toEqual(updatedData.questions)
@@ -811,13 +731,11 @@ describe('QuizController (e2e)', () => {
     it('should fail in retrieving all questions for a non existing quiz', async () => {
       const unknownQuizId = uuidv4()
 
-      const { token } = await authService.legacyAuthenticate({
-        clientId: uuidv4(),
-      })
+      const { accessToken } = await createDefaultUserAndAuthenticate(app)
 
       return supertest(app.getHttpServer())
         .get(`/api/quizzes/${unknownQuizId}/questions`)
-        .set({ Authorization: `Bearer ${token}` })
+        .set({ Authorization: `Bearer ${accessToken}` })
         .expect(404)
         .expect((res) => {
           expect(res.body).toHaveProperty(
@@ -830,19 +748,15 @@ describe('QuizController (e2e)', () => {
     })
 
     it('should fail in retrieving all questions for a non authorized quiz', async () => {
-      const clientId = uuidv4()
+      const user = await userModel.create(buildMockSecondaryUser())
 
-      const client = await clientService.findOrCreateClient(clientId)
+      const quiz = await quizService.createQuiz(originalData, user)
 
-      const quiz = await quizService.createQuiz(originalData, client.player)
-
-      const { token } = await authService.legacyAuthenticate({
-        clientId: uuidv4(),
-      })
+      const { accessToken } = await createDefaultUserAndAuthenticate(app)
 
       return supertest(app.getHttpServer())
         .get(`/api/quizzes/${quiz.id}/questions`)
-        .set({ Authorization: `Bearer ${token}` })
+        .set({ Authorization: `Bearer ${accessToken}` })
         .expect(403)
         .expect((res) => {
           expect(res.body).toHaveProperty('message', 'Forbidden')

--- a/packages/quiz-service/src/quiz/controllers/quiz.controller.ts
+++ b/packages/quiz-service/src/quiz/controllers/quiz.controller.ts
@@ -23,9 +23,14 @@ import {
   ApiUnauthorizedResponse,
   getSchemaPath,
 } from '@nestjs/swagger'
+import { Authority, TokenScope } from '@quiz/common'
 
-import { AuthorizedClientParam } from '../../client/controllers/decorators/auth'
-import { Client } from '../../client/services/models/schemas'
+import {
+  Principal,
+  RequiredAuthorities,
+  RequiresScopes,
+} from '../../auth/controllers/decorators'
+import { User } from '../../user/services/models/schemas'
 import { ParseQuizRequestPipe } from '../pipes'
 import { QuizService } from '../services'
 
@@ -51,7 +56,6 @@ import { QuestionResponseMultiChoiceExample } from './utils/question-examples.ut
  */
 @ApiBearerAuth()
 @ApiTags('quiz')
-@Controller('quizzes')
 @ApiExtraModels(
   QuestionMultiChoice,
   QuestionRange,
@@ -61,27 +65,30 @@ import { QuestionResponseMultiChoiceExample } from './utils/question-examples.ut
   QuizClassicRequest,
   QuizZeroToOneHundredRequest,
 )
+@RequiresScopes(TokenScope.User)
+@RequiredAuthorities(Authority.Quiz)
+@Controller('quizzes')
 export class QuizController {
   /**
    * Initializes the QuizController.
    *
-   * @param {QuizService} quizService - Service for managing quiz operations.
+   * @param quizService - Service for managing quiz operations.
    */
   constructor(private readonly quizService: QuizService) {}
 
   /**
-   * Creates a new quiz and associates it with the authenticated client.
+   * Creates a new quiz and associates it with the authenticated user.
    *
-   * @param {Client} client - The client initiating the request.
-   * @param {QuizClassicRequest | QuizZeroToOneHundredRequest} quizRequest - The details of the quiz to create.
+   * @param user - The user initiating the request.
+   * @param quizRequest - The details of the quiz to create.
    *
-   * @returns {Promise<QuizResponse>} The newly created quiz.
+   * @returns The newly created quiz.
    */
   @Post()
   @ApiOperation({
     summary: 'Create a new quiz',
     description:
-      'Creates a new quiz and associates it with the authenticated client.',
+      'Creates a new quiz and associates it with the authenticated user.',
   })
   @ApiBody({
     description: 'Request body for creating a new game.',
@@ -101,11 +108,11 @@ export class QuizController {
   })
   @HttpCode(HttpStatus.CREATED)
   public async createQuiz(
-    @AuthorizedClientParam() client: Client,
+    @Principal() user: User,
     @Body(new ParseQuizRequestPipe())
     quizRequest: QuizClassicRequest | QuizZeroToOneHundredRequest,
   ): Promise<QuizResponse> {
-    return this.quizService.createQuiz(quizRequest, client.player)
+    return this.quizService.createQuiz(quizRequest, user)
   }
 
   /**
@@ -172,7 +179,7 @@ export class QuizController {
     description: 'Unauthorized access to the endpoint.',
   })
   @ApiForbiddenResponse({
-    description: 'The client does not have access to this quiz.',
+    description: 'The user does not have access to this quiz.',
   })
   @ApiNotFoundResponse({ description: 'Quiz not found.' })
   @HttpCode(HttpStatus.OK)
@@ -214,7 +221,7 @@ export class QuizController {
     description: 'Unauthorized access to the endpoint.',
   })
   @ApiForbiddenResponse({
-    description: 'The client does not have access to this quiz.',
+    description: 'The user does not have access to this quiz.',
   })
   @ApiNotFoundResponse({ description: 'Quiz not found.' })
   @HttpCode(HttpStatus.OK)
@@ -248,7 +255,7 @@ export class QuizController {
     description: 'Unauthorized access to the endpoint.',
   })
   @ApiForbiddenResponse({
-    description: 'The client does not have access to this quiz.',
+    description: 'The user does not have access to this quiz.',
   })
   @ApiNotFoundResponse({ description: 'Quiz not found.' })
   @HttpCode(HttpStatus.NO_CONTENT)
@@ -294,7 +301,7 @@ export class QuizController {
     description: 'Unauthorized access to the endpoint.',
   })
   @ApiForbiddenResponse({
-    description: 'The client does not have access to the quiz.',
+    description: 'The ser does not have access to the quiz.',
   })
   @HttpCode(HttpStatus.OK)
   public async findAllQuestion(

--- a/packages/quiz-service/src/quiz/guards/quiz-auth.guard.spec.ts
+++ b/packages/quiz-service/src/quiz/guards/quiz-auth.guard.spec.ts
@@ -7,14 +7,14 @@ import {
 import { Test, TestingModule } from '@nestjs/testing'
 import { QuizVisibility } from '@quiz/common'
 
-import { Player } from '../../player/services/models/schemas'
+import { User } from '../../user/services/models/schemas'
 import { QuizService } from '../services'
 import { Quiz } from '../services/models/schemas'
 
 import { QuizAuthGuard } from './quiz-auth.guard'
 
 type MockRequest = {
-  client?: { player: Player }
+  user?: User
   params?: { quizId?: string }
 }
 
@@ -39,13 +39,11 @@ describe('QuizAuthGuard', () => {
     quizService = module.get(QuizService)
   })
 
-  it('should allow access if the client is authenticated and owns the quiz', async () => {
+  it('should allow access if the user is authenticated and owns the quiz', async () => {
     const mockRequest: MockRequest = {
-      client: {
-        player: {
-          _id: 'player1',
-        } as Player,
-      },
+      user: {
+        _id: 'player1',
+      } as User,
       params: {
         quizId: 'quiz1',
       },
@@ -53,7 +51,7 @@ describe('QuizAuthGuard', () => {
 
     const mockQuiz = {
       visibility: QuizVisibility.Private,
-      owner: { _id: 'player1' } as Player,
+      owner: { _id: 'player1' } as User,
     } as Quiz
     quizService.findQuizDocumentByIdOrThrow.mockResolvedValue(mockQuiz)
 
@@ -77,9 +75,9 @@ describe('QuizAuthGuard', () => {
     )
   })
 
-  it('should throw UnauthorizedException if the client is not authenticated', async () => {
+  it('should throw UnauthorizedException if the user is not authenticated', async () => {
     const mockRequest: MockRequest = {
-      client: undefined,
+      user: undefined,
       params: {
         quizId: 'quiz1',
       },
@@ -104,11 +102,9 @@ describe('QuizAuthGuard', () => {
 
   it('should throw BadRequestException if quizId is missing', async () => {
     const mockRequest: MockRequest = {
-      client: {
-        player: {
-          _id: 'player1',
-        } as Player,
-      },
+      user: {
+        _id: 'player1',
+      } as User,
       params: {},
     }
 
@@ -129,13 +125,11 @@ describe('QuizAuthGuard', () => {
     )
   })
 
-  it('should throw ForbiddenException if the client is not the owner of the quiz', async () => {
+  it('should throw ForbiddenException if the user is not the owner of the quiz', async () => {
     const mockRequest: MockRequest = {
-      client: {
-        player: {
-          _id: 'player2',
-        } as Player,
-      },
+      user: {
+        _id: 'player2',
+      } as User,
       params: {
         quizId: 'quiz1',
       },
@@ -143,7 +137,7 @@ describe('QuizAuthGuard', () => {
 
     const mockQuiz = {
       visibility: QuizVisibility.Private,
-      owner: { _id: 'player1' } as Player,
+      owner: { _id: 'player1' } as User,
     } as Quiz
     quizService.findQuizDocumentByIdOrThrow.mockResolvedValue(mockQuiz)
 
@@ -166,11 +160,9 @@ describe('QuizAuthGuard', () => {
 
   it('should call findQuizDocumentByIdOrThrow with the correct quizId', async () => {
     const mockRequest = {
-      client: {
-        player: {
-          _id: 'player1',
-        },
-      },
+      user: {
+        _id: 'player1',
+      } as User,
       params: {
         quizId: 'quiz1',
       },
@@ -178,7 +170,7 @@ describe('QuizAuthGuard', () => {
 
     const mockQuiz = {
       visibility: QuizVisibility.Private,
-      owner: { _id: 'player1' } as Player,
+      owner: { _id: 'player1' } as User,
     } as Quiz
     quizService.findQuizDocumentByIdOrThrow.mockResolvedValue(mockQuiz)
 
@@ -203,11 +195,9 @@ describe('QuizAuthGuard', () => {
 
   it('should allow access to a public quiz when allowPublic is true', async () => {
     const mockRequest: MockRequest = {
-      client: {
-        player: {
-          _id: 'player2',
-        } as Player,
-      },
+      user: {
+        _id: 'player2',
+      } as User,
       params: {
         quizId: 'quiz1',
       },
@@ -215,7 +205,7 @@ describe('QuizAuthGuard', () => {
 
     const mockQuiz = {
       visibility: QuizVisibility.Public,
-      owner: { _id: 'player1' } as Player,
+      owner: { _id: 'player1' } as User,
     } as Quiz
     quizService.findQuizDocumentByIdOrThrow.mockResolvedValue(mockQuiz)
 

--- a/packages/quiz-service/src/quiz/quiz.module.ts
+++ b/packages/quiz-service/src/quiz/quiz.module.ts
@@ -2,7 +2,7 @@ import { Logger, Module } from '@nestjs/common'
 import { EventEmitterModule } from '@nestjs/event-emitter'
 import { MongooseModule } from '@nestjs/mongoose'
 
-import { ClientQuizController, QuizController } from './controllers'
+import { ProfileQuizController, QuizController } from './controllers'
 import { QuizService } from './services'
 import { Quiz, QuizSchema } from './services/models/schemas'
 
@@ -16,7 +16,7 @@ import { Quiz, QuizSchema } from './services/models/schemas'
       },
     ]),
   ],
-  controllers: [QuizController, ClientQuizController],
+  controllers: [QuizController, ProfileQuizController],
   providers: [Logger, QuizService],
   exports: [QuizService],
 })

--- a/packages/quiz-service/src/quiz/services/models/schemas/quiz.schema.ts
+++ b/packages/quiz-service/src/quiz/services/models/schemas/quiz.schema.ts
@@ -8,7 +8,7 @@ import {
 } from '@quiz/common'
 import { Model, Schema as MongooseSchema } from 'mongoose'
 
-import { Player } from '../../../../player/services/models/schemas'
+import { User } from '../../../../user/services/models/schemas'
 
 import {
   BaseQuestionDao,
@@ -90,12 +90,12 @@ export class Quiz {
     ))[]
 
   /**
-   * The player document associated with the quiz.
+   * The user document associated with the quiz.
    *
-   * Stores a reference to a Player document to link quizzes with their owners profiles.
+   * Stores a reference to a User document to link quizzes with their owners profiles.
    */
-  @Prop({ type: String, ref: 'Player' })
-  owner: Player
+  @Prop({ type: String, ref: 'User' })
+  owner: User
 
   /**
    * The date and time when the quiz was created.

--- a/packages/quiz-service/src/quiz/services/quiz.service.ts
+++ b/packages/quiz-service/src/quiz/services/quiz.service.ts
@@ -21,7 +21,7 @@ import {
 import { RootFilterQuery } from 'mongoose'
 import { v4 as uuidv4 } from 'uuid'
 
-import { Player } from '../../player/services/models/schemas'
+import { User } from '../../user/services/models/schemas'
 import { QuizNotFoundException } from '../exceptions'
 
 import {
@@ -57,17 +57,17 @@ export class QuizService {
   /**
    * Creates a new quiz.
    *
-   * @param {QuizRequestDto} quizRequest - The data for the quiz to be created.
-   * @param {Player} player - The player creating the quiz.
+   * @param quizRequest - The data for the quiz to be created.
+   * @param user - The user creating the quiz.
    *
-   * @returns {Promise<QuizResponseDto>} - The created quiz's details.
+   * @returns The created quiz's details.
    */
   public async createQuiz(
     quizRequest: QuizRequestDto,
-    player: Player,
+    user: User,
   ): Promise<QuizResponseDto> {
     const quiz = await this.quizModel.create(
-      QuizService.buildNewQuiz(quizRequest, player),
+      QuizService.buildNewQuiz(quizRequest, user),
     )
 
     this.logger.log(`Created quiz with id '${quiz._id}.'`)
@@ -78,29 +78,15 @@ export class QuizService {
   /**
    * Finds a quiz by its ID.
    *
-   * @param {string} quizId - The unique identifier of the quiz.
+   * @param quizId - The unique identifier of the quiz.
    *
-   * @returns {Promise<QuizResponseDto>} - The details of the found quiz.
+   * @returns The details of the found quiz.
    *
-   * @throws {QuizNotFoundException} - If no quiz is found with the given ID.
+   * @throws QuizNotFoundException If no quiz is found with the given ID.
    */
   public async findQuizById(quizId: string): Promise<QuizResponseDto> {
     const quiz = await this.findQuizDocumentByIdOrThrow(quizId)
     return QuizService.buildQuizResponseDto(quiz)
-  }
-
-  /**
-   * Retrieves the owner of a quiz by its ID.
-   *
-   * @param {string} quizId - The unique identifier of the quiz.
-   *
-   * @returns {Promise<Player>} - The owner of the quiz.
-   *
-   * @throws {QuizNotFoundException} - If no quiz is found with the given ID.
-   */
-  public async findOwnerByQuizId(quizId: string): Promise<Player> {
-    const quiz = await this.findQuizDocumentByIdOrThrow(quizId)
-    return quiz.owner
   }
 
   /**
@@ -117,7 +103,7 @@ export class QuizService {
    * @param limit - Maximum number of quizzes to retrieve. Defaults to 10.
    * @param offset - Number of quizzes to skip for pagination. Defaults to 0.
    *
-   * @returns {Promise<PaginatedQuizResponseDto>} A paginated response containing the quizzes and metadata.
+   * @returns A paginated response containing the quizzes and metadata.
    */
   public async findQuizzesByOwnerId(
     ownerId: string,
@@ -161,7 +147,7 @@ export class QuizService {
    * @param limit - Maximum number of quizzes to retrieve. Defaults to 10.
    * @param offset - Number of quizzes to skip for pagination. Defaults to 0.
    *
-   * @returns {Promise<PaginatedQuizResponseDto>} A paginated response containing the list of quizzes.
+   * @returns A paginated response containing the list of quizzes.
    */
   public async findPublicQuizzes(
     search?: string,
@@ -201,7 +187,7 @@ export class QuizService {
    * @param limit - Maximum number of quizzes to retrieve. Defaults to 10.
    * @param offset - Number of quizzes to skip for pagination. Defaults to 0.
    *
-   * @returns {Promise<PaginatedQuizResponseDto>} A paginated response containing the list of quizzes.
+   * @returns A paginated response containing the list of quizzes.
    *
    * @private
    */
@@ -246,12 +232,12 @@ export class QuizService {
   /**
    * Updates an existing quiz.
    *
-   * @param {string} quizId - The unique identifier of the quiz.
-   * @param {QuizRequestDto} quizRequest - The updated quiz data.
+   * @param quizId - The unique identifier of the quiz.
+   * @param quizRequest - The updated quiz data.
    *
-   * @returns {Promise<QuizResponseDto>} - The updated quiz's details.
+   * @returns The updated quiz's details.
    *
-   * @throws {QuizNotFoundException} - If no quiz is found with the given ID.
+   * @throws QuizNotFoundException If no quiz is found with the given ID.
    */
   public async updateQuiz(
     quizId: string,
@@ -276,11 +262,11 @@ export class QuizService {
   /**
    * Deletes a quiz by its ID.
    *
-   * @param {string} quizId - The unique identifier of the quiz.
+   * @param quizId - The unique identifier of the quiz.
    *
-   * @returns {Promise<void>} - Confirms successful deletion of the quiz.
+   * @returns Confirms successful deletion of the quiz.
    *
-   * @throws {QuizNotFoundException} - If no quiz is found with the given ID.
+   * @throws QuizNotFoundException If no quiz is found with the given ID.
    */
   public async deleteQuiz(quizId: string): Promise<void> {
     const deletedQuiz = await this.quizModel.findByIdAndDelete(quizId)
@@ -298,11 +284,11 @@ export class QuizService {
   /**
    * Finds a quiz document by its ID or throws an exception if not found.
    *
-   * @param {string} quizId - The unique identifier of the quiz.
+   * @param quizId - The unique identifier of the quiz.
    *
-   * @returns {Promise<Quiz>} - The found quiz document.
+   * @returns The found quiz document.
    *
-   * @throws {QuizNotFoundException} - If no quiz is found with the given ID.
+   * @throws QuizNotFoundException If no quiz is found with the given ID.
    */
   public async findQuizDocumentByIdOrThrow(quizId: string): Promise<Quiz> {
     const quiz = await this.quizModel.findById(quizId).populate('owner')
@@ -318,11 +304,11 @@ export class QuizService {
   /**
    * Retrieves all questions associated with a given quiz.
    *
-   * @param {string} quizId - The unique identifier of the quiz.
+   * @param quizId - The unique identifier of the quiz.
    *
-   * @returns {Promise<QuestionDto[]>} - A list of all questions associated with the specified quiz.
+   * @returns A list of all questions associated with the specified quiz.
    *
-   * @throws {QuizNotFoundException} - If the quiz with the given ID does not exist.
+   * @throws If the quiz with the given ID does not exist.
    */
   public async findAllQuestion(quizId: string): Promise<QuestionDto[]> {
     const quiz = await this.quizModel.findById(quizId).populate('owner')
@@ -338,18 +324,15 @@ export class QuizService {
   }
 
   /**
-   * Builds a new quiz document based on the request data and player.
+   * Builds a new quiz document based on the request data and user.
    *
-   * @param {QuizRequestDto} quizRequest - The data for the quiz to be created.
-   * @param {Player} player - The player creating the quiz.
+   * @param quizRequest - The data for the quiz to be created.
+   * @param user - The user creating the quiz.
    *
-   * @returns {Quiz} - The constructed quiz document.
+   * @returns The constructed quiz document.
    * @private
    */
-  private static buildNewQuiz(
-    quizRequest: QuizRequestDto,
-    player: Player,
-  ): Quiz {
+  private static buildNewQuiz(quizRequest: QuizRequestDto, user: User): Quiz {
     const created = new Date()
     return {
       _id: uuidv4(),
@@ -361,7 +344,7 @@ export class QuizService {
       imageCoverURL: quizRequest.imageCoverURL,
       languageCode: quizRequest.languageCode,
       questions: QuizService.buildQuizQuestions(quizRequest),
-      owner: player,
+      owner: user,
       created,
       updated: created,
     }
@@ -370,9 +353,9 @@ export class QuizService {
   /**
    * Builds the data for updating a quiz.
    *
-   * @param {QuizRequestDto} quizRequest - The updated quiz data.
+   * @param quizRequest - The updated quiz data.
    *
-   * @returns {Partial<Quiz>} - The updated quiz data to persist.
+   * @returns The updated quiz data to persist.
    * @private
    */
   private static buildUpdatedQuiz(quizRequest: QuizRequestDto): Partial<Quiz> {
@@ -392,9 +375,9 @@ export class QuizService {
   /**
    * Builds the Mongoose-compatible documents for the questions.
    *
-   * @param {QuizRequestDto} quizRequest - The data for the question.
+   * @param quizRequest - The data for the question.
    *
-   * @returns {QuestionDao} - The constructed question documents.
+   * @returns The constructed question documents.
    * @private
    */
   private static buildQuizQuestions(
@@ -472,10 +455,10 @@ export class QuizService {
   /**
    * Constructs a `QuestionDto` object from a Mongoose `Question` document.
    *
-   * @param {GameMode} mode - The game mode of the quiz.
-   * @param {BaseQuestionDao} question - The Mongoose question document to transform.
+   * @param mode - The game mode of the quiz.
+   * @param question - The Mongoose question document to transform.
    *
-   * @returns {QuestionDto} - The constructed DTO representing the question details.
+   * @returns The constructed DTO representing the question details.
    * @private
    */
   private static buildQuestionDto(
@@ -547,9 +530,9 @@ export class QuizService {
   /**
    * Builds a QuizResponseDto from a Quiz document.
    *
-   * @param {Quiz} quiz - The quiz document.
+   * @param quiz - The quiz document.
    *
-   * @returns {QuizResponseDto} - The constructed response DTO.
+   * @returns The constructed response DTO.
    * @private
    */
   private static buildQuizResponseDto(quiz: Quiz): QuizResponseDto {
@@ -579,7 +562,7 @@ export class QuizService {
       numberOfQuestions: questions.length,
       author: {
         id: owner._id,
-        name: owner.nickname,
+        name: owner.defaultNickname,
       },
       created,
       updated,

--- a/packages/quiz-service/test-utils/data/user.data.ts
+++ b/packages/quiz-service/test-utils/data/user.data.ts
@@ -11,9 +11,9 @@ export const MOCK_PRIMARY_USER_GIVEN_NAME = 'John'
 export const MOCK_PRIMARY_USER_FAMILY_NAME = 'Appleseed'
 export const MOCK_PRIMARY_USER_DEFAULT_NICKNAME = 'FrostyBear'
 
-export const MOCK_SECONDARY_USER_EMAIL = 'user@example.com'
-export const MOCK_SECONDARY_USER_GIVEN_NAME = 'John'
-export const MOCK_SECONDARY_USER_FAMILY_NAME = 'Appleseed'
+export const MOCK_SECONDARY_USER_EMAIL = 'another.user@example.com'
+export const MOCK_SECONDARY_USER_GIVEN_NAME = 'Test'
+export const MOCK_SECONDARY_USER_FAMILY_NAME = 'Testsson'
 export const MOCK_SECONDARY_USER_DEFAULT_NICKNAME = 'WhiskerFox'
 
 export const MOCK_DEFAULT_PASSWORD = 'Super#SecretPa$$w0rd123'


### PR DESCRIPTION
- Rename ClientQuizController → ProfileQuizController and route to /api/profile/quizzes
- Protect ProfileQuizController with @RequiresScopes(TokenScope.User) and @RequiredAuthorities(Authority.Quiz)
- Switch controllers to use @Principal() to inject authenticated User instead of Client
- Update QuizController to require user scope/authority and accept Principal() user param
- Adjust Swagger tags: add “profile” tag in main.ts
- Revise e2e specs for profile-quiz and quiz controllers to use createDefaultUserAndAuthenticate and buildMockPrimaryUser/SecondaryUser helpers
- Remove legacy client-quiz controller and tests