### PR TITLE
feat(quiz-service): support email verification tokens and welcome emails

### DIFF
--- a/packages/common/src/models/authority.enum.ts
+++ b/packages/common/src/models/authority.enum.ts
@@ -30,4 +30,9 @@ export enum Authority {
    * retrieving and updating their profiles.
    */
   User = 'USER',
+
+  /**
+   * Permission to allow generation and validation of email-verification tokens.
+   */
+  VerifyEmail = 'VERIFY_EMAIL',
 }

--- a/packages/quiz-service/.env.development
+++ b/packages/quiz-service/.env.development
@@ -16,3 +16,5 @@ JWT_SECRET=super_secret
 PEXELS_API_KEY=XXX
 
 UPLOAD_DIRECTORY=./public/uploads
+
+KLURIGO_URL=http://localhost:3000

--- a/packages/quiz-service/.env.production
+++ b/packages/quiz-service/.env.production
@@ -10,3 +10,5 @@ MONGODB_PORT=27017
 MONGODB_DB=klurigo_prod
 
 UPLOAD_DIRECTORY=/uploads
+
+KLURIGO_URL=https://klurigo.com

--- a/packages/quiz-service/.env.test
+++ b/packages/quiz-service/.env.test
@@ -17,3 +17,5 @@ PEXELS_API_KEY=XXX
 UPLOAD_DIRECTORY=./public/uploads
 
 EMAIL_ENABLED=false
+
+KLURIGO_URL=http://test

--- a/packages/quiz-service/src/app/app.module.ts
+++ b/packages/quiz-service/src/app/app.module.ts
@@ -63,6 +63,7 @@ const isTestEnv = process.env.NODE_ENV === 'test'
         EMAIL_ENABLED: Joi.boolean().default(true),
         EMAIL_USERNAME: Joi.string().optional(),
         EMAIL_PASSWORD: Joi.string().optional(),
+        KLURIGO_URL: Joi.string().required(),
       }),
       isGlobal: true,
     }),

--- a/packages/quiz-service/src/app/config/environment.ts
+++ b/packages/quiz-service/src/app/config/environment.ts
@@ -19,4 +19,5 @@ export interface EnvironmentVariables {
   EMAIL_ENABLED: boolean
   EMAIL_USERNAME: string
   EMAIL_PASSWORD: string
+  KLURIGO_URL: string
 }

--- a/packages/quiz-service/src/auth/auth.module.ts
+++ b/packages/quiz-service/src/auth/auth.module.ts
@@ -1,6 +1,6 @@
 import { readFileSync } from 'fs'
 
-import { Module } from '@nestjs/common'
+import { forwardRef, Module } from '@nestjs/common'
 import { ConfigModule, ConfigService } from '@nestjs/config'
 import { APP_GUARD } from '@nestjs/core'
 import { EventEmitterModule } from '@nestjs/event-emitter'
@@ -57,7 +57,7 @@ import { Token, TokenSchema } from './services/models/schemas'
     ]),
     EventEmitterModule,
     GameModule,
