### PR TITLE
feat(user-auth): add “resend verification email” functionality

### DIFF
--- a/packages/quiz/src/api/use-quiz-service-client.tsx
+++ b/packages/quiz/src/api/use-quiz-service-client.tsx
@@ -276,6 +276,26 @@ export const useQuizServiceClient = () => {
     )
 
   /**
+   * Resend a verification email to the current user.
+   *
+   * @returns {Promise<void>} Resolves once the email has been sent (or rejects on failure).
+   */
+  const resendVerificationEmail = (): Promise<void> =>
+    apiPost<void>('/auth/email/resend_verification', {})
+      .then((response) => {
+        notifySuccess(
+          'Hooray! A fresh verification email is on its way—check your inbox!',
+        )
+        return response
+      })
+      .catch((error) => {
+        notifyError(
+          'Whoops! We couldn’t resend your verification email. Please try again.',
+        )
+        throw error
+      })
+
+  /**
    * Sends a registration request to the API to create a new user account.
    *
    * @param request - The user registration data including email, password, and optional names.
@@ -653,6 +673,7 @@ export const useQuizServiceClient = () => {
     authenticateGame,
     revoke,
     verifyEmail,
+    resendVerificationEmail,
     register,
     getUserProfile,
     updateUserProfile,

--- a/packages/quiz/src/pages/ProfileUserPage/ProfileUserPage.tsx
+++ b/packages/quiz/src/pages/ProfileUserPage/ProfileUserPage.tsx
@@ -8,8 +8,12 @@ import { ProfileUserPageUI, UpdateUserDetailsFormFields } from './components'
 import { UpdateUserPasswordFormFields } from './components/ProfileUserPageUI/components'
 
 const ProfileUserPage: FC = () => {
-  const { getUserProfile, updateUserProfile, updateUserPassword } =
-    useQuizServiceClient()
+  const {
+    getUserProfile,
+    updateUserProfile,
+    updateUserPassword,
+    resendVerificationEmail,
+  } = useQuizServiceClient()
 
   const [isSavingUserProfile, setIsSavingUserProfile] = useState(false)
   const [isSavingUserPassword, setIsSavingUserPassword] = useState(false)
@@ -35,6 +39,10 @@ const ProfileUserPage: FC = () => {
     updateUserPassword(request).finally(() => setIsSavingUserPassword(false))
   }
 
+  const handleResendVerificationEmail = () => {
+    resendVerificationEmail().then(() => {})
+  }
+
   if (!data || isLoadingUserProfile || isError) {
     return (
       <Page profile>
@@ -46,7 +54,8 @@ const ProfileUserPage: FC = () => {
   return (
     <ProfileUserPageUI
       values={{
-        email: data.email,
+        email: data.unverifiedEmail ?? data.email,
+        unverifiedEmail: data.unverifiedEmail,
         givenName: data.givenName,
         familyName: data.familyName,
         defaultNickname: data.defaultNickname,
@@ -55,6 +64,7 @@ const ProfileUserPage: FC = () => {
       loadingPassword={isSavingUserPassword}
       onChange={handleChange}
       onChangePassword={handlePasswordChange}
+      onClickResendVerificationEmail={handleResendVerificationEmail}
     />
   )
 }

--- a/packages/quiz/src/pages/ProfileUserPage/components/ProfileUserPageUI/ProfileUserPageUI.stories.tsx
+++ b/packages/quiz/src/pages/ProfileUserPage/components/ProfileUserPageUI/ProfileUserPageUI.stories.tsx
@@ -21,6 +21,7 @@ export const Default = {
   args: {
     values: {
       email: '',
+      unverifiedEmail: undefined,
       givenName: '',
       familyName: '',
       defaultNickname: '',
@@ -29,5 +30,6 @@ export const Default = {
     loadingPassword: false,
     onChange: () => undefined,
     onChangePassword: () => undefined,
+    onClickResendVerificationEmail: () => undefined,
   },
 } satisfies Story

--- a/packages/quiz/src/pages/ProfileUserPage/components/ProfileUserPageUI/ProfileUserPageUI.test.tsx
+++ b/packages/quiz/src/pages/ProfileUserPage/components/ProfileUserPageUI/ProfileUserPageUI.test.tsx
@@ -12,6 +12,7 @@ describe('ProfileUserPageUI', () => {
         <ProfileUserPageUI
           values={{
             email: '',
+            unverifiedEmail: undefined,
             givenName: '',
             familyName: '',
             defaultNickname: '',
@@ -20,6 +21,30 @@ describe('ProfileUserPageUI', () => {
           loadingPassword={false}
           onChange={() => undefined}
           onChangePassword={() => undefined}
+          onClickResendVerificationEmail={() => undefined}
+        />
+      </MemoryRouter>,
+    )
+
+    expect(container).toMatchSnapshot()
+  })
+
+  it('should render ProfileUserPageUI with prepopulated values', async () => {
+    const { container } = render(
+      <MemoryRouter>
+        <ProfileUserPageUI
+          values={{
+            email: 'user@example.com',
+            unverifiedEmail: undefined,
+            givenName: 'John',
+            familyName: 'Appleseed',
+            defaultNickname: 'FrostyBear',
+          }}
+          loading={false}
+          loadingPassword={false}
+          onChange={() => undefined}
+          onChangePassword={() => undefined}
+          onClickResendVerificationEmail={() => undefined}
         />
       </MemoryRouter>,
     )

--- a/packages/quiz/src/pages/ProfileUserPage/components/ProfileUserPageUI/ProfileUserPageUI.tsx
+++ b/packages/quiz/src/pages/ProfileUserPage/components/ProfileUserPageUI/ProfileUserPageUI.tsx
@@ -15,6 +15,7 @@ export interface ProfileUserPageUIProps {
   loadingPassword: boolean
   onChange: (request: UpdateUserDetailsFormFields) => void
   onChangePassword: (request: UpdateUserPasswordFormFields) => void
+  onClickResendVerificationEmail: () => void
 }
 
 const ProfileUserPageUI: FC<ProfileUserPageUIProps> = ({
@@ -23,9 +24,15 @@ const ProfileUserPageUI: FC<ProfileUserPageUIProps> = ({
   loadingPassword,
   onChange,
   onChangePassword,
+  onClickResendVerificationEmail,
 }) => (
   <Page align="start" discover profile>
-    <UserDetailsForm values={values} loading={loading} onChange={onChange} />
+    <UserDetailsForm
+      values={values}
+      loading={loading}
+      onChange={onChange}
+      onClickResendVerificationEmail={onClickResendVerificationEmail}
+    />
     <PageDivider />
     <UserPasswordForm loading={loadingPassword} onChange={onChangePassword} />
   </Page>

--- a/packages/quiz/src/pages/ProfileUserPage/components/ProfileUserPageUI/__snapshots__/ProfileUserPageUI.test.tsx.snap
+++ b/packages/quiz/src/pages/ProfileUserPage/components/ProfileUserPageUI/__snapshots__/ProfileUserPageUI.test.tsx.snap
@@ -50,22 +50,26 @@ exports[`ProfileUserPageUI > should render ProfileUserPageUI 1`] = `
         class="form"
       >
         <div
-          class="inputContainer"
+          class="formField"
         >
           <div
-            class="textFieldInputContainer textFieldInputKindPrimary"
+            class="inputContainer"
           >
-            <input
-              class="textfield"
-              data-testid="test-email-textfield"
-              id="email"
-              maxlength="128"
-              minlength="6"
-              name="email"
-              placeholder="Email"
-              type="text"
-              value=""
-            />
+            <div
+              class="textFieldInputContainer textFieldInputKindPrimary"
+            >
+              <input
+                class="textfield"
+                data-testid="test-email-textfield"
+                id="email"
+                maxlength="128"
+                minlength="6"
+                name="email"
+                placeholder="Email"
+                type="text"
+                value=""
+              />
+            </div>
           </div>
         </div>
         <div
@@ -131,6 +135,274 @@ exports[`ProfileUserPageUI > should render ProfileUserPageUI 1`] = `
           <button
             data-testid="test-update-user-button-button"
             disabled=""
+            id="update-user-button"
+            name="update-user-button"
+            type="submit"
+          >
+            <svg
+              aria-hidden="true"
+              class="svg-inline--fa fa-floppy-disk "
+              data-icon="floppy-disk"
+              data-prefix="fas"
+              focusable="false"
+              role="img"
+              viewBox="0 0 448 512"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M64 32C28.7 32 0 60.7 0 96L0 416c0 35.3 28.7 64 64 64l320 0c35.3 0 64-28.7 64-64l0-242.7c0-17-6.7-33.3-18.7-45.3L352 50.7C340 38.7 323.7 32 306.7 32L64 32zm0 96c0-17.7 14.3-32 32-32l192 0c17.7 0 32 14.3 32 32l0 64c0 17.7-14.3 32-32 32L96 224c-17.7 0-32-14.3-32-32l0-64zM224 288a64 64 0 1 1 0 128 64 64 0 1 1 0-128z"
+                fill="currentColor"
+              />
+            </svg>
+            <span>
+              Save!
+            </span>
+          </button>
+        </div>
+      </form>
+      <div
+        class="pageDivider"
+      />
+      <div
+        class="typography subtitle full"
+      >
+        Upgrade Your Password
+      </div>
+      <div
+        class="typography text medium"
+      >
+        Enhance your account security with a fresh password—verify your current one, choose a new one, and confirm to complete the update.
+      </div>
+      <form
+        class="form"
+      >
+        <div
+          class="inputContainer"
+        >
+          <div
+            class="textFieldInputContainer textFieldInputKindPrimary"
+          >
+            <input
+              class="textfield"
+              data-testid="test-oldPassword-textfield"
+              id="oldPassword"
+              maxlength="128"
+              minlength="8"
+              name="oldPassword"
+              placeholder="Old Password"
+              type="password"
+              value=""
+            />
+          </div>
+        </div>
+        <div
+          class="inputContainer"
+        >
+          <div
+            class="textFieldInputContainer textFieldInputKindPrimary"
+          >
+            <input
+              class="textfield"
+              data-testid="test-newPassword-textfield"
+              id="newPassword"
+              maxlength="128"
+              minlength="8"
+              name="newPassword"
+              placeholder="New Password"
+              type="password"
+              value=""
+            />
+          </div>
+        </div>
+        <div
+          class="inputContainer"
+        >
+          <div
+            class="textFieldInputContainer textFieldInputKindPrimary"
+          >
+            <input
+              class="textfield"
+              data-testid="test-confirmPassword-textfield"
+              id="confirmPassword"
+              maxlength="128"
+              minlength="8"
+              name="confirmPassword"
+              placeholder="Confirm Password"
+              type="password"
+              value=""
+            />
+          </div>
+        </div>
+        <div
+          class="buttonInputContainer buttonInputKindCallToAction"
+        >
+          <button
+            data-testid="test-update-password-button-button"
+            disabled=""
+            id="update-password-button"
+            name="update-password-button"
+            type="submit"
+          >
+            <svg
+              aria-hidden="true"
+              class="svg-inline--fa fa-lock "
+              data-icon="lock"
+              data-prefix="fas"
+              focusable="false"
+              role="img"
+              viewBox="0 0 448 512"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M144 144l0 48 160 0 0-48c0-44.2-35.8-80-80-80s-80 35.8-80 80zM80 192l0-48C80 64.5 144.5 0 224 0s144 64.5 144 144l0 48 16 0c35.3 0 64 28.7 64 64l0 192c0 35.3-28.7 64-64 64L64 512c-35.3 0-64-28.7-64-64L0 256c0-35.3 28.7-64 64-64l16 0z"
+                fill="currentColor"
+              />
+            </svg>
+            <span>
+              Lock It Down!
+            </span>
+          </button>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ProfileUserPageUI > should render ProfileUserPageUI with prepopulated values 1`] = `
+<div>
+  <div
+    class="main"
+  >
+    <div
+      class="header"
+    >
+      <button
+        class="logo"
+      >
+        <img
+          alt="Klurigo"
+          class="icon"
+          src="/src/assets/images/klurigo-icon.svg"
+        />
+        <span
+          class="text"
+        >
+          Klurigo
+        </span>
+      </button>
+      <div
+        class="side"
+      >
+        <a
+          data-discover="true"
+          href="/auth/login"
+        >
+          Login
+        </a>
+      </div>
+    </div>
+    <div
+      class="content fullWidth startAlign"
+    >
+      <div
+        class="typography subtitle full"
+      >
+        Shape your quiz identity
+      </div>
+      <div
+        class="typography text medium"
+      >
+        Update your personal details to keep your profile up to date. Your information helps personalize your quiz experience and lets others recognize you during games.
+      </div>
+      <form
+        class="form"
+      >
+        <div
+          class="formField"
+        >
+          <div
+            class="inputContainer"
+          >
+            <div
+              class="textFieldInputContainer textFieldInputKindPrimary"
+            >
+              <input
+                class="textfield"
+                data-testid="test-email-textfield"
+                id="email"
+                maxlength="128"
+                minlength="6"
+                name="email"
+                placeholder="Email"
+                type="text"
+                value="user@example.com"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="inputContainer"
+        >
+          <div
+            class="textFieldInputContainer textFieldInputKindPrimary"
+          >
+            <input
+              class="textfield"
+              data-testid="test-givenName-textfield"
+              id="givenName"
+              maxlength="64"
+              minlength="1"
+              name="givenName"
+              placeholder="Given Name"
+              type="text"
+              value="John"
+            />
+          </div>
+        </div>
+        <div
+          class="inputContainer"
+        >
+          <div
+            class="textFieldInputContainer textFieldInputKindPrimary"
+          >
+            <input
+              class="textfield"
+              data-testid="test-familyName-textfield"
+              id="familyName"
+              maxlength="64"
+              minlength="1"
+              name="familyName"
+              placeholder="Family Name"
+              type="text"
+              value="Appleseed"
+            />
+          </div>
+        </div>
+        <div
+          class="inputContainer"
+        >
+          <div
+            class="textFieldInputContainer textFieldInputKindPrimary"
+          >
+            <input
+              class="textfield"
+              data-testid="test-defaultNickname-textfield"
+              id="defaultNickname"
+              maxlength="20"
+              minlength="2"
+              name="defaultNickname"
+              placeholder="Default Nickname"
+              type="text"
+              value="FrostyBear"
+            />
+          </div>
+        </div>
+        <div
+          class="buttonInputContainer buttonInputKindCallToAction"
+        >
+          <button
+            data-testid="test-update-user-button-button"
             id="update-user-button"
             name="update-user-button"
             type="submit"

--- a/packages/quiz/src/pages/ProfileUserPage/components/ProfileUserPageUI/components/UserDetailsForm/UserDetailsForm.tsx
+++ b/packages/quiz/src/pages/ProfileUserPage/components/ProfileUserPageUI/components/UserDetailsForm/UserDetailsForm.tsx
@@ -14,23 +14,34 @@ import {
   PLAYER_NICKNAME_REGEX,
   UpdateUserProfileRequestDto,
 } from '@quiz/common'
-import React, { FC, FormEvent, useEffect, useMemo, useState } from 'react'
+import React, {
+  FC,
+  FormEvent,
+  MouseEvent,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react'
 
 import { Button, TextField, Typography } from '../../../../../../components'
 import styles from '../../../../../../styles/form.module.scss'
 
-export type UpdateUserDetailsFormFields = UpdateUserProfileRequestDto
+export type UpdateUserDetailsFormFields = UpdateUserProfileRequestDto & {
+  unverifiedEmail?: string
+}
 
 export interface UserDetailsFormProps {
   values: UpdateUserDetailsFormFields
   loading: boolean
   onChange: (request: UpdateUserDetailsFormFields) => void
+  onClickResendVerificationEmail: () => void
 }
 
 const UserDetailsForm: FC<UserDetailsFormProps> = ({
   values,
   loading,
   onChange,
+  onClickResendVerificationEmail,
 }) => {
   const [formFields, setFormFields] =
     useState<UpdateUserDetailsFormFields>(values)
@@ -73,6 +84,11 @@ const UserDetailsForm: FC<UserDetailsFormProps> = ({
     }
   }
 
+  const handleClickResendVerificationEmail = (event: MouseEvent) => {
+    event.preventDefault()
+    onClickResendVerificationEmail()
+  }
+
   const handleSubmit = (event: FormEvent) => {
     event.preventDefault()
     onChange(formFields)
@@ -87,19 +103,38 @@ const UserDetailsForm: FC<UserDetailsFormProps> = ({
         recognize you during games.
       </Typography>
       <form className={styles.form} onSubmit={handleSubmit}>
-        <TextField
-          id="email"
-          type="text"
-          placeholder="Email"
-          value={formFields.email}
-          minLength={EMAIL_MIN_LENGTH}
-          maxLength={EMAIL_MAX_LENGTH}
-          regex={EMAIL_REGEX}
-          disabled={loading}
-          onChange={(value) => handleChangeFormField('email', value as string)}
-          onValid={(valid) => handleChangeValidFormField('email', valid)}
-          required
-        />
+        <div className={styles.formField}>
+          <TextField
+            id="email"
+            type="text"
+            placeholder="Email"
+            value={formFields.email}
+            minLength={EMAIL_MIN_LENGTH}
+            maxLength={EMAIL_MAX_LENGTH}
+            regex={EMAIL_REGEX}
+            disabled={loading}
+            onChange={(value) =>
+              handleChangeFormField('email', value as string)
+            }
+            onValid={(valid) => handleChangeValidFormField('email', valid)}
+            required
+          />
+          {formFields.unverifiedEmail && (
+            <span className={styles.hint}>
+              Whoops, your email{' '}
+              <i>
+                <b>{formFields.unverifiedEmail}</b>
+              </i>{' '}
+              hasn’t RSVP’d to verification yet!{' '}
+              <button
+                type="button"
+                className={styles.buttonLink}
+                onClick={handleClickResendVerificationEmail}>
+                Zap me a fresh verification link!
+              </button>
+            </span>
+          )}
+        </div>
         <TextField
           id="givenName"
           type="text"

--- a/packages/quiz/src/styles/form.module.scss
+++ b/packages/quiz/src/styles/form.module.scss
@@ -19,4 +19,67 @@
     row-gap: variables.$desktop-narrow-layout-gutter;
     width: variables.$mobile-width;
   }
+
+  .formField {
+    display: flex;
+    flex-direction: column;
+
+    @include helpers.mobile {
+      row-gap: variables.$mobile-narrow-layout-gutter * 0.5;
+    }
+
+    @include helpers.tablet {
+      row-gap: variables.$tablet-narrow-layout-gutter * 0.5;
+    }
+
+    @include helpers.desktop {
+      row-gap: variables.$desktop-narrow-layout-gutter * 0.5;
+    }
+
+    .hint {
+      display: inline;
+
+      @include helpers.mobile {
+        @include helpers.fontSize(variables.$mobile-control-small-font-size);
+      }
+
+      @include helpers.tablet {
+        @include helpers.fontSize(variables.$tablet-control-small-font-size);
+      }
+
+      @include helpers.desktop {
+        @include helpers.fontSize(variables.$desktop-control-small-font-size);
+      }
+
+      .buttonLink {
+        display: inline-flex;
+        -moz-appearance: none;
+        -o-appearance: none;
+        -webkit-appearance: none;
+        appearance: none;
+        background-color: transparent;
+        border: none;
+        font-family: inherit;
+        outline: none;
+        text-decoration: underline;
+        cursor: pointer;
+
+        @include helpers.mobile {
+          @include helpers.fontSize(variables.$mobile-control-small-font-size);
+        }
+
+        @include helpers.tablet {
+          @include helpers.fontSize(variables.$tablet-control-small-font-size);
+        }
+
+        @include helpers.desktop {
+          @include helpers.fontSize(variables.$desktop-control-small-font-size);
+        }
+
+        &:hover {
+          text-decoration: none;
+        }
+      }
+    }
+  }
 }


### PR DESCRIPTION
- Implement `resendVerificationEmail` in `useQuizServiceClient` with success/error notifications
- Expose and wire up `resendVerificationEmail` in `ProfileUserPage`
- Extend `ProfileUserPageUI` and `UserDetailsForm` to accept and display `unverifiedEmail` hint
- Add “Zap me a fresh verification link!” button with click handler
- Update SCSS (`.formField .hint .buttonLink`) for styling the inline hint and link
- Extend Storybook stories and Jest snapshots/tests to cover the new prop and UI