### PR TITLE
refactor(quiz): unify profile routes & enhance profile UI

### DIFF
--- a/packages/quiz/src/api/use-quiz-service-client.tsx
+++ b/packages/quiz/src/api/use-quiz-service-client.tsx
@@ -1,5 +1,9 @@
 import {
+  AuthLoginRequestDto,
+  AuthLoginResponseDto,
   CreateGameResponseDto,
+  CreateUserRequestDto,
+  CreateUserResponseDto,
   FindGameResponseDto,
   GameResultDto,
   MediaUploadPhotoResponseDto,
@@ -14,12 +18,9 @@ import {
   QuizRequestDto,
   QuizResponseDto,
   SubmitQuestionAnswerRequestDto,
+  UpdateUserProfileRequestDto,
+  UserProfileResponseDto,
 } from '@quiz/common'
-import { AuthLoginRequestDto, AuthLoginResponseDto } from '@quiz/common/src'
-import {
-  CreateUserRequestDto,
-  CreateUserResponseDto,
-} from '@quiz/common/src/models/user.ts'
 
 import { useAuthContext } from '../context/auth'
 import { notifyError, notifySuccess } from '../utils/notification.ts'
@@ -38,7 +39,7 @@ import {
  * It also provides specific methods for retrieving player information and associated quizzes.
  *
  * @returns An object containing the following methods:
- * - `getCurrentPlayer`: Retrieves information about the current player.
+ * - `getUserProfile`: Retrieves information about the current player.
  * - `getCurrentPlayerQuizzes`: Retrieves quizzes associated with the current player.
  */
 export const useQuizServiceClient = () => {
@@ -181,29 +182,34 @@ export const useQuizServiceClient = () => {
     })
 
   /**
-   * Retrieves information about the current player.
+   * Retrieves information about the current user.
    *
-   * @returns A promise resolving to the player information as a `PlayerResponseDto`.
+   * @returns A promise resolving to the user information.
    */
-  const getCurrentPlayer = (): Promise<PlayerResponseDto> =>
-    apiGet<PlayerResponseDto>('/client/player')
+  const getUserProfile = (): Promise<UserProfileResponseDto> =>
+    apiGet<UserProfileResponseDto>('/profile/user')
 
   /**
    * Updates the currently authenticated player's profile.
    *
-   * @param nickname - The new nickname to update for the player.
+   * @param request - The user update data including email and optional names.
    *
-   * @returns A promise resolving to the updated player information as a `PlayerResponseDto`.
+   * @returns A promise resolving to the updated user information.
    */
-  const updateCurrentPlayer = (nickname: string): Promise<PlayerResponseDto> =>
-    apiPut<PlayerResponseDto>('/client/player', { nickname }).then(
-      (response) => {
-        notifySuccess(
-          'Nice! Your new nickname is locked in. Get ready to quiz in style!',
-        )
-        return response
-      },
-    )
+  const updateUserProfile = (
+    request: UpdateUserProfileRequestDto,
+  ): Promise<UserProfileResponseDto> =>
+    apiPut<UserProfileResponseDto>('/profile/user', {
+      email: request.email,
+      givenName: request.givenName,
+      familyName: request.familyName,
+      defaultNickname: request.defaultNickname,
+    }).then((response) => {
+      notifySuccess(
+        'Nice! Your new profile is locked in. Get ready to quiz in style!',
+      )
+      return response
+    })
 
   /**
    * Retrieves the quizzes associated with the current player.
@@ -527,8 +533,8 @@ export const useQuizServiceClient = () => {
   return {
     login,
     register,
-    getCurrentPlayer,
-    updateCurrentPlayer,
+    getUserProfile,
+    updateUserProfile,
     getCurrentPlayerQuizzes,
     createQuiz,
     getQuiz,

--- a/packages/quiz/src/components/Page/Page.tsx
+++ b/packages/quiz/src/components/Page/Page.tsx
@@ -70,7 +70,7 @@ const Page: React.FC<PageProps> = ({
     }
     return (
       <>
-        <MenuItem icon={faUser} link="/player/profile">
+        <MenuItem icon={faUser} link="/profile/user">
           Profile
         </MenuItem>
         <MenuItem icon={faLightbulb} link="/player/quizzes">

--- a/packages/quiz/src/main.tsx
+++ b/packages/quiz/src/main.tsx
@@ -90,7 +90,7 @@ const router = createBrowserRouter([
         ),
       },
       {
-        path: '/player/profile',
+        path: '/profile/user',
         element: (
           <ProtectedRoute>
             <ProfilePage />

--- a/packages/quiz/src/pages/ProfilePage/ProfilePage.tsx
+++ b/packages/quiz/src/pages/ProfilePage/ProfilePage.tsx
@@ -1,17 +1,50 @@
-import React, { FC } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import React, { FC, useState } from 'react'
 
 import { useQuizServiceClient } from '../../api/use-quiz-service-client.tsx'
+import { LoadingSpinner, Page } from '../../components'
 
-import { ProfilePageUI } from './components'
+import { ProfilePageUI, UpdateUserProfileFormFields } from './components'
 
 const ProfilePage: FC = () => {
-  const { updateCurrentPlayer } = useQuizServiceClient()
+  const { getUserProfile, updateUserProfile } = useQuizServiceClient()
 
-  const handleNicknameChange = (nickname: string): void => {
-    updateCurrentPlayer(nickname).then(() => {})
+  const [isSavingUserProfile, setIsSavingUserProfile] = useState(false)
+
+  const {
+    data,
+    isLoading: isLoadingUserProfile,
+    isError,
+  } = useQuery({
+    queryKey: ['myUserProfile'],
+    queryFn: getUserProfile,
+  })
+
+  const handleChange = (request: UpdateUserProfileFormFields): void => {
+    setIsSavingUserProfile(true)
+    updateUserProfile(request).finally(() => setIsSavingUserProfile(false))
   }
 
-  return <ProfilePageUI onNicknameChange={handleNicknameChange} />
+  if (!data || isLoadingUserProfile || isError) {
+    return (
+      <Page profile>
+        <LoadingSpinner />
+      </Page>
+    )
+  }
+
+  return (
+    <ProfilePageUI
+      values={{
+        email: data.email,
+        givenName: data.givenName,
+        familyName: data.familyName,
+        defaultNickname: data.defaultNickname,
+      }}
+      loading={isLoadingUserProfile || isSavingUserProfile}
+      onChange={handleChange}
+    />
+  )
 }
 
 export default ProfilePage

--- a/packages/quiz/src/pages/ProfilePage/components/ProfilePageUI/ProfilePageUI.module.scss
+++ b/packages/quiz/src/pages/ProfilePage/components/ProfilePageUI/ProfilePageUI.module.scss
@@ -3,29 +3,20 @@
 
 .profileDetailsForm {
   display: flex;
-  flex-direction: row;
+  flex-direction: column;
 
   @include helpers.mobile {
-    column-gap: variables.$mobile-narrow-layout-gutter;
+    row-gap: variables.$mobile-narrow-layout-gutter;
     width: 100%;
   }
 
   @include helpers.tablet {
-    column-gap: variables.$tablet-narrow-layout-gutter;
+    row-gap: variables.$tablet-narrow-layout-gutter;
     width: variables.$mobile-width;
   }
 
   @include helpers.desktop {
-    column-gap: variables.$desktop-narrow-layout-gutter;
+    row-gap: variables.$desktop-narrow-layout-gutter;
     width: variables.$mobile-width;
-  }
-
-  .column {
-    display: flex;
-    flex-direction: column;
-
-    &.full {
-      flex: 1;
-    }
   }
 }

--- a/packages/quiz/src/pages/ProfilePage/components/ProfilePageUI/ProfilePageUI.stories.tsx
+++ b/packages/quiz/src/pages/ProfilePage/components/ProfilePageUI/ProfilePageUI.stories.tsx
@@ -17,6 +17,8 @@ type Story = StoryObj<typeof meta>
 
 export const Default = {
   args: {
-    onNicknameChange: () => undefined,
+    values: { email: '', givenName: '', familyName: '', defaultNickname: '' },
+    loading: false,
+    onChange: () => undefined,
   },
 } satisfies Story

--- a/packages/quiz/src/pages/ProfilePage/components/ProfilePageUI/ProfilePageUI.test.tsx
+++ b/packages/quiz/src/pages/ProfilePage/components/ProfilePageUI/ProfilePageUI.test.tsx
@@ -9,7 +9,16 @@ describe('ProfilePageUI', () => {
   it('should render ProfilePageUI', async () => {
     const { container } = render(
       <MemoryRouter>
-        <ProfilePageUI onNicknameChange={() => undefined} />
+        <ProfilePageUI
+          values={{
+            email: '',
+            givenName: '',
+            familyName: '',
+            defaultNickname: '',
+          }}
+          loading={false}
+          onChange={() => undefined}
+        />
       </MemoryRouter>,
     )
 

--- a/packages/quiz/src/pages/ProfilePage/components/ProfilePageUI/ProfilePageUI.tsx
+++ b/packages/quiz/src/pages/ProfilePage/components/ProfilePageUI/ProfilePageUI.tsx
@@ -1,64 +1,164 @@
 import { faFloppyDisk } from '@fortawesome/free-solid-svg-icons'
 import {
+  EMAIL_MAX_LENGTH,
+  EMAIL_MIN_LENGTH,
+  EMAIL_REGEX,
+  FAMILY_NAME_MAX_LENGTH,
+  FAMILY_NAME_MIN_LENGTH,
+  FAMILY_NAME_REGEX,
+  GIVEN_NAME_MAX_LENGTH,
+  GIVEN_NAME_MIN_LENGTH,
+  GIVEN_NAME_REGEX,
   PLAYER_NICKNAME_MAX_LENGTH,
   PLAYER_NICKNAME_MIN_LENGTH,
   PLAYER_NICKNAME_REGEX,
 } from '@quiz/common'
-import React, { FC, FormEvent, useState } from 'react'
+import { UpdateUserProfileRequestDto } from '@quiz/common/src'
+import React, { FC, FormEvent, useEffect, useMemo, useState } from 'react'
 
 import { Button, Page, TextField, Typography } from '../../../../components'
-import { classNames } from '../../../../utils/helpers.ts'
 
 import styles from './ProfilePageUI.module.scss'
 
+export type UpdateUserProfileFormFields = UpdateUserProfileRequestDto
+
 export interface ProfilePageUIProps {
-  onNicknameChange: (nickname: string) => void
+  values: UpdateUserProfileFormFields
+  loading: boolean
+  onChange: (request: UpdateUserProfileFormFields) => void
 }
 
-const ProfilePageUI: FC<ProfilePageUIProps> = ({ onNicknameChange }) => {
-  const [tmpNickname, setTmpNickname] = useState<string | undefined>()
-  const [tmpNicknameValid, setTmpNicknameValid] = useState<boolean>(false)
+const ProfilePageUI: FC<ProfilePageUIProps> = ({
+  values,
+  loading,
+  onChange,
+}) => {
+  const [formFields, setFormFields] =
+    useState<UpdateUserProfileFormFields>(values)
+
+  useEffect(() => {
+    setFormFields(values)
+  }, [values])
+
+  const handleChangeFormField = <K extends keyof UpdateUserProfileFormFields>(
+    key: K,
+    value: UpdateUserProfileFormFields[K],
+  ) => {
+    setFormFields({ ...formFields, [key]: value })
+  }
+
+  const [validFormFields, setValidFormFields] = useState<{
+    [key in keyof UpdateUserProfileFormFields]: boolean
+  }>({
+    email: false,
+    givenName: false,
+    familyName: false,
+    defaultNickname: false,
+  })
+
+  useEffect(() => {
+    console.log(validFormFields)
+  }, [validFormFields])
+
+  const isFormValid = useMemo(
+    () => Object.values(validFormFields).every((valid) => !!valid),
+    [validFormFields],
+  )
+
+  const handleChangeValidFormField = <
+    K extends keyof UpdateUserProfileFormFields,
+  >(
+    key: K,
+    valid: boolean,
+  ) => {
+    if (validFormFields[key] !== valid) {
+      setValidFormFields((prevState) => {
+        return { ...prevState, [key]: valid }
+      })
+    }
+  }
 
   const handleSubmit = (event: FormEvent) => {
     event.preventDefault()
-
-    if (tmpNickname) {
-      onNicknameChange(tmpNickname)
-    }
+    onChange(formFields)
   }
 
   return (
     <Page align="start" discover profile>
-      <Typography variant="subtitle">Update Your Profile</Typography>
+      <Typography variant="subtitle">Shape your quiz identity</Typography>
       <Typography variant="text" size="medium">
-        Customize your player profile by updating your nickname. Your nickname
-        is how other players will see you in quizzes.
+        Update your personal details to keep your profile up to date. Your
+        information helps personalize your quiz experience and lets others
+        recognize you during games.
       </Typography>
       <form className={styles.profileDetailsForm} onSubmit={handleSubmit}>
-        <div className={classNames(styles.column, styles.full)}>
-          <TextField
-            id="nickname"
-            type="text"
-            placeholder="Nickname"
-            value={tmpNickname ?? ''}
-            minLength={PLAYER_NICKNAME_MIN_LENGTH}
-            maxLength={PLAYER_NICKNAME_MAX_LENGTH}
-            regex={PLAYER_NICKNAME_REGEX}
-            onChange={(value) => setTmpNickname(value as string)}
-            onValid={setTmpNicknameValid}
-            required
-          />
-        </div>
-        <div className={styles.column}>
-          <Button
-            id="update-player-button"
-            type="submit"
-            kind="call-to-action"
-            size="normal"
-            icon={faFloppyDisk}
-            disabled={!tmpNicknameValid}
-          />
-        </div>
+        <TextField
+          id="email"
+          type="text"
+          placeholder="Email"
+          value={formFields.email}
+          minLength={EMAIL_MIN_LENGTH}
+          maxLength={EMAIL_MAX_LENGTH}
+          regex={EMAIL_REGEX}
+          disabled={loading}
+          onChange={(value) => handleChangeFormField('email', value as string)}
+          onValid={(valid) => handleChangeValidFormField('email', valid)}
+          required
+        />
+        <TextField
+          id="givenName"
+          type="text"
+          placeholder="Given Name"
+          value={formFields.givenName}
+          minLength={GIVEN_NAME_MIN_LENGTH}
+          maxLength={GIVEN_NAME_MAX_LENGTH}
+          regex={GIVEN_NAME_REGEX}
+          disabled={loading}
+          onChange={(value) =>
+            handleChangeFormField('givenName', value as string)
+          }
+          onValid={(valid) => handleChangeValidFormField('givenName', valid)}
+        />
+        <TextField
+          id="familyName"
+          type="text"
+          placeholder="Family Name"
+          value={formFields.familyName}
+          minLength={FAMILY_NAME_MIN_LENGTH}
+          maxLength={FAMILY_NAME_MAX_LENGTH}
+          regex={FAMILY_NAME_REGEX}
+          disabled={loading}
+          onChange={(value) =>
+            handleChangeFormField('familyName', value as string)
+          }
+          onValid={(valid) => handleChangeValidFormField('familyName', valid)}
+        />
+        <TextField
+          id="defaultNickname"
+          type="text"
+          placeholder="Default Nickname"
+          value={formFields.defaultNickname}
+          minLength={PLAYER_NICKNAME_MIN_LENGTH}
+          maxLength={PLAYER_NICKNAME_MAX_LENGTH}
+          regex={PLAYER_NICKNAME_REGEX}
+          disabled={loading}
+          onChange={(value) =>
+            handleChangeFormField('defaultNickname', value as string)
+          }
+          onValid={(valid) =>
+            handleChangeValidFormField('defaultNickname', valid)
+          }
+        />
+        <Button
+          id="update-user-button"
+          type="submit"
+          kind="call-to-action"
+          size="normal"
+          value="Save"
+          icon={faFloppyDisk}
+          loading={loading}
+          disabled={!isFormValid || loading}
+        />
       </form>
     </Page>
   )

--- a/packages/quiz/src/pages/ProfilePage/components/ProfilePageUI/__snapshots__/ProfilePageUI.test.tsx.snap
+++ b/packages/quiz/src/pages/ProfilePage/components/ProfilePageUI/__snapshots__/ProfilePageUI.test.tsx.snap
@@ -39,69 +39,121 @@ exports[`ProfilePageUI > should render ProfilePageUI 1`] = `
       <div
         class="typography subtitle full"
       >
-        Update Your Profile
+        Shape your quiz identity
       </div>
       <div
         class="typography text medium"
       >
-        Customize your player profile by updating your nickname. Your nickname is how other players will see you in quizzes.
+        Update your personal details to keep your profile up to date. Your information helps personalize your quiz experience and lets others recognize you during games.
       </div>
       <form
         class="profileDetailsForm"
       >
         <div
-          class="column full"
+          class="inputContainer"
         >
           <div
-            class="inputContainer"
+            class="textFieldInputContainer textFieldInputKindPrimary"
           >
-            <div
-              class="textFieldInputContainer textFieldInputKindPrimary"
-            >
-              <input
-                class="textfield"
-                data-testid="test-nickname-textfield"
-                id="nickname"
-                maxlength="20"
-                minlength="2"
-                name="nickname"
-                placeholder="Nickname"
-                type="text"
-                value=""
-              />
-            </div>
+            <input
+              class="textfield"
+              data-testid="test-email-textfield"
+              id="email"
+              maxlength="128"
+              minlength="6"
+              name="email"
+              placeholder="Email"
+              type="text"
+              value=""
+            />
           </div>
         </div>
         <div
-          class="column"
+          class="inputContainer"
         >
           <div
-            class="buttonInputContainer buttonInputKindCallToAction"
+            class="textFieldInputContainer textFieldInputKindPrimary"
           >
-            <button
-              data-testid="test-update-player-button-button"
-              disabled=""
-              id="update-player-button"
-              name="update-player-button"
-              type="submit"
-            >
-              <svg
-                aria-hidden="true"
-                class="svg-inline--fa fa-floppy-disk "
-                data-icon="floppy-disk"
-                data-prefix="fas"
-                focusable="false"
-                role="img"
-                viewBox="0 0 448 512"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M64 32C28.7 32 0 60.7 0 96L0 416c0 35.3 28.7 64 64 64l320 0c35.3 0 64-28.7 64-64l0-242.7c0-17-6.7-33.3-18.7-45.3L352 50.7C340 38.7 323.7 32 306.7 32L64 32zm0 96c0-17.7 14.3-32 32-32l192 0c17.7 0 32 14.3 32 32l0 64c0 17.7-14.3 32-32 32L96 224c-17.7 0-32-14.3-32-32l0-64zM224 288a64 64 0 1 1 0 128 64 64 0 1 1 0-128z"
-                  fill="currentColor"
-                />
-              </svg>
-            </button>
+            <input
+              class="textfield"
+              data-testid="test-givenName-textfield"
+              id="givenName"
+              maxlength="64"
+              minlength="1"
+              name="givenName"
+              placeholder="Given Name"
+              type="text"
+              value=""
+            />
           </div>
+        </div>
+        <div
+          class="inputContainer"
+        >
+          <div
+            class="textFieldInputContainer textFieldInputKindPrimary"
+          >
+            <input
+              class="textfield"
+              data-testid="test-familyName-textfield"
+              id="familyName"
+              maxlength="64"
+              minlength="1"
+              name="familyName"
+              placeholder="Family Name"
+              type="text"
+              value=""
+            />
+          </div>
+        </div>
+        <div
+          class="inputContainer"
+        >
+          <div
+            class="textFieldInputContainer textFieldInputKindPrimary"
+          >
+            <input
+              class="textfield"
+              data-testid="test-defaultNickname-textfield"
+              id="defaultNickname"
+              maxlength="20"
+              minlength="2"
+              name="defaultNickname"
+              placeholder="Default Nickname"
+              type="text"
+              value=""
+            />
+          </div>
+        </div>
+        <div
+          class="buttonInputContainer buttonInputKindCallToAction"
+        >
+          <button
+            data-testid="test-update-user-button-button"
+            disabled=""
+            id="update-user-button"
+            name="update-user-button"
+            type="submit"
+          >
+            <svg
+              aria-hidden="true"
+              class="svg-inline--fa fa-floppy-disk "
+              data-icon="floppy-disk"
+              data-prefix="fas"
+              focusable="false"
+              role="img"
+              viewBox="0 0 448 512"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M64 32C28.7 32 0 60.7 0 96L0 416c0 35.3 28.7 64 64 64l320 0c35.3 0 64-28.7 64-64l0-242.7c0-17-6.7-33.3-18.7-45.3L352 50.7C340 38.7 323.7 32 306.7 32L64 32zm0 96c0-17.7 14.3-32 32-32l192 0c17.7 0 32 14.3 32 32l0 64c0 17.7-14.3 32-32 32L96 224c-17.7 0-32-14.3-32-32l0-64zM224 288a64 64 0 1 1 0 128 64 64 0 1 1 0-128z"
+                fill="currentColor"
+              />
+            </svg>
+            <span>
+              Save
+            </span>
+          </button>
         </div>
       </form>
     </div>

--- a/packages/quiz/src/pages/ProfilePage/components/ProfilePageUI/index.ts
+++ b/packages/quiz/src/pages/ProfilePage/components/ProfilePageUI/index.ts
@@ -1,2 +1,5 @@
-export type { ProfilePageUIProps } from './ProfilePageUI'
+export type {
+  UpdateUserProfileFormFields,
+  ProfilePageUIProps,
+} from './ProfilePageUI'
 export { default } from './ProfilePageUI'

--- a/packages/quiz/src/pages/ProfilePage/components/index.ts
+++ b/packages/quiz/src/pages/ProfilePage/components/index.ts
@@ -1,2 +1,5 @@
-export type { ProfilePageUIProps } from './ProfilePageUI'
+export type {
+  UpdateUserProfileFormFields,
+  ProfilePageUIProps,
+} from './ProfilePageUI'
 export { default as ProfilePageUI } from './ProfilePageUI'

--- a/packages/quiz/src/pages/QuizDetailsPage/QuizDetailsPage.tsx
+++ b/packages/quiz/src/pages/QuizDetailsPage/QuizDetailsPage.tsx
@@ -25,7 +25,7 @@ const QuizDetailsPage: FC = () => {
 
   useEffect(() => {
     if (hasQuizLoadingError) {
-      navigate('/player/profile')
+      navigate('/profile/user')
     }
   }, [hasQuizLoadingError, navigate])
 
@@ -54,7 +54,7 @@ const QuizDetailsPage: FC = () => {
     if (quizId) {
       setIsDeleteQuizLoading(true)
       deleteQuiz(quizId)
-        .then(() => navigate('/player/profile'))
+        .then(() => navigate('/profile/user'))
         .finally(() => setIsDeleteQuizLoading(false))
     }
   }


### PR DESCRIPTION
- Rename all “player” profile hooks and routes to “user” (e.g. `/player/profile` → `/profile/user`)
- Replace single-nickname form with full user-profile editor (email, given/family name, nickname)
- Simplify form layout to single column and update stories/tests to match
