### PR TITLE
feat(auth): handle revoked and missing refresh tokens as unauthorized

### DIFF
--- a/packages/quiz-service/src/auth/exceptions/index.ts
+++ b/packages/quiz-service/src/auth/exceptions/index.ts
@@ -1,0 +1,1 @@
+export * from './token-not-found.exception'

--- a/packages/quiz-service/src/auth/exceptions/token-not-found.exception.ts
+++ b/packages/quiz-service/src/auth/exceptions/token-not-found.exception.ts
@@ -1,0 +1,12 @@
+import { NotFoundException } from '@nestjs/common'
+
+/**
+ * Thrown when the token was not found by its unique identifier (HTTP 404).
+ *
+ * @extends {NotFoundException}
+ */
+export class TokenNotFoundException extends NotFoundException {
+  constructor(id: string) {
+    super(`Token with id '${id}' was not found`)
+  }
+}

--- a/packages/quiz-service/src/auth/services/auth.service.ts
+++ b/packages/quiz-service/src/auth/services/auth.service.ts
@@ -159,6 +159,17 @@ export class AuthService {
       throw new UnauthorizedException()
     }
 
+    try {
+      await this.tokenRepository.findByIdOrThrow(payload.jti)
+    } catch (error) {
+      const { message, stack } = error as Error
+      this.logger.debug(
+        `Unable to retrieve existing refresh token: '${message}'.`,
+        stack,
+      )
+      throw new UnauthorizedException()
+    }
+
     if (!payload.authorities.includes(Authority.RefreshAuth)) {
       this.logger.debug(
         `Failed to refresh token since missing '${Authority.RefreshAuth}' authority.`,
@@ -199,7 +210,7 @@ export class AuthService {
     try {
       const { jti } = this.jwtService.decode<TokenDto>(token)
 
-      const document = await this.tokenRepository.findByIdOrThrow(jti)
+      const document = await this.tokenRepository.findById(jti)
       if (document) {
         return this.tokenRepository.deleteByPairId(document.pairId)
       }

--- a/packages/quiz-service/src/auth/services/token.repository.ts
+++ b/packages/quiz-service/src/auth/services/token.repository.ts
@@ -1,6 +1,8 @@
 import { Injectable, Logger } from '@nestjs/common'
 import { InjectModel } from '@nestjs/mongoose'
 
+import { TokenNotFoundException } from '../exceptions'
+
 import { Token, TokenModel } from './models/schemas'
 
 /**
@@ -37,8 +39,24 @@ export class TokenRepository {
    * @param id – The JWT ID (`jti`) of the token.
    * @returns The matching Token document or `null` if not found.
    */
-  public async findByIdOrThrow(id: string): Promise<Token | null> {
+  public async findById(id: string): Promise<Token | null> {
     return this.tokenModel.findById(id)
+  }
+
+  /**
+   * Retrieves a token document by its unique identifier, or throws if not found.
+   *
+   * @param id – The JWT ID (`jti`) of the token.
+   * @returns The matching Token document.
+   * @throws TokenNotFoundException if no token exists with the given `id`.
+   */
+  public async findByIdOrThrow(id: string): Promise<Token | null> {
+    const document = await this.findById(id)
+    if (!document) {
+      this.logger.warn(`Token was not found by id '${id}.`)
+      throw new TokenNotFoundException(id)
+    }
+    return document
   }
 
   /**


### PR DESCRIPTION
- Introduce TokenNotFoundException and export it from auth/exceptions
- Add TokenRepository.findByIdOrThrow() to throw when a token ID is not found
- Update AuthService:
  - Catch missing token errors and throw UnauthorizedException
  - Decode and delete refresh tokens using findById instead of throwing on delete
- Change expired-token E2E test to expect 401 Unauthorized instead of 400 Bad Request
- Add new E2E test to assert revoked refresh tokens return 401 Unauthorized