### PR TITLE
feat(auth): add support for game-scoped tokens

### DIFF
--- a/packages/common/src/models/token.dto.ts
+++ b/packages/common/src/models/token.dto.ts
@@ -1,4 +1,5 @@
 import { Authority } from './authority.enum'
+import { GameParticipantType } from './game-participant-type.enum'
 
 /**
  * The functional area of the application that this token is intended for.
@@ -46,4 +47,29 @@ export interface TokenDto {
    * Determines which actions or endpoints the bearer is allowed to access.
    */
   authorities: Authority[]
+}
+
+/**
+ * A token issued for game‐related operations.
+ *
+ * Extends `TokenDto` with:
+ *  - `scope: TokenScope.Game`
+ *  - `gameId`: the UUID of the game
+ *  - `participantType`: whether this token is for the host or a player
+ */
+export interface GameTokenDto extends TokenDto {
+  /**
+   * Always `TokenScope.Game` for game tokens.
+   */
+  readonly scope: TokenScope.Game
+
+  /**
+   * The unique identifier (UUID) of the game this token pertains to.
+   */
+  readonly gameId: string
+
+  /**
+   * The role of the bearer in the game: host or player.
+   */
+  readonly participantType: GameParticipantType
 }

--- a/packages/quiz-service/src/auth/auth.module.ts
+++ b/packages/quiz-service/src/auth/auth.module.ts
@@ -8,6 +8,7 @@ import * as jwt from 'jsonwebtoken'
 
 import { EnvironmentVariables } from '../app/config'
 import { ClientModule } from '../client'
+import { GameModule } from '../game'
 import { UserModule } from '../user'
 
 import { AuthController } from './controllers'
@@ -47,6 +48,7 @@ import { AuthService } from './services'
       },
     }),
     ClientModule,
+    GameModule,
     UserModule,
   ],
   controllers: [AuthController],

--- a/packages/quiz-service/src/auth/controllers/auth.controller.ts
+++ b/packages/quiz-service/src/auth/controllers/auth.controller.ts
@@ -1,13 +1,26 @@
-import { Body, Controller, HttpCode, HttpStatus, Post } from '@nestjs/common'
+import {
+  Body,
+  Controller,
+  Headers,
+  HttpCode,
+  HttpStatus,
+  Param,
+  Post,
+  UnauthorizedException,
+} from '@nestjs/common'
 import {
   ApiBadRequestResponse,
   ApiBody,
+  ApiNotFoundResponse,
   ApiOkResponse,
   ApiOperation,
+  ApiParam,
   ApiTags,
   ApiUnauthorizedResponse,
 } from '@nestjs/swagger'
+import { Authority, TokenScope } from '@quiz/common'
 
+import { ParseGamePINPipe } from '../../game/pipes'
 import { AuthService } from '../services'
 
 import { Public } from './decorators'
