### PR TITLE
feat(auth): implement password reset flow

### DIFF
--- a/packages/common/src/models/auth.ts
+++ b/packages/common/src/models/auth.ts
@@ -88,3 +88,13 @@ export interface AuthPasswordChangeRequestDto {
    */
   readonly newPassword: string
 }
+
+/**
+ * Data Transfer Object for a password reset request.
+ */
+export interface AuthPasswordResetRequestDto {
+  /**
+   * The user’s email.
+   */
+  readonly email: string
+}

--- a/packages/common/src/models/authority.enum.ts
+++ b/packages/common/src/models/authority.enum.ts
@@ -26,6 +26,11 @@ export enum Authority {
   RefreshAuth = 'REFRESH_AUTH',
 
   /**
+   * Permission to allow generation and validation of password-reset tokens.
+   */
+  ResetPassword = 'RESET_PASSWORD',
+
+  /**
    * Permission to perform user-related operations, including
    * retrieving and updating their profiles.
    */

--- a/packages/quiz-service/src/auth/services/auth.service.ts
+++ b/packages/quiz-service/src/auth/services/auth.service.ts
@@ -363,12 +363,12 @@ export class AuthService {
    *
    * Generates a token with the `VERIFY_EMAIL` authority that expires in 72 hours.
    *
-   * @param subject – The user ID (JWT `sub` claim) for whom the token is issued.
-   * @param email   – The email address to include in the token payload.
+   * @param userId – The user ID (JWT `sub` claim) for whom the token is issued.
+   * @param email  – The email address to include in the token payload.
    * @returns A promise that resolves to the signed verification token string.
    */
   public async signVerifyEmailToken(
-    subject: string,
+    userId: string,
     email: string,
   ): Promise<string> {
     return this.jwtService.signAsync(
@@ -379,8 +379,30 @@ export class AuthService {
       },
       {
         jwtid: uuidv4(),
-        subject,
+        subject: userId,
         expiresIn: '72h',
+      },
+    )
+  }
+
+  /**
+   * Signs a JWT token for password reset.
+   *
+   * Generates a token with the `RESET_PASSWORD` authority that expires in 1 hour.
+   *
+   * @param userId – The user ID (JWT `sub` claim) for whom the token is issued.
+   * @returns A promise that resolves to the signed password reset token string.
+   */
+  public async signPasswordResetToken(userId: string): Promise<string> {
+    return this.jwtService.signAsync(
+      {
+        scope: TokenScope.User,
+        authorities: [Authority.ResetPassword],
+      },
+      {
+        jwtid: uuidv4(),
+        subject: userId,
+        expiresIn: '1h',
       },
     )
   }

--- a/packages/quiz-service/src/email/services/email.service.ts
+++ b/packages/quiz-service/src/email/services/email.service.ts
@@ -72,7 +72,7 @@ Thank you for signing up for Klurigo. We’re thrilled to have you on board!
 Please verify your email address by clicking or copying the link below into your browser:
 ${verificationLink}
 
-If you didn’t create this account, simply ignore this email.
+This link will expire in 3 days. If you didn’t create this account, simply ignore this email.
 
 Cheers,  
 The Klurigo Team`
@@ -84,7 +84,7 @@ The Klurigo Team`
 <p>Please verify your email address by clicking or copying the link below into your browser:</p>
 <a href="${verificationLink}">${verificationLink}</a>
 
-<p>If you didn’t create this account, simply ignore this email.</p>
+<p>This link will expire in 3 days. If you didn’t create this account, simply ignore this email.</p>
 
 <p>Cheers,<br />The Klurigo Team</p>`
 
@@ -114,7 +114,7 @@ The Klurigo Team`
 We received a request to change the email address on your Klurigo account. To complete this update, please verify your new email by clicking or copying the link below into your browser:
 ${verificationLink}
 
-If you did not request an email change, you can safely ignore this message and no changes will be made.
+This link will expire in 3 days. If you did not request an email change, you can safely ignore this message and no changes will be made.
 
 Thanks for helping us keep your account secure!
 
@@ -126,7 +126,7 @@ The Klurigo Team`
 <p>We received a request to change the email address on your Klurigo account. To complete this update, please verify your new email by clicking or copying the link below into your browser:</p>
 <a href="${verificationLink}">${verificationLink}</a>
 
-<p>If you did not request an email change, you can safely ignore this message and no changes will be made.</p>
+<p>This link will expire in 3 days. If you did not request an email change, you can safely ignore this message and no changes will be made.</p>
 
 <p>Thanks for helping us keep your account secure!</p>
 
@@ -135,6 +135,46 @@ The Klurigo Team`
     await this.sendEmail({
       to,
       subject: 'Confirm Your New Email Address for Klurigo',
+      text,
+      html,
+    })
+  }
+
+  /**
+   * Sends a password reset email to the specified recipient.
+   *
+   * @param to – The recipient’s email address.
+   * @param passwordResetLink – The URL containing the password reset token.
+   * @returns A promise that resolves when the email has been sent.
+   */
+  public async sendPasswordResetEmail(
+    to: string,
+    passwordResetLink: string,
+  ): Promise<void> {
+    this.logger.log(`Sending password reset email to ${to}.`)
+
+    const text = `Hi,
+
+We received a request to reset the password for your Klurigo account. To choose a new password, please click or copy the link below into your browser:
+${passwordResetLink}
+
+This link will expire in 60 minutes. If you did not request a password reset, no changes will be made to your account.
+
+Stay safe,
+The Klurigo Team`
+
+    const html = `<p>Hi,</p>
+
+<p>We received a request to reset the password for your Klurigo account. To choose a new password, please click or copy the link below into your browser:<p/>
+<a href="${passwordResetLink}">${passwordResetLink}</a>
+
+<p>This link will expire in 60 minutes. If you did not request a password reset, no changes will be made to your account.</p>
+
+<p>Stay safe,<br />The Klurigo Team</p>`
+
+    await this.sendEmail({
+      to,
+      subject: 'Reset Your Klurigo Password',
       text,
       html,
     })

--- a/packages/quiz-service/src/user/controllers/models/auth-password-reset.request.ts
+++ b/packages/quiz-service/src/user/controllers/models/auth-password-reset.request.ts
@@ -1,0 +1,30 @@
+import { ApiProperty } from '@nestjs/swagger'
+import {
+  AuthPasswordResetRequestDto,
+  EMAIL_MAX_LENGTH,
+  EMAIL_MIN_LENGTH,
+  EMAIL_REGEX,
+} from '@quiz/common'
+import { Matches, MaxLength, MinLength } from 'class-validator'
+
+/**
+ * Request object for resetting a user’s password.
+ */
+export class AuthPasswordResetRequest implements AuthPasswordResetRequestDto {
+  /**
+   * The user’s email address.
+   */
+  @ApiProperty({
+    title: 'Email',
+    description: 'Unique email address for the user.',
+    type: String,
+    pattern: EMAIL_REGEX.source,
+    example: 'user@example.com',
+  })
+  @MinLength(EMAIL_MIN_LENGTH)
+  @MaxLength(EMAIL_MAX_LENGTH)
+  @Matches(EMAIL_REGEX, {
+    message: 'Email must be a valid address.',
+  })
+  readonly email: string
+}

--- a/packages/quiz-service/src/user/controllers/models/index.ts
+++ b/packages/quiz-service/src/user/controllers/models/index.ts
@@ -1,3 +1,4 @@
+export * from './auth-password-reset.request'
 export * from './create-user.request'
 export * from './create-user.response'
 export * from './update-user-profile.request'

--- a/packages/quiz-service/src/user/controllers/user-auth.controller.e2e-spec.ts
+++ b/packages/quiz-service/src/user/controllers/user-auth.controller.e2e-spec.ts
@@ -205,4 +205,56 @@ describe('UserAuthController (e2e)', () => {
         })
     })
   })
