### PR TITLE
feat(auth): support Game TokenScope alongside User and add comprehensive JSDoc

### DIFF
--- a/packages/quiz/.storybook/mockAuthContext.tsx
+++ b/packages/quiz/.storybook/mockAuthContext.tsx
@@ -1,17 +1,62 @@
+import { Authority, GameParticipantType } from '@quiz/common'
 import { PartialStoryFn } from '@storybook/core/csf'
 import type { Decorator, ReactRenderer, StoryContext } from '@storybook/react'
 import React from 'react'
 
 import { AuthContext, AuthContextType } from '../src/context/auth'
 
+/**
+ * Storybook decorator supplying a mock AuthContext with dummy tokens
+ * and authentication flags for rendering components in isolation.
+ */
 const mockAuth: AuthContextType = {
-  accessToken: 'MOCK',
-  refreshToken: 'MOCK',
-  isLoggedIn: true,
-  setAuth: () => undefined,
-  logout: () => undefined,
+  user: {
+    ACCESS: {
+      sub: 'MOCK',
+      exp: -1,
+      authorities: [
+        Authority.Game,
+        Authority.User,
+        Authority.Quiz,
+        Authority.Media,
+      ],
+      token: 'MOCK',
+    },
+    REFRESH: {
+      sub: 'MOCK',
+      exp: -1,
+      authorities: [Authority.RefreshAuth],
+      token: 'MOCK',
+    },
+  },
+  game: {
+    ACCESS: {
+      sub: 'MOCK',
+      exp: -1,
+      authorities: [Authority.Game],
+      token: 'MOCK',
+      gameId: 'MOCK',
+      participantType: GameParticipantType.HOST,
+    },
+    REFRESH: {
+      sub: 'MOCK',
+      exp: -1,
+      authorities: [Authority.RefreshAuth],
+      token: 'MOCK',
+      gameId: 'MOCK',
+      participantType: GameParticipantType.HOST,
+    },
+  },
+  isUserAuthenticated: true,
+  isGameAuthenticated: true,
+  setTokenPair: () => undefined,
+  revokeUser: () => undefined,
+  revokeGame: () => undefined,
 }
 
