### PR TITLE
feat(auth): add full JWT payload support and index signature for extra claims

### DIFF
--- a/packages/common/src/models/token.dto.ts
+++ b/packages/common/src/models/token.dto.ts
@@ -64,6 +64,14 @@ export interface TokenDto {
    * Determines which actions or endpoints the bearer is allowed to access.
    */
   authorities: Authority[]
+
+  /**
+   * Capture any extra JWT claims not explicitly defined in this interface.
+   *
+   * This index signature allows the payload to include arbitrary properties,
+   * ensuring that custom or non-standard claims can be safely represented.
+   */
+  [claim: string]: unknown
 }
 
 /**

--- a/packages/quiz-service/src/auth/controllers/decorators/auth/index.ts
+++ b/packages/quiz-service/src/auth/controllers/decorators/auth/index.ts
@@ -1,3 +1,4 @@
+export * from './jwt-payload.decorator'
 export * from './principal-id.decorator'
 export * from './principal.decorator'
 export * from './public.decorator'

--- a/packages/quiz-service/src/auth/controllers/decorators/auth/jwt-payload.decorator.ts
+++ b/packages/quiz-service/src/auth/controllers/decorators/auth/jwt-payload.decorator.ts
@@ -1,0 +1,25 @@
+import {
+  createParamDecorator,
+  ExecutionContext,
+  UnauthorizedException,
+} from '@nestjs/common'
+import { TokenDto } from '@quiz/common'
+
+import { AuthGuardRequest } from '../../../guards'
+
+/**
+ * Parameter decorator that extracts the full JWT payload from the request.
+ *
+ * Applies:
+ * - Retrieves the `TokenDto` payload attached by `AuthGuard`.
+ * - Throws `UnauthorizedException` if no payload is present.
+ */
+export const JwtPayload = createParamDecorator(
+  (data: unknown, ctx: ExecutionContext): TokenDto => {
+    const request = ctx.switchToHttp().getRequest<AuthGuardRequest<TokenDto>>()
+    if (!request.payload) {
+      throw new UnauthorizedException('Unauthorized')
+    }
+    return request.payload
+  },
+)

--- a/packages/quiz-service/src/auth/controllers/decorators/auth/principal-id.decorator.ts
+++ b/packages/quiz-service/src/auth/controllers/decorators/auth/principal-id.decorator.ts
@@ -3,6 +3,7 @@ import {
   ExecutionContext,
   UnauthorizedException,
 } from '@nestjs/common'
+import { TokenDto } from '@quiz/common'
 
 import { AuthGuardRequest } from '../../../guards'
 