+
+  describe('/api/auth/password/reset (POST)', () => {
+    it('should send a password reset email successfully', async () => {
+      const { email } = await userRepository.createLocalUser({
+        email: MOCK_PRIMARY_USER_EMAIL,
+        hashedPassword: MOCK_DEFAULT_HASHED_PASSWORD,
+        givenName: MOCK_PRIMARY_USER_GIVEN_NAME,
+        familyName: MOCK_PRIMARY_USER_FAMILY_NAME,
+        defaultNickname: MOCK_PRIMARY_USER_DEFAULT_NICKNAME,
+      })
+
+      return supertest(app.getHttpServer())
+        .post('/api/auth/password/reset')
+        .send({ email })
+        .expect(204)
+        .expect((res) => {
+          expect(res.body).toEqual({})
+        })
+    })
+
+    it('should return successfully when a user was not found by email', async () => {
+      return supertest(app.getHttpServer())
+        .post('/api/auth/password/reset')
+        .send({ email: 'non-existent-email@example.com' })
+        .expect(204)
+        .expect((res) => {
+          expect(res.body).toEqual({})
+        })
+    })
+
+    it('should return 400 bad request when email validation fails', async () => {
+      return supertest(app.getHttpServer())
+        .post('/api/auth/password/reset')
+        .send({ email: 'invalid-email' })
+        .expect(400)
+        .expect((res) => {
+          expect(res.body).toEqual({
+            message: 'Validation failed',
+            status: 400,
+            timestamp: expect.any(String),
+            validationErrors: [
+              {
+                constraints: {
+                  matches: 'Email must be a valid address.',
+                },
+                property: 'email',
+              },
+            ],
+          })
+        })
+    })
+  })
 })