+/**
+ * Wraps a story in AuthContext.Provider using `mockAuth`.
+ */
 export const withMockAuth: Decorator = (
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   Story: PartialStoryFn<ReactRenderer, any>,

--- a/packages/quiz/src/components/Page/Page.tsx
+++ b/packages/quiz/src/components/Page/Page.tsx
@@ -41,7 +41,7 @@ const Page: React.FC<PageProps> = ({
   footer,
   children,
 }) => {
-  const { isLoggedIn, logout } = useAuthContext()
+  const { isUserAuthenticated, revokeUser } = useAuthContext()
 
   const navigate = useNavigate()
 
@@ -59,7 +59,7 @@ const Page: React.FC<PageProps> = ({
   const toggleMobileMenu = () => setMobileMenuOpen((prev) => !prev)
 
   const profileMenuItems = useMemo(() => {
-    if (!isLoggedIn || !profile) {
+    if (!isUserAuthenticated || !profile) {
       return null
     }
     return (
@@ -74,12 +74,12 @@ const Page: React.FC<PageProps> = ({
           Games
         </MenuItem>
         <MenuSeparator />
-        <MenuItem icon={faRightFromBracket} onClick={logout}>
+        <MenuItem icon={faRightFromBracket} onClick={revokeUser}>
           Logout
         </MenuItem>
       </>
     )
-  }, [profile, isLoggedIn, logout])
+  }, [profile, isUserAuthenticated, revokeUser])
 
   return (
     <div className={styles.main}>
@@ -89,15 +89,15 @@ const Page: React.FC<PageProps> = ({
           <span className={styles.text}>Klurigo</span>
         </button>
         <div className={styles.side}>
-          {isLoggedIn && discover && !isMobile && (
+          {isUserAuthenticated && discover && !isMobile && (
             <Link to="/discover">Discover</Link>
           )}
-          {!isLoggedIn && <Link to="/auth/login">Login</Link>}
-          {isLoggedIn && discover && header && !isMobile && (
+          {!isUserAuthenticated && <Link to="/auth/login">Login</Link>}
+          {isUserAuthenticated && discover && header && !isMobile && (
             <div className={styles.verticalLine} />
           )}
           {header}
-          {isLoggedIn && profile && !isMobile && (
+          {isUserAuthenticated && profile && !isMobile && (
             <div
               className={styles.menuButtonWrapper}
               ref={profileMenuButtonRef}>
@@ -112,7 +112,7 @@ const Page: React.FC<PageProps> = ({
               </Menu>
             </div>
           )}
-          {isLoggedIn && isMobile && (discover || profile) && (
+          {isUserAuthenticated && isMobile && (discover || profile) && (
             <div className={styles.menuButtonWrapper} ref={mobileMenuButtonRef}>
               <button onClick={toggleMobileMenu} type="button">
                 <img src={Bars} alt="Menu" />

--- a/packages/quiz/src/components/ProtectedRoute/ProtectedRoute.tsx
+++ b/packages/quiz/src/components/ProtectedRoute/ProtectedRoute.tsx
@@ -1,20 +1,61 @@
-import React, { FC } from 'react'
+import { TokenScope } from '@quiz/common'
+import React, { FC, useMemo } from 'react'
 import { Navigate } from 'react-router-dom'
 
 import { useAuthContext } from '../../context/auth'
 
+/**
+ * Props for the ProtectedRoute component which guards access to a route
+ * based on the user’s authentication state in a given scope.
+ *
+ * @property scope - Which TokenScope to check (TokenScope.User or TokenScope.Game). Defaults to User.
+ * @property authenticated  - If true, the route is only accessible when authenticated;
+ *                            if false, it’s only accessible when _not_ authenticated. Defaults to true.
+ * @property children - The React elements to render when access is allowed.
+ */
 export interface ProtectedRouteProps {
+  scope?: TokenScope
+  authenticated?: boolean
   children: React.ReactNode
 }
 
-const ProtectedRoute: FC<ProtectedRouteProps> = ({ children }) => {
-  const auth = useAuthContext()
+/**
+ * Conditionally renders the given children or redirects to the root path,
+ * based on whether the user meets the authentication requirements.
+ *
+ * @param scope - The TokenScope to validate (defaults to TokenScope.User).
+ * @param authenticated - Whether the route requires being authenticated (defaults to true).
+ * @param children - The component(s) to render when access is permitted.
+ * @returns The children if allowed, otherwise a <Navigate> to "/".
+ */
+const ProtectedRoute: FC<ProtectedRouteProps> = ({
+  scope = TokenScope.User,
+  authenticated = true,
+  children,
+}) => {
+  /**
+   * Retrieve the current authentication flags for User and Game scopes
+   * from our AuthContext.
+   */
+  const { isUserAuthenticated, isGameAuthenticated } = useAuthContext()
 
-  if (!auth.isLoggedIn) {
+  /**
+   * Determine whether we should redirect away from this route.
+   *
+   * - If `authenticated` is true, we redirect when the user is _not_ allowed.
+   * - If `authenticated` is false, we redirect when the user _is_ allowed.
+   */
+  const shouldRedirect = useMemo(() => {
+    const isAllowed =
+      scope === TokenScope.Game ? isGameAuthenticated : isUserAuthenticated
+    return authenticated ? !isAllowed : isAllowed
+  }, [scope, authenticated, isUserAuthenticated, isGameAuthenticated])
+
+  if (shouldRedirect) {
     return <Navigate to="/" replace />
   }
 
-  return children
+  return <>{children}</>
 }
 
 export default ProtectedRoute

--- a/packages/quiz/src/context/auth/auth-context.tsx
+++ b/packages/quiz/src/context/auth/auth-context.tsx
@@ -1,3 +1,4 @@
+import { TokenScope } from '@quiz/common'
 import { createContext } from 'react'
 
 import { AuthState } from '../../models'
@@ -6,30 +7,38 @@ import { AuthState } from '../../models'
  * AuthContextType defines the shape of authentication-related data
  * and actions available throughout the app.
  *
- * @property accessToken - The current access authentication token, if any.
- * @property refreshToken - The current refresh authentication token, if any.
- * @property isLoggedIn - Indicates whether a user is currently authenticated.
- * @property setAuth - Function to update the authentication state.
- * @property logout - Function to log out the user by revoking tokens and clearing state.
+ * @property user               Decoded token payloads for the User scope.
+ * @property game               Decoded token payloads for the Game scope.
+ * @property isUserAuthenticated Indicates if the User scope has valid tokens.
+ * @property isGameAuthenticated Indicates if the Game scope has valid tokens.
+ * @property setTokenPair       Function to store new tokens for a given scope.
+ * @property revokeUser         Function to revoke User-scope tokens.
+ * @property revokeGame         Function to revoke Game-scope tokens.
  */
 export type AuthContextType = {
-  accessToken?: string
-  refreshToken?: string
-  isLoggedIn: boolean
-  setAuth: (auth?: AuthState) => void
-  logout: () => void
+  user?: AuthState[TokenScope.User]
+  game?: AuthState[TokenScope.Game]
+  isUserAuthenticated: boolean
+  isGameAuthenticated: boolean
+  setTokenPair: (
+    scope: TokenScope,
+    accessToken: string,
+    refreshToken: string,
+  ) => void
+  revokeUser: () => void
+  revokeGame: () => void
 }
 
 /**
- * A React context providing authentication-related state and functions.
- *
- * This context holds the user's tokens, login status, and methods to
- * update authentication or log out.
+ * React context providing authentication state (tokens + flags)
+ * and actions (setTokenPair, revokeUser/Game).
  */
 export const AuthContext = createContext<AuthContextType>({
-  accessToken: undefined,
-  refreshToken: undefined,
-  isLoggedIn: false,
-  setAuth: () => undefined,
-  logout: () => undefined,
+  user: undefined,
+  game: undefined,
+  isUserAuthenticated: false,
+  isGameAuthenticated: false,
+  setTokenPair: () => undefined,
+  revokeUser: () => undefined,
+  revokeGame: () => undefined,
 })

--- a/packages/quiz/src/context/game/GameContextProvider.tsx
+++ b/packages/quiz/src/context/game/GameContextProvider.tsx
@@ -4,6 +4,7 @@ import { FullScreen, useFullScreenHandle } from 'react-full-screen'
 
 import { useQuizServiceClient } from '../../api/use-quiz-service-client.tsx'
 import { useGameIDQueryParam } from '../../utils/use-game-id-query-param.tsx'
+import { useAuthContext } from '../auth'
 
 import { GameContext, GameContextType } from './game-context.tsx'
 
@@ -27,6 +28,7 @@ export interface GameContextProviderProps {
  * @returns A React component wrapping its children with the `GameContext` provider.
  */
 const GameContextProvider: FC<GameContextProviderProps> = ({ children }) => {
+  const { revokeGame } = useAuthContext()
   const [gameID] = useGameIDQueryParam()
 
   const {
@@ -51,7 +53,9 @@ const GameContextProvider: FC<GameContextProviderProps> = ({ children }) => {
       submitQuestionAnswer: (request) =>
         gameID ? submitQuestionAnswer(gameID, request) : Promise.reject(),
       leaveGame: (playerID: string) =>
-        gameID ? leaveGame(gameID, playerID) : Promise.reject(),
+        gameID
+          ? leaveGame(gameID, playerID).then(revokeGame)
+          : Promise.reject(),
       addCorrectAnswer: (answer: QuestionCorrectAnswerDto) =>
         gameID ? addCorrectAnswer(gameID, answer) : Promise.reject(),
       deleteCorrectAnswer: (answer: QuestionCorrectAnswerDto) =>
@@ -68,6 +72,7 @@ const GameContextProvider: FC<GameContextProviderProps> = ({ children }) => {
       leaveGame,
       addCorrectAnswer,
       deleteCorrectAnswer,
+      revokeGame,
     ],
   )
 

--- a/packages/quiz/src/main.tsx
+++ b/packages/quiz/src/main.tsx
@@ -1,3 +1,4 @@
+import { TokenScope } from '@quiz/common'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import React, { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
@@ -44,11 +45,19 @@ const router = createBrowserRouter([
       },
       {
         path: '/auth/login',
-        element: <LoginPage />,
+        element: (
+          <ProtectedRoute authenticated={false}>
+            <LoginPage />
+          </ProtectedRoute>
+        ),
       },
       {
         path: '/auth/register',
-        element: <CreateUserPage />,
+        element: (
+          <ProtectedRoute authenticated={false}>
+            <CreateUserPage />
+          </ProtectedRoute>
+        ),
       },
       {
         path: '/discover',
@@ -61,15 +70,17 @@ const router = createBrowserRouter([
       {
         path: '/join',
         element: (
-          <GameContextProvider>
-            <JoinPage />
-          </GameContextProvider>
+          <ProtectedRoute scope={TokenScope.Game}>
+            <GameContextProvider>
+              <JoinPage />
+            </GameContextProvider>
+          </ProtectedRoute>
         ),
       },
       {
         path: '/game',
         element: (
-          <ProtectedRoute>
+          <ProtectedRoute scope={TokenScope.Game}>
             <GameContextProvider>
               <GamePage />
             </GameContextProvider>

--- a/packages/quiz/src/models/authState.ts
+++ b/packages/quiz/src/models/authState.ts
@@ -1,4 +1,23 @@
-export interface AuthState {
-  accessToken?: string
-  refreshToken?: string
-}
+import { GameTokenDto, TokenDto, TokenScope, TokenType } from '@quiz/common'
+
+/**
+ * Represents the decoded payload for a token in a given scope.
+ *
+ * @template S The TokenScope (User or Game) whose claims are included.
+ */
+export type ScopePayload<S extends TokenScope> = (S extends TokenScope.User
+  ? Pick<TokenDto, 'sub' | 'exp' | 'authorities'>
+  : Pick<
+      GameTokenDto,
+      'sub' | 'exp' | 'authorities' | 'gameId' | 'participantType'
+    >) & { token: string }
+
+/**
+ * In-memory authentication state mapping each TokenScope to its
+ * decoded payloads, keyed by TokenType.
+ */
+export type AuthState = Partial<{
+  [S in TokenScope]: {
+    [T in TokenType]: ScopePayload<S>
+  }
+}>

--- a/packages/quiz/src/pages/HomePage/HomePage.tsx
+++ b/packages/quiz/src/pages/HomePage/HomePage.tsx
@@ -25,7 +25,7 @@ const MESSAGES = [
 ]
 
 const HomePage: FC = () => {
-  const { isLoggedIn } = useAuthContext()
+  const { isUserAuthenticated } = useAuthContext()
 
   const navigate = useNavigate()
 
@@ -85,7 +85,7 @@ const HomePage: FC = () => {
           disabled={!gamePINValid}
         />
       </form>
-      {isLoggedIn ? (
+      {isUserAuthenticated ? (
         <Link to={'/quiz/create'}>
           <Typography variant="link" size="small">
             Create your own quiz and challenge others!


### PR DESCRIPTION
- Extend AuthContext, useQuizServiceClient, ProtectedRoute, Page and HomePage to handle both User and Game scopes with isUserAuthenticated/isGameAuthenticated flags
- Introduce getToken helper and setTokenPair to centralize token handling
- Update mockAuthContext to include game scope tokens and participantType
- Replace legacy isLoggedIn/logout with scope-aware revokeUser/revokeGame methods
- Wrap children in ProtectedRoute with fragment and switch on scope for redirection
- Add detailed JSDoc comments for all public interfaces, hooks, and decorators
