### PR TITLE
refactor(quiz): rename player quizzes to profile quizzes

### DIFF
--- a/packages/quiz/src/api/use-quiz-service-client.tsx
+++ b/packages/quiz/src/api/use-quiz-service-client.tsx
@@ -236,19 +236,19 @@ export const useQuizServiceClient = () => {
     })
 
   /**
-   * Retrieves the quizzes associated with the current player.
+   * Retrieves the quizzes associated with the current user.
    *
    * @param options.limit - The maximum number of quizzes to retrieve per page.
    * @param options.offset - The number of quizzes to skip before starting retrieval.
    *
    * @returns A promise resolving to the quizzes in a paginated format as a `PaginatedQuizResponseDto`.
    */
-  const getCurrentPlayerQuizzes = (options: {
+  const getProfileQuizzes = (options: {
     limit: number
     offset: number
   }): Promise<PaginatedQuizResponseDto> =>
     apiGet<PaginatedQuizResponseDto>(
-      `/client/quizzes${parseQueryParams(options)}`,
+      `/profile/quizzes${parseQueryParams(options)}`,
     )
 
   /**
@@ -541,7 +541,7 @@ export const useQuizServiceClient = () => {
     register,
     getUserProfile,
     updateUserProfile,
-    getCurrentPlayerQuizzes,
+    getProfileQuizzes,
     createQuiz,
     getQuiz,
     getPublicQuizzes,

--- a/packages/quiz/src/components/Page/Page.tsx
+++ b/packages/quiz/src/components/Page/Page.tsx
@@ -72,7 +72,7 @@ const Page: React.FC<PageProps> = ({
         <MenuItem icon={faUser} link="/profile/user">
           Profile
         </MenuItem>
-        <MenuItem icon={faLightbulb} link="/player/quizzes">
+        <MenuItem icon={faLightbulb} link="/profile/quizzes">
           Quizzes
         </MenuItem>
         <MenuItem icon={faClockRotateLeft} link="/game/history">

--- a/packages/quiz/src/main.tsx
+++ b/packages/quiz/src/main.tsx
@@ -97,7 +97,7 @@ const router = createBrowserRouter([
         ),
       },
       {
-        path: '/player/quizzes',
+        path: '/profile/quizzes',
         element: (
           <ProtectedRoute>
             <QuizzesPage />

--- a/packages/quiz/src/pages/QuizCreatorPage/QuizCreatorPage.tsx
+++ b/packages/quiz/src/pages/QuizCreatorPage/QuizCreatorPage.tsx
@@ -158,11 +158,11 @@ const QuizCreatorPage: FC = () => {
 
     if (quizId) {
       updateQuiz(quizId, requestData)
-        .then(() => navigate('/player/quizzes'))
+        .then(() => navigate('/profile/quizzes'))
         .finally(() => setIsSavingQuiz(false))
     } else {
       createQuiz(requestData)
-        .then(() => navigate('/player/quizzes'))
+        .then(() => navigate('/profile/quizzes'))
         .finally(() => setIsSavingQuiz(false))
     }
   }

--- a/packages/quiz/src/pages/QuizzesPage/QuizzesPage.tsx
+++ b/packages/quiz/src/pages/QuizzesPage/QuizzesPage.tsx
@@ -16,7 +16,7 @@ import { QuizzesPageUI } from './components'
 const QuizzesPage: FC = () => {
   const navigate = useNavigate()
 
-  const { getCurrentPlayerQuizzes } = useQuizServiceClient()
+  const { getProfileQuizzes } = useQuizServiceClient()
 
   const [searchParams, setSearchParams] = useState<{
     search?: string
@@ -31,8 +31,8 @@ const QuizzesPage: FC = () => {
   }>({ limit: DEFAULT_QUIZ_PAGINATION_LIMIT, offset: 0 })
 
   const { data, isLoading, isError } = useQuery({
-    queryKey: ['currentPlayerQuizzes', searchParams],
-    queryFn: () => getCurrentPlayerQuizzes(searchParams),
+    queryKey: ['myProfileQuizzes', searchParams],
+    queryFn: () => getProfileQuizzes(searchParams),
   })
 
   return (


### PR DESCRIPTION
- Rename getCurrentPlayerQuizzes → getProfileQuizzes and update its signature
- Change API endpoint from `/client/quizzes` to `/profile/quizzes`
- Update menu link in Page.tsx from `/player/quizzes` → `/profile/quizzes`
- Adjust router path in main.tsx to `/profile/quizzes`
- Update redirects in QuizCreatorPage to navigate to `/profile/quizzes`
- Replace queryKey 'currentPlayerQuizzes' with 'myProfileQuizzes' in QuizzesPage