--- a/packages/quiz-service/src/user/controllers/user-auth.controller.ts
+++ b/packages/quiz-service/src/user/controllers/user-auth.controller.ts
@@ -1,4 +1,5 @@
 import {
+  Body,
   Controller,
   HttpCode,
   HttpStatus,
@@ -8,6 +9,7 @@ import {
 import {
   ApiBadRequestResponse,
   ApiBearerAuth,
+  ApiBody,
   ApiForbiddenResponse,
   ApiNoContentResponse,
   ApiOperation,
@@ -19,10 +21,13 @@ import { Authority, TokenDto, TokenScope } from '@quiz/common'
 import {
   JwtPayload,
   PrincipalId,
+  Public,
   RequiredAuthorities,
   RequiresScopes,
 } from '../../auth/controllers/decorators'
 import { UserService } from '../services'
+
+import { AuthPasswordResetRequest } from './models'
 
 /**
  * Controller for email verification and other user-auth endpoints.
@@ -110,5 +115,34 @@ export class UserAuthController {
     @PrincipalId() userId: string,
   ): Promise<void> {
     return this.userService.resendVerificationEmail(userId)
+  }
+
+  /**
+   * Sends a password reset link to the user's email address.
+   *
+   * @param authPasswordResetRequest – DTO containing the user’s email.
+   * @returns A promise that resolves when the password reset email has been sent.
+   */
+  @Public()
+  @Post('/password/reset')
+  @ApiOperation({
+    summary: 'Reset password',
+    description: 'Sends a password reset link to the user’s email address.',
+  })
+  @ApiBody({
+    description: 'Password reset request payload',
+    type: AuthPasswordResetRequest,
+  })
+  @ApiNoContentResponse({
+    description:
+      'No content returned when the password reset email is sent successfully.',
+  })
+  @HttpCode(HttpStatus.NO_CONTENT)
+  public async resetPassword(
+    @Body() authPasswordResetRequest: AuthPasswordResetRequest,
+  ): Promise<void> {
+    return this.userService.sendPasswordResetEmail(
+      authPasswordResetRequest.email,
+    )
   }
 }


### PR DESCRIPTION
- Add AuthPasswordResetRequestDto to common models
- Introduce ResetPassword authority in Authority enum
- Update signVerifyEmailToken parameter name to userId for consistency
- Add signPasswordResetToken to AuthService (1h expiry)
- Update email templates to include expiration notices for verification links
- Implement sendPasswordResetEmail in EmailService (60m expiry, HTML & text)
- Create AuthPasswordResetRequest DTO with class-validator and Swagger decorators
- Expose POST /api/auth/password/reset in UserAuthController
- Implement UserService.sendPasswordResetEmail and private generatePasswordResetLink
- Add e2e tests for the password reset endpoint (success, non-existent user, validation failure)
