### PR TITLE
refactor(auth): rename AuthLoginResponseDto to AuthResponseDto

### DIFF
--- a/packages/common/src/models/auth.ts
+++ b/packages/common/src/models/auth.ts
@@ -23,9 +23,9 @@ export interface AuthLoginRequestDto {
 }
 
 /**
- * Data transfer object for authentication login responses.
+ * Data transfer object for authentication responses.
  */
-export interface AuthLoginResponseDto {
+export interface AuthResponseDto {
   /**
    * JWT access token—short-lived credential for resource access.
    */

--- a/packages/quiz-service/src/auth/controllers/auth.controller.ts
+++ b/packages/quiz-service/src/auth/controllers/auth.controller.ts
@@ -27,8 +27,8 @@ import { AuthService } from '../services'
 import { IpAddress, Public, UserAgent } from './decorators'
 import {
   AuthLoginRequest,
-  AuthLoginResponse,
   AuthRefreshRequest,
+  AuthResponse,
   AuthRevokeRequest,
 } from './models'
 
@@ -52,7 +52,7 @@ export class AuthController {
    * @param authLoginRequest - Request containing the user's email and password.
    * @param ipAddress - The client's IP address, extracted via the `@IpAddress()` decorator.
    * @param userAgent - The client's User-Agent header, extracted via the `@UserAgent()` decorator.
-   * @returns Promise resolving to an AuthLoginResponse with both tokens.
+   * @returns Promise resolving to an AuthResponse with both tokens.
    */
   @Public()
   @Post('/login')
@@ -67,7 +67,7 @@ export class AuthController {
   })
   @ApiOkResponse({
     description: 'Returns the issued access and refresh tokens.',
-    type: AuthLoginResponse,
+    type: AuthResponse,
   })
   @ApiBadRequestResponse({
     description: 'Validation failed or credentials are incorrect.',
@@ -77,7 +77,7 @@ export class AuthController {
     @Body() authLoginRequest: AuthLoginRequest,
     @IpAddress() ipAddress: string,
     @UserAgent() userAgent: string,
-  ): Promise<AuthLoginResponse> {
+  ): Promise<AuthResponse> {
     return this.authService.login(authLoginRequest, ipAddress, userAgent)
   }
 
@@ -106,7 +106,7 @@ export class AuthController {
     example: '123456',
   })
   @ApiOkResponse({
-    type: AuthLoginResponse,
+    type: AuthResponse,
     description: 'Game access and refresh tokens.',
   })
   @ApiBadRequestResponse({ description: 'Invalid game PIN format.' })
@@ -117,7 +117,7 @@ export class AuthController {
     @IpAddress() ipAddress: string,
     @UserAgent() userAgent: string,
     @Headers('Authorization') authorization?: string,
-  ): Promise<AuthLoginResponse> {
+  ): Promise<AuthResponse> {
     const optionalUserId =
       await this.extractUserIdFromAuthorizationHeader(authorization)
     return this.authService.authenticateGame(
@@ -135,7 +135,7 @@ export class AuthController {
    * @param authRefreshRequest - Request containing the existing refresh token.
    * @param ipAddress - The client's IP address, extracted via the `@IpAddress()` decorator.
    * @param userAgent - The client's User-Agent header, extracted via the `@UserAgent()` decorator.
-   * @returns Promise resolving to an AuthLoginResponse with new tokens.
+   * @returns Promise resolving to an AuthResponse with new tokens.
    */
   @Public()
   @Post('/refresh')
@@ -151,7 +151,7 @@ export class AuthController {
   @ApiOkResponse({
     description:
       'Returns a new access token and, if rotated, a new refresh token.',
-    type: AuthLoginResponse,
+    type: AuthResponse,
   })
   @ApiBadRequestResponse({
     description: 'Validation failed.',
@@ -164,7 +164,7 @@ export class AuthController {
     @Body() authRefreshRequest: AuthRefreshRequest,
     @IpAddress() ipAddress: string,
     @UserAgent() userAgent: string,
-  ): Promise<AuthLoginResponse> {
+  ): Promise<AuthResponse> {
     return this.authService.refresh(authRefreshRequest, ipAddress, userAgent)
   }
 

--- a/packages/quiz-service/src/auth/controllers/models/auth.response.ts
+++ b/packages/quiz-service/src/auth/controllers/models/auth.response.ts
@@ -1,10 +1,10 @@
 import { ApiProperty } from '@nestjs/swagger'
-import { AuthLoginResponseDto } from '@quiz/common'
+import { AuthResponseDto } from '@quiz/common'
 
 /**
  * Response object for successful login.
  */
-export class AuthLoginResponse implements AuthLoginResponseDto {
+export class AuthResponse implements AuthResponseDto {
   /**
    * JWT access token for use in protected requests.
    */

--- a/packages/quiz-service/src/auth/controllers/models/index.ts
+++ b/packages/quiz-service/src/auth/controllers/models/index.ts
@@ -1,4 +1,4 @@
+export * from './auth.response'
 export * from './auth-login.request'
-export * from './auth-login.response'
 export * from './auth-refresh.request'
 export * from './auth-revoke.request'

--- a/packages/quiz-service/src/auth/services/auth.service.ts
+++ b/packages/quiz-service/src/auth/services/auth.service.ts
@@ -3,9 +3,9 @@ import { EventEmitter2 } from '@nestjs/event-emitter'
 import { JwtService } from '@nestjs/jwt'
 import {
   AuthLoginRequestDto,
-  AuthLoginResponseDto,
   Authority,
   AuthRefreshRequestDto,
+  AuthResponseDto,
   GameParticipantType,
   GameTokenDto,
   TokenDto,
@@ -58,14 +58,14 @@ export class AuthService {
    * @param authLoginRequestDto - DTO containing the user's email and password.
    * @param ipAddress - The client's IP address, used for logging and token metadata.
    * @param userAgent - The client's User-Agent string, used for logging and token metadata.
-   * @returns Promise resolving to an AuthLoginResponseDto with access & refresh tokens.
+   * @returns Promise resolving to an AuthResponseDto with access & refresh tokens.
    * @throws BadCredentialsException if credentials are invalid.
    */
   public async login(
     authLoginRequestDto: AuthLoginRequestDto,
     ipAddress: string,
     userAgent: string,
-  ): Promise<AuthLoginResponseDto> {
+  ): Promise<AuthResponseDto> {
     const { _id: userId } = await this.userService.verifyUserCredentialsOrThrow(
       authLoginRequestDto.email,
       authLoginRequestDto.password,
@@ -98,7 +98,7 @@ export class AuthService {
     ipAddress: string,
     userAgent: string,
     userId?: string,
-  ): Promise<AuthLoginResponseDto> {
+  ): Promise<AuthResponseDto> {
     const game = await this.gameRepository.findGameByPINOrThrow(gamePIN)
     const gameId = game._id
 
@@ -139,14 +139,14 @@ export class AuthService {
    * @param authRefreshRequestDto - DTO containing the refresh token.
    * @param ipAddress - The client's IP address, used for logging and token metadata.
    * @param userAgent - The client's User-Agent string, used for logging and token metadata.
-   * @returns Promise resolving to an AuthLoginResponseDto with fresh tokens.
+   * @returns Promise resolving to an AuthResponseDto with fresh tokens.
    * @throws UnauthorizedException if token is invalid or missing REFRESH_AUTH authority.
    */
   public async refresh(
     authRefreshRequestDto: AuthRefreshRequestDto,
     ipAddress: string,
     userAgent: string,
-  ): Promise<AuthLoginResponseDto> {
+  ): Promise<AuthResponseDto> {
     let payload: TokenDto
 
     try {
@@ -228,7 +228,7 @@ export class AuthService {
    * @param ipAddress - The client's IP address to record in the token metadata.
    * @param userAgent - The client's User-Agent string to record in the token metadata.
    * @param additionalClaims - Extra payload (e.g. gameId, participantType).
-   * @returns Promise resolving to AuthLoginResponseDto with both tokens.
+   * @returns Promise resolving to AuthResponseDto with both tokens.
    * @private
    */
   private async signTokenPair(
@@ -237,7 +237,7 @@ export class AuthService {
     ipAddress: string,
     userAgent: string,
     additionalClaims?: Record<string, unknown>,
-  ): Promise<AuthLoginResponseDto> {
+  ): Promise<AuthResponseDto> {
     const pairId = uuidv4()
 
     const accessToken = await this.signToken(

--- a/packages/quiz/src/api/use-quiz-service-client.tsx
+++ b/packages/quiz/src/api/use-quiz-service-client.tsx
@@ -1,7 +1,7 @@
 import {
   AuthLoginRequestDto,
-  AuthLoginResponseDto,
   AuthRefreshRequestDto,
+  AuthResponseDto,
   AuthRevokeRequestDto,
   CreateGameResponseDto,
   CreateUserRequestDto,
@@ -194,8 +194,8 @@ export const useQuizServiceClient = () => {
    *
    * @returns A promise that resolves to the login response with access and refresh tokens.
    */
-  const login = (request: AuthLoginRequestDto): Promise<AuthLoginResponseDto> =>
-    apiPost<AuthLoginResponseDto>('/auth/login', {
+  const login = (request: AuthLoginRequestDto): Promise<AuthResponseDto> =>
+    apiPost<AuthResponseDto>('/auth/login', {
       email: request.email,
       password: request.password,
     }).then((loginAuthResponse) => {
@@ -214,10 +214,8 @@ export const useQuizServiceClient = () => {
    *
    * @returns A promise that resolves to the login response with access and refresh tokens.
    */
-  const refresh = (
-    request: AuthRefreshRequestDto,
-  ): Promise<AuthLoginResponseDto> =>
-    apiPost<AuthLoginResponseDto>('/auth/refresh', request)
+  const refresh = (request: AuthRefreshRequestDto): Promise<AuthResponseDto> =>
+    apiPost<AuthResponseDto>('/auth/refresh', request)
 
   /**
    * Revokes the specified authentication token.


### PR DESCRIPTION
- Update DTO interface and documentation in common models (packages/common/src/models/auth.ts)
- Change interface name from `AuthLoginResponseDto` to `AuthResponseDto` and adjust JSDoc
- Update all imports and references in AuthController:
  - Method signatures, return types, and Swagger annotations now use `AuthResponse`/`AuthResponseDto`
- Rename `auth-login.response.ts` to `auth.response.ts` and class `AuthLoginResponse` to `AuthResponse`
- Update model exports in controllers’ index to export `AuthResponse` only
- Modify AuthService methods to return `AuthResponseDto` instead of `AuthLoginResponseDto`
- Adjust client hook `useQuizServiceClient` to use `AuthResponseDto` for login and refresh calls