@@ -62,6 +75,44 @@ export class AuthController {
     @Body() authLoginRequest: AuthLoginRequest,
   ): Promise<AuthLoginResponse> {
     return this.authService.login(authLoginRequest)
+  }
+
+  /**
+   * Issue game‐scoped tokens by providing a game PIN.
+   * If an Authorization header with a valid User token (and `Game` authority) is present,
+   * that user ID is reused; otherwise a new anonymous participant is created.
+   *
+   * @param gamePIN - A 6-digit PIN that identifies the game.
+   * @param authorization - Optional Bearer token of an authenticated user.
+   * @returns A pair of access + refresh tokens scoped to the specified game.
+   */
+  @Public()
+  @Post('/games/:gamePIN')
+  @ApiOperation({
+    summary: 'Game authentication',
+    description: 'Issue JWTs for game participation using the game’s PIN.',
+  })
+  @ApiParam({
+    name: 'gamePIN',
+    type: String,
+    description: 'The unique 6-digit PIN for the game to be retrieved.',
+    required: true,
+    example: '123456',
+  })
+  @ApiOkResponse({
+    type: AuthLoginResponse,
+    description: 'Game access and refresh tokens.',
+  })
+  @ApiBadRequestResponse({ description: 'Invalid game PIN format.' })
+  @ApiNotFoundResponse({ description: 'No active game found with that PIN.' })
+  @HttpCode(HttpStatus.OK)
+  public async authenticateGame(
+    @Param('gamePIN', new ParseGamePINPipe()) gamePIN: string,
+    @Headers('Authorization') authorization?: string,
+  ): Promise<AuthLoginResponse> {
+    const optionalUserId =
+      await this.extractUserIdFromAuthorizationHeader(authorization)
+    return this.authService.authenticateGame(gamePIN, optionalUserId)
   }
 
   /**
@@ -132,5 +183,36 @@ export class AuthController {
     authRequest: LegacyAuthRequest,
   ): Promise<LegacyAuthResponse> {
     return this.authService.legacyAuthenticate(authRequest)
+  }
+
+  /**
+   * If present, parses and validates a Bearer user‐token from the Authorization header.
+   * Returns the user ID only if it has `TokenScope.User` and includes `Authority.Game`.
+   *
+   * @param authorization - The raw Authorization header (e.g. "Bearer eyJ...")
+   * @returns The user ID to reuse as the game participant, or `undefined`.
+   * @throws UnauthorizedException when the token is invalid or expired.
+   * @private
+   */
+  private async extractUserIdFromAuthorizationHeader(
+    authorization?: string,
+  ): Promise<string | undefined> {
+    if (!authorization) {
+      return undefined
+    }
+    const [type, token] = authorization.split(' ') ?? []
+    const accessToken = type === 'Bearer' ? token : undefined
+
+    try {
+      const payload = await this.authService.verifyToken(accessToken)
+      if (
+        payload.scope === TokenScope.User &&
+        payload.authorities.includes(Authority.Game)
+      ) {
+        return payload.sub
+      }
+    } catch {
+      throw new UnauthorizedException('Invalid or expired token')
+    }
   }
 }

--- a/packages/quiz-service/src/auth/services/utils/token.constants.ts
+++ b/packages/quiz-service/src/auth/services/utils/token.constants.ts
@@ -4,7 +4,7 @@ export const DEFAULT_REFRESH_TOKEN_EXPIRATION_TIME = '15m'
 export const DEFAULT_ACCESS_TOKEN_EXPIRATION_TIME = '15m'
 
 export const DEFAULT_CLIENT_AUTHORITIES: Authority[] = []
-export const DEFAULT_GAME_AUTHORITIES: Authority[] = []
+export const DEFAULT_GAME_AUTHORITIES: Authority[] = [Authority.Game]
 export const DEFAULT_USER_AUTHORITIES: Authority[] = [
   Authority.Game,
   Authority.Media,

--- a/packages/quiz-service/src/game/game.module.ts
+++ b/packages/quiz-service/src/game/game.module.ts
@@ -3,7 +3,6 @@ import { Logger, Module } from '@nestjs/common'
 import { EventEmitterModule } from '@nestjs/event-emitter'
 import { MongooseModule } from '@nestjs/mongoose'
 
-import { AuthModule } from '../auth'
 import { ClientModule } from '../client'
 import { PlayerModule } from '../player'
 import { QuizModule } from '../quiz'
@@ -48,7 +47,6 @@ import { GameResult, GameResultSchema } from './services/models/schemas'
         schema: GameResultSchema,
       },
     ]),
-    AuthModule,
     PlayerModule,
     ClientModule,
     QuizModule,
@@ -72,5 +70,6 @@ import { GameResult, GameResultSchema } from './services/models/schemas'
     GameTaskTransitionService,
     GameTaskTransitionScheduler,
   ],
+  exports: [GameRepository],
 })
 export class GameModule {}


### PR DESCRIPTION
- common: introduce GameTokenDto with scope=Game, gameId and participantType
- auth-module: register GameModule
- AuthController: add POST /games/:gamePIN endpoint, reuse optional User token or create anonymous participant
- AuthService: implement authenticateGame(), issue + refresh game-scoped JWTs with gameId/participantType
- AuthGuard: recognize Game scope, attach gameId and participantType to request
- Tests: cover game authentication flows and token verification in e2e and guard specs