### PR TITLE
feat(user-auth): implement email verification endpoint with docs and e2e tests

### DIFF
--- a/packages/quiz-service/src/user/controllers/index.ts
+++ b/packages/quiz-service/src/user/controllers/index.ts
@@ -1,2 +1,3 @@
-export * from './user.controller'
+export * from './user-auth.controller'
 export * from './user-profile.controller'
+export * from './user.controller'

--- a/packages/quiz-service/src/user/controllers/user-auth.controller.e2e-spec.ts
+++ b/packages/quiz-service/src/user/controllers/user-auth.controller.e2e-spec.ts
@@ -1,0 +1,177 @@
+import { INestApplication } from '@nestjs/common'
+import { JwtService } from '@nestjs/jwt'
+import { Authority, TokenScope } from '@quiz/common'
+import supertest from 'supertest'
+import { v4 as uuidv4 } from 'uuid'
+
+import {
+  MOCK_DEFAULT_HASHED_PASSWORD,
+  MOCK_PRIMARY_USER_DEFAULT_NICKNAME,
+  MOCK_PRIMARY_USER_EMAIL,
+  MOCK_PRIMARY_USER_FAMILY_NAME,
+  MOCK_PRIMARY_USER_GIVEN_NAME,
+  MOCK_SECONDARY_USER_EMAIL,
+} from '../../../test-utils/data'
+import {
+  closeTestApp,
+  createDefaultUserAndAuthenticate,
+  createTestApp,
+} from '../../../test-utils/utils'
+import { AuthService } from '../../auth/services'
+import { LocalUser, UserRepository } from '../repositories'
+
+describe('UserAuthController (e2e)', () => {
+  let app: INestApplication
+  let userRepository: UserRepository
+  let authService: AuthService
+  let jwtService: JwtService
+
+  beforeEach(async () => {
+    app = await createTestApp()
+    userRepository = app.get<UserRepository>(UserRepository)
+    authService = app.get<AuthService>(AuthService)
+    jwtService = app.get(JwtService)
+  })
+
+  afterEach(async () => {
+    await closeTestApp(app)
+  })
+
+  describe('/api/auth/email/verify (POST)', () => {
+    it('should verify a user email successfully', async () => {
+      const { _id: userId, email } = await userRepository.createLocalUser({
+        email: MOCK_PRIMARY_USER_EMAIL,
+        unverifiedEmail: MOCK_PRIMARY_USER_EMAIL,
+        hashedPassword: MOCK_DEFAULT_HASHED_PASSWORD,
+        givenName: MOCK_PRIMARY_USER_GIVEN_NAME,
+        familyName: MOCK_PRIMARY_USER_FAMILY_NAME,
+        defaultNickname: MOCK_PRIMARY_USER_DEFAULT_NICKNAME,
+      })
+
+      const accessToken = await authService.signVerifyEmailToken(userId, email)
+
+      return supertest(app.getHttpServer())
+        .post('/api/auth/email/verify')
+        .set({ Authorization: `Bearer ${accessToken}` })
+        .send()
+        .expect(204)
+        .expect((res) => {
+          expect(res.body).toEqual({})
+        })
+    })
+
+    it('should return 400 when email does not match the unverified email', async () => {
+      const { _id: userId } = await userRepository.createLocalUser({
+        email: MOCK_PRIMARY_USER_EMAIL,
+        unverifiedEmail: MOCK_PRIMARY_USER_EMAIL,
+        hashedPassword: MOCK_DEFAULT_HASHED_PASSWORD,
+        givenName: MOCK_PRIMARY_USER_GIVEN_NAME,
+        familyName: MOCK_PRIMARY_USER_FAMILY_NAME,
+        defaultNickname: MOCK_PRIMARY_USER_DEFAULT_NICKNAME,
+      })
+
+      const accessToken = await authService.signVerifyEmailToken(
+        userId,
+        MOCK_SECONDARY_USER_EMAIL,
+      )
+
+      return supertest(app.getHttpServer())
+        .post('/api/auth/email/verify')
+        .set({ Authorization: `Bearer ${accessToken}` })
+        .send()
+        .expect(400)
+        .expect((res) => {
+          expect(res.body).toEqual({
+            message: 'Email does not match',
+            status: 400,
+            timestamp: expect.anything(),
+          })
+        })
+    })
+
+    it('should return 401 when the authorization has expired', async () => {
+      const { _id: userId, email } = await userRepository.createLocalUser({
+        email: MOCK_PRIMARY_USER_EMAIL,
+        unverifiedEmail: MOCK_PRIMARY_USER_EMAIL,
+        hashedPassword: MOCK_DEFAULT_HASHED_PASSWORD,
+        givenName: MOCK_PRIMARY_USER_GIVEN_NAME,
+        familyName: MOCK_PRIMARY_USER_FAMILY_NAME,
+        defaultNickname: MOCK_PRIMARY_USER_DEFAULT_NICKNAME,
+      })
+
+      const accessToken = await jwtService.signAsync(
+        {
+          scope: TokenScope.User,
+          authorities: [Authority.VerifyEmail],
+          email,
+        },
+        {
+          jwtid: uuidv4(),
+          subject: userId,
+          expiresIn: '-1d',
+        },
+      )
+
+      return supertest(app.getHttpServer())
+        .post('/api/auth/email/verify')
+        .set({ Authorization: `Bearer ${accessToken}` })
+        .send()
+        .expect(401)
+        .expect((res) => {
+          expect(res.body).toEqual({
+            message: 'Invalid or expired token',
+            status: 401,
+            timestamp: expect.anything(),
+          })
+        })
+    })
+
+    it('should return 401 when malformed authorization', async () => {
+      return supertest(app.getHttpServer())
+        .post('/api/auth/email/verify')
+        .set({ Authorization: 'Bearer garbage' })
+        .send()
+        .expect(401)
+        .expect((res) => {
+          expect(res.body).toEqual({
+            message: 'Invalid or expired token',
+            status: 401,
+            timestamp: expect.anything(),
+          })
+        })
+    })
+
+    it('should return 401 when missing authorization header', async () => {
+      return supertest(app.getHttpServer())
+        .post('/api/auth/email/verify')
+        .send()
+        .expect(401)
+        .expect((res) => {
+          expect(res.body).toEqual({
+            message: 'Missing Authorization header',
+            status: 401,
+            timestamp: expect.anything(),
+          })
+        })
+    })
+
+    it('should return 403 when missing required authority', async () => {
+      const { accessToken } = await createDefaultUserAndAuthenticate(app, {
+        unverifiedEmail: MOCK_PRIMARY_USER_EMAIL,
+      } as Partial<LocalUser>)
+
+      return supertest(app.getHttpServer())
+        .post('/api/auth/email/verify')
+        .set({ Authorization: `Bearer ${accessToken}` })
+        .send()
+        .expect(403)
+        .expect((res) => {
+          expect(res.body).toEqual({
+            message: 'Insufficient authorities',
+            status: 403,
+            timestamp: expect.anything(),
+          })
+        })
+    })
+  })
+})

