### PR TITLE
feat(auth): integrate EventEmitter and user login events

### DIFF
--- a/packages/quiz-service/src/auth/auth.module.ts
+++ b/packages/quiz-service/src/auth/auth.module.ts
@@ -3,6 +3,7 @@ import { readFileSync } from 'fs'
 import { Module } from '@nestjs/common'
 import { ConfigModule, ConfigService } from '@nestjs/config'
 import { APP_GUARD } from '@nestjs/core'
+import { EventEmitterModule } from '@nestjs/event-emitter'
 import { JwtModule } from '@nestjs/jwt'
 import * as jwt from 'jsonwebtoken'
 
@@ -46,6 +47,7 @@ import { AuthService } from './services'
         }
       },
     }),
+    EventEmitterModule,
     GameModule,
     UserModule,
   ],

--- a/packages/quiz-service/src/auth/services/auth.service.spec.ts
+++ b/packages/quiz-service/src/auth/services/auth.service.spec.ts
@@ -1,0 +1,64 @@
+import { EventEmitter2 } from '@nestjs/event-emitter'
+
+import { AuthService } from './auth.service'
+import { USER_LOGIN_EVENT_KEY } from './utils'
+
+describe('AuthService', () => {
+  let service: AuthService
+  let eventEmitter: EventEmitter2
+  let logger: { error: jest.Mock }
+
+  beforeEach(() => {
+    // We only care about emitUserLoginEvent, so other deps can be dummy objects.
+    eventEmitter = new EventEmitter2()
+    logger = { error: jest.fn() }
+
+    service = new AuthService(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      /* userService    */ {} as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      /* gameRepository */ {} as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      /* jwtService     */ {} as any,
+      /* eventEmitter   */ eventEmitter,
+    )
+
+    // Override the internal logger so we can spy on .error()
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(service as any).logger = logger
+  })
+
+  describe('emitUserLoginEvent', () => {
+    it('should emit a UserLoginEvent with correct payload', async () => {
+      const emitSpy = jest.spyOn(eventEmitter, 'emit')
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await (service as any).emitUserLoginEvent('user-123')
+
+      expect(emitSpy).toHaveBeenCalledWith(
+        USER_LOGIN_EVENT_KEY,
+        expect.objectContaining({
+          userId: 'user-123',
+          date: expect.any(Date),
+        }),
+      )
+      expect(logger.error).not.toHaveBeenCalled()
+    })
+
+    it('should catch and log errors thrown by eventEmitter.emit', async () => {
+      jest.spyOn(eventEmitter, 'emit').mockImplementation(() => {
+        throw new Error('boom happened')
+      })
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await (service as any).emitUserLoginEvent('user-456')
+
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.stringContaining(
+          `Failed to emit user login event for userId 'user-456': 'boom happened.'`,
+        ),
+        expect.any(String), // stack trace
+      )
+    })
+  })
+})

--- a/packages/quiz-service/src/auth/services/models/index.ts
+++ b/packages/quiz-service/src/auth/services/models/index.ts
@@ -1,0 +1,1 @@
+export * from './user-login.event'

--- a/packages/quiz-service/src/auth/services/models/user-login.event.ts
+++ b/packages/quiz-service/src/auth/services/models/user-login.event.ts
@@ -1,0 +1,10 @@
+/**
+ * Payload for the UserLoginEvent, emitted whenever a user successfully logs in.
+ *
+ * @property userId  - The unique identifier of the user that just logged in.
+ * @property date    - The exact date and time when the login occurred.
+ */
+export interface UserLoginEvent {
+  userId: string
+  date: Date
+}

--- a/packages/quiz-service/src/auth/services/utils/event.constants.ts
+++ b/packages/quiz-service/src/auth/services/utils/event.constants.ts
@@ -1,0 +1,4 @@
+/**
+ * The event key under which UserLoginEvent payloads are emitted and listened for.
+ */
+export const USER_LOGIN_EVENT_KEY = 'user.login'

--- a/packages/quiz-service/src/auth/services/utils/index.ts
+++ b/packages/quiz-service/src/auth/services/utils/index.ts
@@ -1,2 +1,3 @@
+export * from './event.constants'
 export * from './token.constants'
 export * from './token.utils'

