### PR TITLE
Add unverifiedEmail support and email verification flow

### DIFF
--- a/packages/common/src/models/user.ts
+++ b/packages/common/src/models/user.ts
@@ -45,6 +45,11 @@ export interface CreateUserResponseDto {
   readonly email: string
 
   /**
+   * The user’s unverified email address, if provided.
+   */
+  readonly unverifiedEmail?: string
+
+  /**
    * The new user’s given name, if provided.
    */
   readonly givenName?: string
@@ -83,6 +88,11 @@ export interface UserProfileResponseDto {
    * The user’s email address.
    */
   readonly email: string
+
+  /**
+   * The user’s unverified email address, if provided.
+   */
+  readonly unverifiedEmail?: string
 
   /**
    * The user’s given name, if provided.

--- a/packages/quiz-service/src/email/services/email.service.ts
+++ b/packages/quiz-service/src/email/services/email.service.ts
@@ -59,7 +59,10 @@ export class EmailService {
    * @param verificationLink – URL the user clicks to verify their email.
    * @returns A promise that resolves when the welcome email has been sent.
    */
-  public async sendWelcomeEmail(to: string, verificationLink: string) {
+  public async sendWelcomeEmail(
+    to: string,
+    verificationLink: string,
+  ): Promise<void> {
     this.logger.log(`Sending welcome email to ${to}.`)
 
     const text = `Hi,
@@ -88,6 +91,50 @@ The Klurigo Team`
     await this.sendEmail({
       to,
       subject: 'Welcome to Klurigo!',
+      text,
+      html,
+    })
+  }
+
+  /**
+   * Sends a verification email containing a verification link to an existing user.
+   *
+   * @param to               – Recipient’s email address.
+   * @param verificationLink – URL the user clicks to verify their email.
+   * @returns A promise that resolves when the verification email has been sent.
+   */
+  public async sendVerificationEmail(
+    to: string,
+    verificationLink: string,
+  ): Promise<void> {
+    this.logger.log(`Sending verification email to ${to}.`)
+
+    const text = `Hi,
+
+We received a request to change the email address on your Klurigo account. To complete this update, please verify your new email by clicking or copying the link below into your browser:
+${verificationLink}
+
+If you did not request an email change, you can safely ignore this message and no changes will be made.
+
+Thanks for helping us keep your account secure!
+
+Cheers,  
+The Klurigo Team`
+
+    const html = `<p>Hi,</p>
+
+<p>We received a request to change the email address on your Klurigo account. To complete this update, please verify your new email by clicking or copying the link below into your browser:</p>
+<a href="${verificationLink}">${verificationLink}</a>
+
+<p>If you did not request an email change, you can safely ignore this message and no changes will be made.</p>
+
+<p>Thanks for helping us keep your account secure!</p>
+
+<p>Cheers,<br />The Klurigo Team</p>`
+
+    await this.sendEmail({
+      to,
+      subject: 'Confirm Your New Email Address for Klurigo',
       text,
       html,
     })

--- a/packages/quiz-service/src/user/controllers/models/create-user.response.ts
+++ b/packages/quiz-service/src/user/controllers/models/create-user.response.ts
@@ -31,10 +31,24 @@ export class CreateUserResponse implements CreateUserResponseDto {
     title: 'Email',
     description: 'Email address of the created user.',
     type: String,
+    format: 'email',
     pattern: EMAIL_REGEX.source,
     example: 'user@example.com',
   })
   readonly email: string
+
+  /**
+   * The user’s unverified email address, if provided.
+   */
+  @ApiPropertyOptional({
+    title: 'Unverified Email',
+    description: 'The user’s unverified email address.',
+    type: String,
+    format: 'email',
+    pattern: EMAIL_REGEX.source,
+    example: 'user@example.com',
+  })
+  readonly unverifiedEmail?: string
 
   /**
    * The new user’s given name, if provided.

--- a/packages/quiz-service/src/user/controllers/models/user-profile.response.ts
+++ b/packages/quiz-service/src/user/controllers/models/user-profile.response.ts
@@ -32,10 +32,24 @@ export class UserProfileResponse implements UserProfileResponseDto {
     title: 'Email',
     description: 'Email address of the user.',
     type: String,
+    format: 'email',
     pattern: EMAIL_REGEX.source,
     example: 'user@example.com',
   })
   readonly email: string
+
+  /**
+   * The user’s unverified email address, if provided.
+   */
+  @ApiPropertyOptional({
+    title: 'Unverified Email',
+    description: 'The user’s unverified email address.',
+    type: String,
+    format: 'email',
+    pattern: EMAIL_REGEX.source,
+    example: 'user@example.com',
+  })
+  readonly unverifiedEmail?: string
 
   /**
    * The user’s given name, if provided.

--- a/packages/quiz-service/src/user/controllers/user.controller.e2e-spec.ts
+++ b/packages/quiz-service/src/user/controllers/user.controller.e2e-spec.ts
@@ -41,6 +41,7 @@ describe('UserController (e2e)', () => {
           expect(res.body).toEqual({
             id: expect.any(String),
             email: MOCK_PRIMARY_USER_EMAIL,
+            unverifiedEmail: MOCK_PRIMARY_USER_EMAIL,
             givenName: MOCK_PRIMARY_USER_GIVEN_NAME,
             familyName: MOCK_PRIMARY_USER_FAMILY_NAME,
             defaultNickname: MOCK_PRIMARY_USER_DEFAULT_NICKNAME,


### PR DESCRIPTION
- Expose `unverifiedEmail` in CreateUserResponseDto and UserProfileResponseDto interfaces
- Document the new field in Swagger DTOs with @ApiPropertyOptional (format: email)
- Update EmailService:
  - Change sendWelcomeEmail signature to return Promise<void>
  - Add sendVerificationEmail(to, verificationLink): Promise<void> with JSDoc
- Enhance UserService:
  - Introduce computeEmailUpdate() helper to stage vs. verify email updates
  - Refactor generateVerifyEmailLink() and wire it into both welcome and verification emails
  - Wire `unverifiedEmail` through create and update response mappings
- Update E2E tests to cover retrieval and update scenarios involving `unverifiedEmail`