### PR TITLE
feat(user-auth): add optional unverifiedEmail to LocalUser

### DIFF
--- a/packages/quiz-service/src/user/repositories/models/schemas/user.schema.ts
+++ b/packages/quiz-service/src/user/repositories/models/schemas/user.schema.ts
@@ -156,6 +156,12 @@ export class LocalUser implements IUser {
   email: string
 
   /**
+   * The user’s unverified email address (optional).
+   */
+  @Prop({ type: String, required: false })
+  unverifiedEmail?: string
+
+  /**
    * The user’s hashed password for a local account.
    */
   @Prop({ type: String, required: true })

--- a/packages/quiz-service/src/user/repositories/user.repository.ts
+++ b/packages/quiz-service/src/user/repositories/user.repository.ts
@@ -5,7 +5,7 @@ import { v4 as uuidv4 } from 'uuid'
 
 import { EmailNotUniqueException, UserNotFoundException } from '../exceptions'
 
-import { User, UserModel } from './models/schemas'
+import { LocalUser, User, UserModel } from './models'
 
 /**
  * Repository for interacting with the User collection in the database.
@@ -81,17 +81,16 @@ export class UserRepository {
    * @param details - Object containing email, hashedPassword, givenName and familyName.
    * @returns The newly created User document.
    */
-  public async createLocalUser(details: {
-    email: string
-    hashedPassword: string
-    givenName?: string
-    familyName?: string
-    defaultNickname?: string
-  }): Promise<User> {
+  public async createLocalUser(
+    details: Omit<
+      LocalUser,
+      '_id' | 'authProvider' | 'createdAt' | 'updatedAt'
+    >,
+  ): Promise<User> {
     return new this.userModel({
+      ...details,
       _id: uuidv4(),
       authProvider: AuthProvider.Local,
-      ...details,
     }).save()
   }
 

--- a/packages/quiz-service/src/user/services/user.service.ts
+++ b/packages/quiz-service/src/user/services/user.service.ts
@@ -93,8 +93,9 @@ export class UserService {
       CreateUserRequestDto,
       'email' | 'givenName' | 'familyName' | 'defaultNickname'
     > &
-      Pick<LocalUser, 'hashedPassword'> = {
+      Pick<LocalUser, 'unverifiedEmail' | 'hashedPassword'> = {
       email,
+      unverifiedEmail: email,
       hashedPassword,
       givenName,
       familyName,


### PR DESCRIPTION
- Introduce `unverifiedEmail?` to the LocalUser schema with `@Prop({ type: String, required: false })`
- Refactor `UserRepository.createLocalUser` to accept a `LocalUser` DTO (omitting `_id`, `authProvider`, `createdAt`, `updatedAt`)
- Initialize `unverifiedEmail` in `UserService` to track users’ pending email verification