### PR TITLE
feat(api): improve token refresh flow and loosen ApiPostBody type

### DIFF
--- a/packages/quiz/src/api/api-utils.ts
+++ b/packages/quiz/src/api/api-utils.ts
@@ -6,7 +6,7 @@ import { notifyError } from '../utils/notification.ts'
 /**
  * Represents the structure of a POST body for API requests.
  */
-export type ApiPostBody = { [key: string]: unknown }
+export type ApiPostBody = object
 
 /**
  * Represents an error that occurs during an API call.

--- a/packages/quiz/src/pages/ProfilePage/components/ProfilePageUI/ProfilePageUI.tsx
+++ b/packages/quiz/src/pages/ProfilePage/components/ProfilePageUI/ProfilePageUI.tsx
@@ -56,10 +56,6 @@ const ProfilePageUI: FC<ProfilePageUIProps> = ({
     defaultNickname: false,
   })
 
-  useEffect(() => {
-    console.log(validFormFields)
-  }, [validFormFields])
-
   const isFormValid = useMemo(
     () => Object.values(validFormFields).every((valid) => !!valid),
     [validFormFields],


### PR DESCRIPTION
- Change ApiPostBody from `{ [key: string]: unknown }` to `object` so DTOs (e.g. AuthRefreshRequestDto) can be passed directly
- Import and use `isTokenExpired` in `apiFetch` to pre-emptively refresh expired access tokens (skipping /auth/refresh itself)
- Add dedicated `refresh()` helper to centralize `/auth/refresh` calls and `setAuth()` updates
- Enhance `apiFetch` to retry once on 401 with a fresh token
- Remove stray debug `useEffect` from ProfilePageUI