### PR TITLE
feat(auth): add PrincipalId decorator

### DIFF
--- a/packages/quiz-service/src/auth/controllers/decorators/auth/index.ts
+++ b/packages/quiz-service/src/auth/controllers/decorators/auth/index.ts
@@ -1,3 +1,4 @@
+export * from './principal-id.decorator'
 export * from './principal.decorator'
 export * from './public.decorator'
 export * from './required-authorities.decorator'

--- a/packages/quiz-service/src/auth/controllers/decorators/auth/principal-id.decorator.ts
+++ b/packages/quiz-service/src/auth/controllers/decorators/auth/principal-id.decorator.ts
@@ -1,0 +1,35 @@
+import {
+  createParamDecorator,
+  ExecutionContext,
+  UnauthorizedException,
+} from '@nestjs/common'
+
+import { AuthGuardRequest } from '../../../guards'
+
+/**
+ * Parameter decorator that injects the authenticated user's unique identifier.
+ *
+ * Retrieves `principalId` (the `sub` claim) from the request, as set by AuthGuard.
+ *
+ * @example
+ * ```ts
+ * @Get('me')
+ * getProfile(@PrincipalId() userId: string) {
+ *   return this.userService.findById(userId);
+ * }
+ * ```
+ *
+ * @param _unused Always ignored.
+ * @param ctx     Nest execution context, used to access the raw request.
+ * @returns       The authenticated user's principal ID.
+ * @throws        {UnauthorizedException} if no `principalId` is found on the request.
+ */
+export const PrincipalId = createParamDecorator(
+  (_unused: unknown, ctx: ExecutionContext): string => {
+    const req = ctx.switchToHttp().getRequest<AuthGuardRequest>()
+    if (!req.principalId) {
+      throw new UnauthorizedException('Missing principalId on request')
+    }
+    return req.principalId
+  },
+)

--- a/packages/quiz-service/src/auth/guards/auth.guard.ts
+++ b/packages/quiz-service/src/auth/guards/auth.guard.ts
@@ -38,6 +38,12 @@ export interface AuthGuardRequest extends Request {
   authorities: Authority[]
 
   /**
+   * Unique identifier of the authenticated subject (from the JWT `sub` claim).
+   * Always set when authentication succeeds.
+   */
+  principalId: string
+
+  /**
    * The authenticated user record, populated when `scope` is `User` or `Game`.
    * Fetched via `UserRepository.findUserByIdOrThrow(sub)`.
    */
@@ -121,6 +127,7 @@ export class AuthGuard implements CanActivate {
 
     request.scope = scope
     request.authorities = authorities
+    request.principalId = sub
 
     if (scope === TokenScope.User || scope === TokenScope.Game) {
       try {


### PR DESCRIPTION
- Introduce `PrincipalId` parameter decorator to inject the authenticated user's unique identifier (`principalId`) into controller handlers.
- Add null‐check and throw `UnauthorizedException` if `principalId` is missing.
- Extend `AuthGuardRequest` interface to include `principalId` with JSDoc.
- Assign `request.principalId = sub` in `AuthGuard` after token validation.