-    UserModule,
+    forwardRef(() => UserModule),
   ],
   controllers: [AuthController],
   providers: [

--- a/packages/quiz-service/src/auth/services/auth.service.ts
+++ b/packages/quiz-service/src/auth/services/auth.service.ts
@@ -1,4 +1,10 @@
-import { Injectable, Logger, UnauthorizedException } from '@nestjs/common'
+import {
+  forwardRef,
+  Inject,
+  Injectable,
+  Logger,
+  UnauthorizedException,
+} from '@nestjs/common'
 import { EventEmitter2 } from '@nestjs/event-emitter'
 import { JwtService } from '@nestjs/jwt'
 import {
@@ -47,6 +53,7 @@ export class AuthService {
    * @param eventEmitter - EventEmitter2 instance for emitting authentication-related events.
    */
   constructor(
+    @Inject(forwardRef(() => UserService))
     private readonly userService: UserService,
     private readonly gameRepository: GameRepository,
     private readonly tokenRepository: TokenRepository,
@@ -349,6 +356,33 @@ export class AuthService {
     })
 
     return token
+  }
+
+  /**
+   * Signs a JWT token for email verification.
+   *
+   * Generates a token with the `VERIFY_EMAIL` authority that expires in 72 hours.
+   *
+   * @param subject – The user ID (JWT `sub` claim) for whom the token is issued.
+   * @param email   – The email address to include in the token payload.
+   * @returns A promise that resolves to the signed verification token string.
+   */
+  public async signVerifyEmailToken(
+    subject: string,
+    email: string,
+  ): Promise<string> {
+    return this.jwtService.signAsync(
+      {
+        scope: TokenScope.User,
+        authorities: [Authority.VerifyEmail],
+        email,
+      },
+      {
+        jwtid: uuidv4(),
+        subject,
+        expiresIn: '72h',
+      },
+    )
   }
 
   /**

--- a/packages/quiz-service/src/email/services/email.service.ts
+++ b/packages/quiz-service/src/email/services/email.service.ts
@@ -34,7 +34,7 @@ export class EmailService {
    *   - `html`: HTML body of the email.
    * @returns A promise that resolves when the email has been sent.
    */
-  public async sendEmail(
+  private async sendEmail(
     options: Pick<ISendMailOptions, 'to' | 'subject' | 'text' | 'html'>,
   ) {
     if (this.configService.get('EMAIL_ENABLED') === false) {
@@ -50,5 +50,46 @@ export class EmailService {
       const { message, stack } = error as Error
       this.logger.error(`Failed to send email: '${message}'.`, stack)
     }
+  }
+
+  /**
+   * Sends a welcome email containing a verification link to a new user.
+   *
+   * @param to               – Recipient’s email address.
+   * @param verificationLink – URL the user clicks to verify their email.
+   * @returns A promise that resolves when the welcome email has been sent.
+   */
+  public async sendWelcomeEmail(to: string, verificationLink: string) {
+    this.logger.log(`Sending welcome email to ${to}.`)
+
+    const text = `Hi,
+
+Thank you for signing up for Klurigo. We’re thrilled to have you on board!
+
+Please verify your email address by clicking or copying the link below into your browser:
+${verificationLink}
+
+If you didn’t create this account, simply ignore this email.
+
+Cheers,  
+The Klurigo Team`
+
+    const html = `<p>Hi,</p>
+
+<p>Thank you for signing up for Klurigo. We’re thrilled to have you on board!</p>
+
+<p>Please verify your email address by clicking or copying the link below into your browser:</p>
+<a href="${verificationLink}">${verificationLink}</a>
+
+<p>If you didn’t create this account, simply ignore this email.</p>
+
+<p>Cheers,<br />The Klurigo Team</p>`
+
+    await this.sendEmail({
+      to,
+      subject: 'Welcome to Klurigo!',
+      text,
+      html,
+    })
   }
 }

--- a/packages/quiz-service/src/user/user.module.ts
+++ b/packages/quiz-service/src/user/user.module.ts
@@ -1,7 +1,10 @@
-import { Module } from '@nestjs/common'
+import { forwardRef, Module } from '@nestjs/common'
 import { EventEmitterModule } from '@nestjs/event-emitter'
 import { MongooseModule } from '@nestjs/mongoose'
 import { AuthProvider } from '@quiz/common'
+
+import { AuthModule } from '../auth'
+import { EmailModule } from '../email'
 
 import { UserController, UserProfileController } from './controllers'
 import {
@@ -25,6 +28,8 @@ import { UserEventHandler, UserService } from './services'
       },
     ]),
     EventEmitterModule,
+    forwardRef(() => AuthModule),
+    EmailModule,
   ],
   controllers: [UserController, UserProfileController],
   providers: [UserService, UserRepository, UserEventHandler],


### PR DESCRIPTION
- Add `VERIFY_EMAIL` authority to common Authority enum for email verification.
- Introduce `KLURIGO_URL` env var in dev, prod, and test, and require it in AppModule config schema.
- Update AuthModule and UserModule to use forwardRef for circular imports.
- Extend AuthService with `signVerifyEmailToken()` to generate 72-hour email verification JWTs.
- Add `sendWelcomeEmail()` in EmailService and invoke it in UserService after user creation.