--- a/packages/quiz-service/src/user/services/index.ts
+++ b/packages/quiz-service/src/user/services/index.ts
@@ -1,2 +1,3 @@
 export * from './user.repository'
 export * from './user.service'
+export * from './user-event.handler'

--- a/packages/quiz-service/src/user/services/models/schemas/user.schema.ts
+++ b/packages/quiz-service/src/user/services/models/schemas/user.schema.ts
@@ -58,6 +58,13 @@ export class User {
   defaultNickname?: string
 
   /**
+   * Date and time of the user's last successful login.
+   * This field is updated by listening to UserLoginEvent.
+   */
+  @Prop({ type: Date, required: false })
+  lastLoggedInAt?: Date
+
+  /**
    * Timestamp when the user was created (ISO-8601 string).
    */
   @Prop({ type: Date, default: now() })

--- a/packages/quiz-service/src/user/services/user-event.handler.ts
+++ b/packages/quiz-service/src/user/services/user-event.handler.ts
@@ -1,0 +1,49 @@
+import { Injectable, Logger } from '@nestjs/common'
+import { OnEvent } from '@nestjs/event-emitter'
+
+import { UserLoginEvent } from '../../auth/services/models'
+import { USER_LOGIN_EVENT_KEY } from '../../auth/services/utils'
+
+import { UserRepository } from './user.repository'
+
+/**
+ * Handles domain events related to users.
+ *
+ * Currently listens for the UserLoginEvent to update each user's last-logged-in timestamp.
+ */
+@Injectable()
+export class UserEventHandler {
+  // Logger instance for recording event handler operations.
+  private readonly logger: Logger = new Logger(UserEventHandler.name)
+
+  /**
+   * Initializes the UserEventHandler.
+   *
+   * @param userRepository  - Repository for user data access.
+   */
+  constructor(private readonly userRepository: UserRepository) {}
+
+  /**
+   * Handles a UserLoginEvent by updating the corresponding user’s `lastLoggedInAt` field.
+   *
+   * @param event  - The UserLoginEvent containing the user's ID and the login timestamp.
+   */
+  @OnEvent(USER_LOGIN_EVENT_KEY)
+  public async handleUserLoginEvent(event: UserLoginEvent) {
+    this.logger.debug(
+      `Handling 'UserLoginEvent' for user with id '${event.userId}'.`,
+    )
+
+    try {
+      await this.userRepository.findUserByIdAndUpdateOrThrow(event.userId, {
+        lastLoggedInAt: event.date,
+      })
+    } catch (error) {
+      const { message, stack } = error as Error
+      this.logger.error(
+        `Failed to update user '${event.userId}' with last login timestamp: '${message}'.`,
+        stack,
+      )
+    }
+  }
+}

--- a/packages/quiz-service/src/user/user.module.ts
+++ b/packages/quiz-service/src/user/user.module.ts
@@ -1,9 +1,10 @@
 import { Module } from '@nestjs/common'
+import { EventEmitterModule } from '@nestjs/event-emitter'
 import { MongooseModule } from '@nestjs/mongoose'
 import { AuthProvider } from '@quiz/common'
 
 import { UserController, UserProfileController } from './controllers'
-import { UserRepository, UserService } from './services'
+import { UserEventHandler, UserRepository, UserService } from './services'
 import { LocalUserSchema, User, UserSchema } from './services/models/schemas'
 
 /**
@@ -18,9 +19,10 @@ import { LocalUserSchema, User, UserSchema } from './services/models/schemas'
         discriminators: [{ name: AuthProvider.Local, schema: LocalUserSchema }],
       },
     ]),
+    EventEmitterModule,
   ],
   controllers: [UserController, UserProfileController],
-  providers: [UserService, UserRepository],
+  providers: [UserService, UserRepository, UserEventHandler],
   exports: [UserService, UserRepository],
 })
 export class UserModule {}


### PR DESCRIPTION
- Import EventEmitterModule in AuthModule and UserModule to enable event publishing
- Add private emitUserLoginEvent() in AuthService to wrap event emission with error handling
- Invoke emitUserLoginEvent() on successful login and token refresh for TokenScope.User
- Define UserLoginEvent interface and USER_LOGIN_EVENT_KEY constant for event payloads
- Extend User schema with lastLoggedInAt and implement UserEventHandler to update it on login events
- Add Jest tests for emitUserLoginEvent covering both emit success and error‐logging paths