### PR TITLE
feat(auth): add password forgot & reset DTOs, endpoints, and docs

### DIFF
--- a/packages/common/src/models/auth.ts
+++ b/packages/common/src/models/auth.ts
@@ -90,11 +90,21 @@ export interface AuthPasswordChangeRequestDto {
 }
 
 /**
- * Data Transfer Object for a password reset request.
+ * Data Transfer Object for initiating a password-forgot flow.
+ */
+export interface AuthPasswordForgotRequestDto {
+  /**
+   * The user’s email address.
+   */
+  readonly email: string
+}
+
+/**
+ * Data Transfer Object for completing a password-reset flow.
  */
 export interface AuthPasswordResetRequestDto {
   /**
-   * The user’s email.
+   * The new password the user wants to set.
    */
-  readonly email: string
+  readonly password: string
 }

--- a/packages/quiz-service/src/user/controllers/models/auth-password-forgot.request.ts
+++ b/packages/quiz-service/src/user/controllers/models/auth-password-forgot.request.ts
@@ -1,0 +1,30 @@
+import { ApiProperty } from '@nestjs/swagger'
+import {
+  AuthPasswordForgotRequestDto,
+  EMAIL_MAX_LENGTH,
+  EMAIL_MIN_LENGTH,
+  EMAIL_REGEX,
+} from '@quiz/common'
+import { Matches, MaxLength, MinLength } from 'class-validator'
+
+/**
+ * Request object for sending password reset email.
+ */
+export class AuthPasswordForgotRequest implements AuthPasswordForgotRequestDto {
+  /**
+   * The user’s email address.
+   */
+  @ApiProperty({
+    title: 'Email',
+    description: 'Unique email address for the user.',
+    type: String,
+    pattern: EMAIL_REGEX.source,
+    example: 'user@example.com',
+  })
+  @MinLength(EMAIL_MIN_LENGTH)
+  @MaxLength(EMAIL_MAX_LENGTH)
+  @Matches(EMAIL_REGEX, {
+    message: 'Email must be a valid address.',
+  })
+  readonly email: string
+}

--- a/packages/quiz-service/src/user/controllers/models/auth-password-reset.request.ts
+++ b/packages/quiz-service/src/user/controllers/models/auth-password-reset.request.ts
@@ -1,9 +1,9 @@
 import { ApiProperty } from '@nestjs/swagger'
 import {
   AuthPasswordResetRequestDto,
-  EMAIL_MAX_LENGTH,
-  EMAIL_MIN_LENGTH,
-  EMAIL_REGEX,
+  PASSWORD_MAX_LENGTH,
+  PASSWORD_MIN_LENGTH,
+  PASSWORD_REGEX,
 } from '@quiz/common'
 import { Matches, MaxLength, MinLength } from 'class-validator'
 
@@ -12,19 +12,20 @@ import { Matches, MaxLength, MinLength } from 'class-validator'
  */
 export class AuthPasswordResetRequest implements AuthPasswordResetRequestDto {
   /**
-   * The user’s email address.
+   * The new password the user wants to set.
    */
   @ApiProperty({
-    title: 'Email',
-    description: 'Unique email address for the user.',
+    title: 'Password',
+    description: 'Strong password meeting complexity requirements.',
     type: String,
-    pattern: EMAIL_REGEX.source,
-    example: 'user@example.com',
+    pattern: PASSWORD_REGEX.source,
+    example: 'Super#SecretPa$$w0rd123',
   })
-  @MinLength(EMAIL_MIN_LENGTH)
-  @MaxLength(EMAIL_MAX_LENGTH)
-  @Matches(EMAIL_REGEX, {
-    message: 'Email must be a valid address.',
+  @MinLength(PASSWORD_MIN_LENGTH)
+  @MaxLength(PASSWORD_MAX_LENGTH)
+  @Matches(PASSWORD_REGEX, {
+    message:
+      'Password must include ≥2 uppercase, ≥2 lowercase, ≥2 digits, ≥2 symbols.',
   })
-  readonly email: string
+  readonly password: string
 }

--- a/packages/quiz-service/src/user/controllers/models/index.ts
+++ b/packages/quiz-service/src/user/controllers/models/index.ts
@@ -1,3 +1,4 @@
+export * from './auth-password-forgot.request'
 export * from './auth-password-reset.request'
 export * from './create-user.request'
 export * from './create-user.response'


### PR DESCRIPTION
- Rename common AuthPasswordResetRequestDto to AuthPasswordForgotRequestDto for forgot flow
- Add new AuthPasswordResetRequestDto interface for completing reset in common models
- Create AuthPasswordForgotRequest and AuthPasswordResetRequest classes with class-validator and Swagger decorators
- Export forgot DTO in user controllers models index
- Update e2e tests to use /password/forgot for initiating reset and add tests for /password/reset with JWT
- Enhance UserAuthController: document and throttle POST /password/forgot, add PATCH /password/reset with JWT auth and Swagger docs
- Document UserService.setPassword method to hash and store new local passwords