### PR TITLE
feat(user-auth): implement resend-verification-email endpoint and tests

### DIFF
--- a/packages/quiz-service/src/user/controllers/user-auth.controller.e2e-spec.ts
+++ b/packages/quiz-service/src/user/controllers/user-auth.controller.e2e-spec.ts
@@ -174,4 +174,35 @@ describe('UserAuthController (e2e)', () => {
         })
     })
   })
+
+  describe('/api/auth/email/resend_verification (POST)', () => {
+    it('should resend the verification email successfully', async () => {
+      const { accessToken } = await createDefaultUserAndAuthenticate(app, {
+        unverifiedEmail: MOCK_PRIMARY_USER_EMAIL,
+      } as Partial<LocalUser>)
+
+      return supertest(app.getHttpServer())
+        .post('/api/auth/email/resend_verification')
+        .set({ Authorization: `Bearer ${accessToken}` })
+        .send()
+        .expect(204)
+        .expect((res) => {
+          expect(res.body).toEqual({})
+        })
+    })
+
+    it('should return 401 when missing authorization header', async () => {
+      return supertest(app.getHttpServer())
+        .post('/api/auth/email/resend_verification')
+        .send()
+        .expect(401)
+        .expect((res) => {
+          expect(res.body).toEqual({
+            message: 'Missing Authorization header',
+            status: 401,
+            timestamp: expect.anything(),
+          })
+        })
+    })
+  })
 })

--- a/packages/quiz-service/src/user/controllers/user-auth.controller.ts
+++ b/packages/quiz-service/src/user/controllers/user-auth.controller.ts
@@ -18,6 +18,7 @@ import { Authority, TokenDto, TokenScope } from '@quiz/common'
 
 import {
   JwtPayload,
+  PrincipalId,
   RequiredAuthorities,
   RequiresScopes,
 } from '../../auth/controllers/decorators'
@@ -73,5 +74,41 @@ export class UserAuthController {
       throw new UnauthorizedException('Unauthorized')
     }
     return this.userService.verifyEmail(payload.sub, payload.email)
+  }
+
+  /**
+   * Resends the verification email to the authenticated user’s unverified email address.
+   *
+   * Applies:
+   * - `@RequiresScopes(TokenScope.User)` to enforce the user scope.
+   * - `@RequiredAuthorities(Authority.User)` to ensure the user has the proper authority.
+   *
+   * @param userId - The unique identifier of the authenticated user requesting the resend.
+   * @returns void upon successful dispatch of the verification email.
+   */
+  @Post('/email/resend_verification')
+  @RequiresScopes(TokenScope.User)
+  @RequiredAuthorities(Authority.User)
+  @ApiOperation({
+    summary: 'Resend email verification',
+    description:
+      'Sends a new email verification link to the user’s unverified email address.',
+  })
+  @ApiNoContentResponse({
+    description:
+      'No content returned when the verification email is sent successfully.',
+  })
+  @ApiUnauthorizedResponse({
+    description: 'Authorization header is missing or invalid.',
+  })
+  @ApiForbiddenResponse({
+    description:
+      'User does not have sufficient authority to perform this operation.',
+  })
+  @HttpCode(HttpStatus.NO_CONTENT)
+  public async resendEmailVerification(
+    @PrincipalId() userId: string,
+  ): Promise<void> {
+    return this.userService.resendVerificationEmail(userId)
   }
 }


### PR DESCRIPTION
- Add POST /api/auth/email/resend_verification to UserAuthController
  - Enforce TokenScope.User and Authority.User via @RequiresScopes/@RequiredAuthorities
  - Document with Swagger decorators (@ApiOperation, @ApiNoContentResponse, etc.)
  - Extract the current user’s ID with @PrincipalId()
- Refactor UserService:
  - Replace inline email logic in update flow with a private sendVerificationEmail helper
  - Implement public resendVerificationEmail(userId) that logs, fetches the user, and calls the helper
  - sendVerificationEmail now checks qualification, generates link, logs, and sends the email
- Add e2e specs in user-auth.controller.e2e-spec.ts:
  - Happy path: returns 204 and empty body when authenticated
  - Error path: returns 401 when Authorization header is missing