@@ -26,10 +27,10 @@ import { AuthGuardRequest } from '../../../guards'
  */
 export const PrincipalId = createParamDecorator(
   (_unused: unknown, ctx: ExecutionContext): string => {
-    const req = ctx.switchToHttp().getRequest<AuthGuardRequest>()
-    if (!req.principalId) {
+    const req = ctx.switchToHttp().getRequest<AuthGuardRequest<TokenDto>>()
+    if (!req.payload.sub) {
       throw new UnauthorizedException('Missing principalId on request')
     }
-    return req.principalId
+    return req.payload.sub
   },
 )

--- a/packages/quiz-service/src/auth/controllers/decorators/auth/principal.decorator.ts
+++ b/packages/quiz-service/src/auth/controllers/decorators/auth/principal.decorator.ts
@@ -3,6 +3,7 @@ import {
   ExecutionContext,
   UnauthorizedException,
 } from '@nestjs/common'
+import { TokenDto } from '@quiz/common'
 
 import { User } from '../../../../user/repositories'
 import { AuthGuardRequest } from '../../../guards'
@@ -30,7 +31,7 @@ import { AuthGuardRequest } from '../../../guards'
  */
 export const Principal = createParamDecorator(
   (data: unknown, ctx: ExecutionContext): User => {
-    const request = ctx.switchToHttp().getRequest<AuthGuardRequest>()
+    const request = ctx.switchToHttp().getRequest<AuthGuardRequest<TokenDto>>()
     if (!request.user) {
       throw new UnauthorizedException('Unauthorized')
     }

--- a/packages/quiz-service/src/auth/guards/auth.guard.spec.ts
+++ b/packages/quiz-service/src/auth/guards/auth.guard.spec.ts
@@ -32,7 +32,9 @@ describe('AuthGuard', () => {
   const fakeHandler = () => {}
   const fakeClass = class {}
 
-  function makeContext(req: Partial<AuthGuardRequest>): ExecutionContext {
+  function makeContext(
+    req: Partial<AuthGuardRequest<TokenDto>>,
+  ): ExecutionContext {
     return {
       getHandler: () => fakeHandler,
       getClass: () => fakeClass,
@@ -148,8 +150,8 @@ describe('AuthGuard', () => {
     const req: any = { headers: { authorization: 'Bearer ok' } }
     const ok = await guard.canActivate(makeContext(req))
     expect(ok).toBe(true)
-    expect(req.scope).toEqual(TokenScope.User)
-    expect(req.authorities).toEqual([])
+    expect(req.payload.scope).toEqual(TokenScope.User)
+    expect(req.payload.authorities).toEqual([])
     expect(req.user).toBe(fakeUser)
   })
 
@@ -199,10 +201,10 @@ describe('AuthGuard', () => {
     const req: any = { headers: { authorization: 'Bearer ok' } }
     const ok = await guard.canActivate(makeContext(req))
     expect(ok).toBe(true)
-    expect(req.scope).toEqual(TokenScope.Game)
-    expect(req.authorities).toEqual([Authority.Game])
-    expect(req.gameId).toEqual('game-id')
-    expect(req.participantType).toEqual(GameParticipantType.HOST)
+    expect(req.payload.scope).toEqual(TokenScope.Game)
+    expect(req.payload.authorities).toEqual([Authority.Game])
+    expect(req.payload.gameId).toEqual('game-id')
+    expect(req.payload.participantType).toEqual(GameParticipantType.HOST)
   })
 
   it('should throw if missing gameId or participantType in Game scope', async () => {

--- a/packages/quiz-service/src/media/pipes/parse-image-file.pipe.ts
+++ b/packages/quiz-service/src/media/pipes/parse-image-file.pipe.ts
@@ -14,6 +14,7 @@ import {
 import { ConfigService } from '@nestjs/config'
 import { REQUEST } from '@nestjs/core'
 import {
+  TokenDto,
   UPLOAD_IMAGE_MAX_FILE_SIZE,
   UPLOAD_IMAGE_MIMETYPE_REGEX,
   UPLOAD_IMAGE_MIN_FILE_SIZE,
@@ -42,7 +43,7 @@ export class ParseImageFilePipe
    * @param logger - Optional logger for error tracking.
    */
   constructor(
-    @Inject(REQUEST) private readonly request: AuthGuardRequest,
+    @Inject(REQUEST) private readonly request: AuthGuardRequest<TokenDto>,
     private readonly configService: ConfigService<EnvironmentVariables>,
     private readonly logger: Logger = new Logger(ParseImageFilePipe.name),
   ) {}

--- a/packages/quiz-service/src/quiz/guards/quiz-auth.guard.ts
+++ b/packages/quiz-service/src/quiz/guards/quiz-auth.guard.ts
@@ -7,7 +7,7 @@ import {
   UnauthorizedException,
 } from '@nestjs/common'
 import { Reflector } from '@nestjs/core'
-import { QuizVisibility } from '@quiz/common'
+import { QuizVisibility, TokenDto } from '@quiz/common'
 
 import { AuthGuardRequest } from '../../auth/guards'
 import { AUTHORIZED_QUIZ_ALLOW_PUBLIC } from '../controllers/decorators/auth'
@@ -44,7 +44,9 @@ export class QuizAuthGuard implements CanActivate {
    * @throws ForbiddenException If the user is not the owner of the quiz.
    */
   async canActivate(context: ExecutionContext): Promise<boolean> {
-    const request = context.switchToHttp().getRequest<AuthGuardRequest>()
+    const request = context
+      .switchToHttp()
+      .getRequest<AuthGuardRequest<TokenDto>>()
 
     if (!request.user?._id) {
       throw new UnauthorizedException()

--- a/packages/quiz-service/test-utils/utils/auth.utils.ts
+++ b/packages/quiz-service/test-utils/utils/auth.utils.ts
@@ -13,9 +13,13 @@ import { buildMockPrimaryUser } from '../data'
 
 export async function createDefaultUserAndAuthenticate(
   app: INestApplication,
+  mockUser?: Partial<User>,
 ): Promise<{ accessToken: string; user: User }> {
   const userModel = app.get<UserModel>(getModelToken(User.name))
-  const user = await userModel.create(buildMockPrimaryUser())
+  const user = await userModel.create({
+    ...buildMockPrimaryUser(),
+    ...mockUser,
+  })
 
   const jwtService = app.get<JwtService>(JwtService)
   const accessToken = await jwtService.signAsync(


### PR DESCRIPTION
- Extend TokenDto with an index signature to capture arbitrary JWT claims
- Export and implement a new @JwtPayload decorator to retrieve the full TokenDto from requests
- Update PrincipalId and Principal decorators to pull values from request.payload.sub
- Refactor AuthGuard to attach payload to request and remove deprecated scope/authorities/principalId fields
- Update GameAuthGuard, QuizAuthGuard and ParseImageFilePipe to use AuthGuardRequest<T> with payload
- Adjust auth guard tests to assert against request.payload instead of top‐level properties
- Allow createDefaultUserAndAuthenticate() helper to accept partial mockUser overrides
