### PR TITLE
feat(auth): implement password‐change flow

### DIFF
--- a/packages/common/src/models/auth.ts
+++ b/packages/common/src/models/auth.ts
@@ -71,3 +71,20 @@ export interface AuthRevokeRequestDto {
    */
   readonly token: string
 }
+
+/**
+ * Data Transfer Object for a password change request.
+ *
+ * Contains the user’s current password for verification and the desired new password.
+ */
+export interface AuthPasswordChangeRequestDto {
+  /**
+   * The user’s current password.
+   */
+  readonly oldPassword: string
+
+  /**
+   * The new password the user wants to set.
+   */
+  readonly newPassword: string
+}

--- a/packages/quiz-service/src/auth/controllers/models/auth-password-change.request.ts
+++ b/packages/quiz-service/src/auth/controllers/models/auth-password-change.request.ts
@@ -1,0 +1,54 @@
+import { ApiProperty } from '@nestjs/swagger'
+import {
+  AuthPasswordChangeRequestDto,
+  PASSWORD_MAX_LENGTH,
+  PASSWORD_MIN_LENGTH,
+  PASSWORD_REGEX,
+} from '@quiz/common'
+import { Matches, MaxLength, MinLength } from 'class-validator'
+
+/**
+ * Request object for changing a user’s password.
+ *
+ * Contains the user’s current password (for verification) and the new password to set.
+ */
+export class AuthPasswordChangeRequest implements AuthPasswordChangeRequestDto {
+  /**
+   * The user’s current password, used to verify their identity before allowing a change.
+   */
+  @ApiProperty({
+    title: 'Old Password',
+    description:
+      'The user’s existing password; must match their current credentials.',
+    type: String,
+    pattern: PASSWORD_REGEX.source,
+    example: 'Super#SecretPa$$w0rd123',
+  })
+  @MinLength(PASSWORD_MIN_LENGTH)
+  @MaxLength(PASSWORD_MAX_LENGTH)
+  @Matches(PASSWORD_REGEX, {
+    message:
+      'Old password must include at least 2 uppercase letters, 2 lowercase letters, 2 digits, and 2 symbols.',
+  })
+  readonly oldPassword: string
+
+  /**
+   * The new password the user wants to set.
+   * Must meet complexity requirements: 8–128 chars, ≥2 uppercase, ≥2 lowercase, ≥2 digits, ≥2 symbols.
+   */
+  @ApiProperty({
+    title: 'New Password',
+    description:
+      'The new password to apply; 8–128 chars, min 2 uppercase, 2 lowercase, 2 digits, 2 symbols.',
+    type: String,
+    pattern: PASSWORD_REGEX.source,
+    example: 'Tr0ub4dor&3NewP@ssw0rd!',
+  })
+  @MinLength(PASSWORD_MIN_LENGTH)
+  @MaxLength(PASSWORD_MAX_LENGTH)
+  @Matches(PASSWORD_REGEX, {
+    message:
+      'New password must include at least 2 uppercase letters, 2 lowercase letters, 2 digits, and 2 symbols.',
+  })
+  readonly newPassword: string
+}

--- a/packages/quiz-service/src/auth/controllers/models/index.ts
+++ b/packages/quiz-service/src/auth/controllers/models/index.ts
@@ -1,4 +1,6 @@
 export * from './auth.response'
+export * from './auth-game.request'
 export * from './auth-login.request'
+export * from './auth-password-change.request'
 export * from './auth-refresh.request'
 export * from './auth-revoke.request'

--- a/packages/quiz-service/src/user/controllers/user.controller.e2e-spec.ts
+++ b/packages/quiz-service/src/user/controllers/user.controller.e2e-spec.ts
@@ -3,7 +3,7 @@ import supertest from 'supertest'
 
 import {
   MOCK_DEFAULT_HASHED_PASSWORD,
-  MOCK_DEFAULT_PASSWORD,
+  MOCK_PRIMARY_PASSWORD,
   MOCK_PRIMARY_USER_DEFAULT_NICKNAME,
   MOCK_PRIMARY_USER_EMAIL,
   MOCK_PRIMARY_USER_FAMILY_NAME,
@@ -31,7 +31,7 @@ describe('UserController (e2e)', () => {
         .post(`/api/users`)
         .send({
           email: MOCK_PRIMARY_USER_EMAIL,
-          password: MOCK_DEFAULT_PASSWORD,
+          password: MOCK_PRIMARY_PASSWORD,
           givenName: MOCK_PRIMARY_USER_GIVEN_NAME,
           familyName: MOCK_PRIMARY_USER_FAMILY_NAME,
           defaultNickname: MOCK_PRIMARY_USER_DEFAULT_NICKNAME,
@@ -127,7 +127,7 @@ describe('UserController (e2e)', () => {
         .post(`/api/users`)
         .send({
           email: MOCK_PRIMARY_USER_EMAIL,
-          password: MOCK_DEFAULT_PASSWORD,
+          password: MOCK_PRIMARY_PASSWORD,
           givenName: MOCK_PRIMARY_USER_GIVEN_NAME,
           familyName: MOCK_PRIMARY_USER_FAMILY_NAME,
           defaultNickname: MOCK_PRIMARY_USER_DEFAULT_NICKNAME,

--- a/packages/quiz-service/test-utils/data/user.data.ts
+++ b/packages/quiz-service/test-utils/data/user.data.ts
@@ -23,10 +23,12 @@ export const MOCK_QUATERNARY_USER_GIVEN_NAME = 'Quaternary'
 export const MOCK_QUATERNARY_USER_FAMILY_NAME = 'User'
 export const MOCK_QUATERNARY_USER_DEFAULT_NICKNAME = 'PuddingPop'
 
-export const MOCK_DEFAULT_PASSWORD = 'Super#SecretPa$$w0rd123'
-export const MOCK_DEFAULT_INVALID_PASSWORD = 'Super#$ecretPassw0rd123'
+export const MOCK_PRIMARY_PASSWORD = 'Super#SecretPa$$w0rd123'
+export const MOCK_PRIMARY_INVALID_PASSWORD = 'Super#$ecretPassw0rd123'
 export const MOCK_DEFAULT_HASHED_PASSWORD =
   '$2b$10$.xzhAfwhLmb2Nbe5i2jRB.j4IUuWqnDvgUuQ/AZ/unHhOPJcJyVJ6'
+export const MOCK_SECONDARY_PASSWORD = 'Tr0ub4dor&3NewP@ssw0rd!'
+export const MOCK_WEAK_PASSWORD = 'not-a-strong-password'
 
 export function buildMockPrimaryUser(
   user?: Partial<User & LocalUser>,


### PR DESCRIPTION
- add AuthPasswordChangeRequestDto to common models
- create AuthPasswordChangeRequest class with class-validator rules and Swagger decorators
- extend AuthController with PATCH /api/auth/password endpoint, complete with @ApiOperation, 204/400/401/403 responses
- implement UserService.changePassword: verify old password, hash new one, throw BadRequest or Forbidden, and add logging
- update e2e specs: rename mock password constants (PRIMARY_INVALID, PRIMARY, SECONDARY, WEAK), adjust describe headers, and add comprehensive password-change tests
- update test-utils data: introduce MOCK_PRIMARY_INVALID_PASSWORD, MOCK_SECONDARY_PASSWORD, MOCK_WEAK_PASSWORD