### PR TITLE
chore(auth): extend default refresh token expiration to 30 days

### DIFF
--- a/packages/quiz-service/src/auth/services/utils/token.constants.ts
+++ b/packages/quiz-service/src/auth/services/utils/token.constants.ts
@@ -1,6 +1,6 @@
 import { Authority } from '@quiz/common'
 
-export const DEFAULT_REFRESH_TOKEN_EXPIRATION_TIME = '15m'
+export const DEFAULT_REFRESH_TOKEN_EXPIRATION_TIME = '30d'
 export const DEFAULT_ACCESS_TOKEN_EXPIRATION_TIME = '15m'
 
 export const DEFAULT_GAME_AUTHORITIES: Authority[] = [Authority.Game]


### PR DESCRIPTION
- Change DEFAULT_REFRESH_TOKEN_EXPIRATION_TIME from '15m' to '30d' in token.constants.ts

This update allows refresh tokens to remain valid for 30 days by default, improving session longevity.