--- a/packages/quiz-service/src/user/controllers/user-auth.controller.ts
+++ b/packages/quiz-service/src/user/controllers/user-auth.controller.ts
@@ -1,0 +1,77 @@
+import {
+  Controller,
+  HttpCode,
+  HttpStatus,
+  Post,
+  UnauthorizedException,
+} from '@nestjs/common'
+import {
+  ApiBadRequestResponse,
+  ApiBearerAuth,
+  ApiForbiddenResponse,
+  ApiNoContentResponse,
+  ApiOperation,
+  ApiTags,
+  ApiUnauthorizedResponse,
+} from '@nestjs/swagger'
+import { Authority, TokenDto, TokenScope } from '@quiz/common'
+
+import {
+  JwtPayload,
+  RequiredAuthorities,
+  RequiresScopes,
+} from '../../auth/controllers/decorators'
+import { UserService } from '../services'
+
+/**
+ * Controller for email verification and other user-auth endpoints.
+ */
+@ApiBearerAuth()
+@ApiTags('auth')
+@Controller('auth')
+export class UserAuthController {
+  /**
+   * Initializes the UserAuthController.
+   *
+   * @param userService Service for user operations.
+   */
+  constructor(private readonly userService: UserService) {}
+
+  /**
+   * Verifies a user's email address using a signed JWT.
+   *
+   * Checks that the `email` claim on the payload matches the user's
+   * `unverifiedEmail` and, if so, marks it as verified.
+   *
+   * @param payload - JWT payload containing `sub` (userId) and `email` claim.
+   * @returns A promise that resolves with no content on success.
+   */
+  @Post('/email/verify')
+  @RequiresScopes(TokenScope.User)
+  @RequiredAuthorities(Authority.VerifyEmail)
+  @ApiOperation({
+    summary: 'Verify user email',
+    description:
+      'Consume a signed email-verification token and mark the user’s email as verified.',
+  })
+  @ApiNoContentResponse({
+    description: 'Email successfully verified; no content returned.',
+  })
+  @ApiBadRequestResponse({
+    description:
+      'The provided email does not match the user’s pending unverified email.',
+  })
+  @ApiUnauthorizedResponse({
+    description: 'Missing or invalid authentication token.',
+  })
+  @ApiForbiddenResponse({
+    description: 'Authenticated user lacks the VerifyEmail authority.',
+  })
+  @HttpCode(HttpStatus.NO_CONTENT)
+  public async verifyEmail(@JwtPayload() payload: TokenDto): Promise<void> {
+    if (!payload.email || !(typeof payload.email === 'string')) {
+      throw new UnauthorizedException('Unauthorized')
+    }
+    return this.userService.verifyEmail(payload.sub, payload.email)
+  }
+}

--- a/packages/quiz-service/src/user/user.module.ts
+++ b/packages/quiz-service/src/user/user.module.ts
@@ -6,7 +6,11 @@ import { AuthProvider } from '@quiz/common'
 import { AuthModule } from '../auth'
 import { EmailModule } from '../email'
 
-import { UserController, UserProfileController } from './controllers'
+import {
+  UserAuthController,
+  UserController,
+  UserProfileController,
+} from './controllers'
 import {
   LocalUserSchema,
   User,
@@ -31,7 +35,7 @@ import { UserEventHandler, UserService } from './services'
     forwardRef(() => AuthModule),
     EmailModule,
   ],
-  controllers: [UserController, UserProfileController],
+  controllers: [UserController, UserProfileController, UserAuthController],
   providers: [UserService, UserRepository, UserEventHandler],
   exports: [UserService, UserRepository],
 })


### PR DESCRIPTION
- Change export order in controllers/index.ts to expose user-auth first
- Add UserAuthController with POST /auth/email/verify, Swagger decorators, and JSDoc
- Implement verifyEmail in UserService (logging, unverifiedEmail check, exceptions)
- Register UserAuthController in UserModule
- Add e2e-spec for UserAuthController
