### PR TITLE
feat(user-auth): implement end-to-end password reset flow

### DIFF
--- a/packages/quiz-service/src/user/services/user.service.ts
+++ b/packages/quiz-service/src/user/services/user.service.ts
@@ -470,7 +470,7 @@ export class UserService {
     const passwordResetToken =
       await this.authService.signPasswordResetToken(userId)
 
-    return `${this.configService.get('KLURIGO_URL')}/auth/password_reset?token=${passwordResetToken}`
+    return `${this.configService.get('KLURIGO_URL')}/auth/password/reset?token=${passwordResetToken}`
   }
 
   /**

--- a/packages/quiz/src/main.tsx
+++ b/packages/quiz/src/main.tsx
@@ -11,6 +11,8 @@ import GameContextProvider from './context/game'
 import {
   AuthGamePage,
   AuthLoginPage,
+  AuthPasswordForgotPage,
+  AuthPasswordResetPage,
   AuthRegisterPage,
   AuthVerifyPage,
   ErrorPage,
@@ -64,6 +66,22 @@ const router = createBrowserRouter([
       {
         path: '/auth/verify',
         element: <AuthVerifyPage />,
+      },
+      {
+        path: '/auth/password/forgot',
+        element: (
+          <ProtectedRoute authenticated={false}>
+            <AuthPasswordForgotPage />
+          </ProtectedRoute>
+        ),
+      },
+      {
+        path: '/auth/password/reset',
+        element: (
+          <ProtectedRoute authenticated={false}>
+            <AuthPasswordResetPage />
+          </ProtectedRoute>
+        ),
       },
       {
         path: '/auth/game',

--- a/packages/quiz/src/pages/AuthLoginPage/components/AuthLoginPageUI/AuthLoginPageUI.tsx
+++ b/packages/quiz/src/pages/AuthLoginPage/components/AuthLoginPageUI/AuthLoginPageUI.tsx
@@ -114,6 +114,11 @@ const AuthLoginPageUI: FC<AuthLoginPageUIProps> = ({ loading, onSubmit }) => {
           onValid={(valid) => handleChangeValidFormField('password', valid)}
           required
         />
+        <Link to={'/auth/password/forgot'}>
+          <Typography variant="link" size="small">
+            Forgot your password?
+          </Typography>
+        </Link>
         <IconButtonArrowRight
           id="join"
           type="submit"

--- a/packages/quiz/src/pages/AuthPasswordForgotPage/AuthPasswordForgotPage.tsx
+++ b/packages/quiz/src/pages/AuthPasswordForgotPage/AuthPasswordForgotPage.tsx
@@ -1,0 +1,30 @@
+import React, { FC, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+
+import { useQuizServiceClient } from '../../api/use-quiz-service-client.tsx'
+
+import {
+  AuthPasswordForgotFormFields,
+  AuthPasswordForgotPageUI,
+} from './components'
+
+const AuthPasswordForgotPage: FC = () => {
+  const navigate = useNavigate()
+
+  const { sendPasswordResetEmail } = useQuizServiceClient()
+
+  const [isLoading, setIsLoading] = useState(false)
+
+  const handleSubmit = (values: AuthPasswordForgotFormFields): void => {
+    setIsLoading(true)
+    sendPasswordResetEmail({ email: values.email })
+      .then(() => navigate('/'))
+      .finally(() => setIsLoading(false))
+  }
+
+  return (
+    <AuthPasswordForgotPageUI loading={isLoading} onSubmit={handleSubmit} />
+  )
+}
+
+export default AuthPasswordForgotPage

--- a/packages/quiz/src/pages/AuthPasswordForgotPage/components/AuthPasswordForgotPageUI/AuthPasswordForgotPageUI.stories.tsx
+++ b/packages/quiz/src/pages/AuthPasswordForgotPage/components/AuthPasswordForgotPageUI/AuthPasswordForgotPageUI.stories.tsx
@@ -1,0 +1,30 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { withRouter } from 'storybook-addon-remix-react-router'
+
+import AuthPasswordForgotPageUI from './AuthPasswordForgotPageUI'
+
+const meta = {
+  title: 'Pages/AuthPasswordForgotPage',
+  component: AuthPasswordForgotPageUI,
+  decorators: [withRouter],
+  parameters: {
+    layout: 'fullscreen',
+  },
+} satisfies Meta<typeof AuthPasswordForgotPageUI>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default = {
+  args: {
+    loading: false,
+    onSubmit: () => undefined,
+  },
+} satisfies Story
+
+export const Loading = {
+  args: {
+    loading: true,
+    onSubmit: () => undefined,
+  },
+} satisfies Story

--- a/packages/quiz/src/pages/AuthPasswordForgotPage/components/AuthPasswordForgotPageUI/AuthPasswordForgotPageUI.test.tsx
+++ b/packages/quiz/src/pages/AuthPasswordForgotPage/components/AuthPasswordForgotPageUI/AuthPasswordForgotPageUI.test.tsx
@@ -1,0 +1,28 @@
+import { render } from '@testing-library/react'
+import React from 'react'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, expect, it } from 'vitest'
+
+import AuthPasswordForgotPageUI from './AuthPasswordForgotPageUI'
+
+describe('AuthPasswordForgotPageUI', () => {
+  it('should render AuthPasswordForgotPageUI', async () => {
+    const { container } = render(
+      <MemoryRouter>
+        <AuthPasswordForgotPageUI loading={false} onSubmit={() => undefined} />
+      </MemoryRouter>,
+    )
+
+    expect(container).toMatchSnapshot()
+  })
+
+  it('should render AuthPasswordForgotPageUI when loading', async () => {
+    const { container } = render(
+      <MemoryRouter>
+        <AuthPasswordForgotPageUI loading={true} onSubmit={() => undefined} />
+      </MemoryRouter>,
+    )
+
+    expect(container).toMatchSnapshot()
+  })
+})

--- a/packages/quiz/src/pages/AuthPasswordForgotPage/components/AuthPasswordForgotPageUI/AuthPasswordForgotPageUI.tsx
+++ b/packages/quiz/src/pages/AuthPasswordForgotPage/components/AuthPasswordForgotPageUI/AuthPasswordForgotPageUI.tsx
@@ -1,0 +1,105 @@
+import {
+  AuthPasswordForgotRequestDto,
+  EMAIL_MAX_LENGTH,
+  EMAIL_MIN_LENGTH,
+  EMAIL_REGEX,
+} from '@quiz/common'
+import React, { FC, FormEvent, useMemo, useState } from 'react'
+
+import {
+  IconButtonArrowRight,
+  Page,
+  TextField,
+  Typography,
+} from '../../../../components'
+import styles from '../../../../styles/form.module.scss'
+
+export type AuthPasswordForgotFormFields = AuthPasswordForgotRequestDto
+
+export interface AuthPasswordForgotPageUIProps {
+  loading: boolean
+  onSubmit: (values: AuthPasswordForgotFormFields) => void
+}
+
+type AuthPasswordForgotValidFormFields = {
+  [key in keyof AuthPasswordForgotFormFields]: boolean
+}
+
+const AuthPasswordForgotPageUI: FC<AuthPasswordForgotPageUIProps> = ({
+  loading,
+  onSubmit,
+}) => {
+  const [formFields, setFormFields] = useState<AuthPasswordForgotFormFields>({
+    email: '',
+  })
+
+  const handleChangeFormField = <K extends keyof AuthPasswordForgotFormFields>(
+    key: K,
+    value: AuthPasswordForgotFormFields[K],
+  ) => {
+    setFormFields({ ...formFields, [key]: value })
+  }
+
+  const [validFormFields, setValidFormFields] =
+    useState<AuthPasswordForgotValidFormFields>({
+      email: false,
+    })
+
+  const isFormValid = useMemo(
+    () => Object.values(validFormFields).every((valid) => !!valid),
+    [validFormFields],
+  )
+
+  const handleChangeValidFormField = <
+    K extends keyof AuthPasswordForgotValidFormFields,
+  >(
+    key: K,
+    valid: boolean,
+  ) => {
+    if (validFormFields[key] !== valid) {
+      setValidFormFields((prevState) => {
+        return { ...prevState, [key]: valid }
+      })
+    }
+  }
+
+  const handleSubmit = (event: FormEvent) => {
+    event.preventDefault()
+    onSubmit({ email: formFields.email })
+  }
+
+  return (
+    <Page>
+      <Typography variant="subtitle">Uh-oh, Lost Your Key?</Typography>
+      <Typography variant="text" size="medium">
+        Don’t panic – it happens! Drop your email below and we’ll beam you a
+        shiny new password link.
+      </Typography>
+      <form className={styles.form} onSubmit={handleSubmit}>
+        <TextField
+          id="email"
+          type="text"
+          placeholder="Email"
+          value={formFields.email}
+          minLength={EMAIL_MIN_LENGTH}
+          maxLength={EMAIL_MAX_LENGTH}
+          regex={EMAIL_REGEX}
+          disabled={loading}
+          onChange={(value) => handleChangeFormField('email', value as string)}
+          onValid={(valid) => handleChangeValidFormField('email', valid)}
+          required
+        />
+        <IconButtonArrowRight
+          id="continue-button"
+          type="submit"
+          kind="call-to-action"
+          value="Send Reset Link"
+          loading={loading}
+          disabled={!isFormValid || loading}
+        />
+      </form>
+    </Page>
+  )
+}
+
+export default AuthPasswordForgotPageUI

--- a/packages/quiz/src/pages/AuthPasswordForgotPage/components/AuthPasswordForgotPageUI/__snapshots__/AuthPasswordForgotPageUI.test.tsx.snap
+++ b/packages/quiz/src/pages/AuthPasswordForgotPage/components/AuthPasswordForgotPageUI/__snapshots__/AuthPasswordForgotPageUI.test.tsx.snap
@@ -1,0 +1,199 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`AuthPasswordForgotPageUI > should render AuthPasswordForgotPageUI 1`] = `
+<div>
+  <div
+    class="main"
+  >
+    <div
+      class="header"
+    >
+      <button
+        class="logo"
+      >
+        <img
+          alt="Klurigo"
+          class="icon"
+          src="/src/assets/images/klurigo-icon.svg"
+        />
+        <span
+          class="text"
+        >
+          Klurigo
+        </span>
+      </button>
+      <div
+        class="side"
+      >
+        <a
+          data-discover="true"
+          href="/auth/login"
+        >
+          Login
+        </a>
+      </div>
+    </div>
+    <div
+      class="content fullWidth centerAlign"
+    >
+      <div
+        class="typography subtitle full"
+      >
+        Uh-oh, Lost Your Key?
+      </div>
+      <div
+        class="typography text medium"
+      >
+        Don’t panic – it happens! Drop your email below and we’ll beam you a shiny new password link.
+      </div>
+      <form
+        class="form"
+      >
+        <div
+          class="inputContainer"
+        >
+          <div
+            class="textFieldInputContainer textFieldInputKindPrimary"
+          >
+            <input
+              class="textfield"
+              data-testid="test-email-textfield"
+              id="email"
+              maxlength="128"
+              minlength="6"
+              name="email"
+              placeholder="Email"
+              type="text"
+              value=""
+            />
+          </div>
+        </div>
+        <div
+          class="buttonInputContainer buttonInputKindCallToAction"
+        >
+          <button
+            data-testid="test-continue-button-button"
+            disabled=""
+            id="continue-button"
+            name="continue-button"
+            type="submit"
+          >
+            <span>
+              Send Reset Link
+            </span>
+            <svg
+              aria-hidden="true"
+              class="svg-inline--fa fa-arrow-right "
+              data-icon="arrow-right"
+              data-prefix="fas"
+              focusable="false"
+              role="img"
+              viewBox="0 0 448 512"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M438.6 278.6c12.5-12.5 12.5-32.8 0-45.3l-160-160c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3L338.8 224 32 224c-17.7 0-32 14.3-32 32s14.3 32 32 32l306.7 0L233.4 393.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0l160-160z"
+                fill="currentColor"
+              />
+            </svg>
+          </button>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`AuthPasswordForgotPageUI > should render AuthPasswordForgotPageUI when loading 1`] = `
+<div>
+  <div
+    class="main"
+  >
+    <div
+      class="header"
+    >
+      <button
+        class="logo"
+      >
+        <img
+          alt="Klurigo"
+          class="icon"
+          src="/src/assets/images/klurigo-icon.svg"
+        />
+        <span
+          class="text"
+        >
+          Klurigo
+        </span>
+      </button>
+      <div
+        class="side"
+      >
+        <a
+          data-discover="true"
+          href="/auth/login"
+        >
+          Login
+        </a>
+      </div>
+    </div>
+    <div
+      class="content fullWidth centerAlign"
+    >
+      <div
+        class="typography subtitle full"
+      >
+        Uh-oh, Lost Your Key?
+      </div>
+      <div
+        class="typography text medium"
+      >
+        Don’t panic – it happens! Drop your email below and we’ll beam you a shiny new password link.
+      </div>
+      <form
+        class="form"
+      >
+        <div
+          class="inputContainer"
+        >
+          <div
+            class="textFieldInputContainer textFieldInputKindPrimary disabled"
+          >
+            <input
+              class="textfield"
+              data-testid="test-email-textfield"
+              disabled=""
+              id="email"
+              maxlength="128"
+              minlength="6"
+              name="email"
+              placeholder="Email"
+              type="text"
+              value=""
+            />
+          </div>
+        </div>
+        <div
+          class="buttonInputContainer buttonInputKindCallToAction"
+        >
+          <button
+            data-testid="test-continue-button-button"
+            disabled=""
+            id="continue-button"
+            name="continue-button"
+            type="submit"
+          >
+            <div
+              class="loadingSpinner"
+            >
+              <div />
+              <div />
+              <div />
+            </div>
+          </button>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>
+`;

--- a/packages/quiz/src/pages/AuthPasswordForgotPage/components/AuthPasswordForgotPageUI/index.ts
+++ b/packages/quiz/src/pages/AuthPasswordForgotPage/components/AuthPasswordForgotPageUI/index.ts
@@ -1,0 +1,5 @@
+export type {
+  AuthPasswordForgotFormFields,
+  AuthPasswordForgotPageUIProps,
+} from './AuthPasswordForgotPageUI'
+export { default } from './AuthPasswordForgotPageUI'

--- a/packages/quiz/src/pages/AuthPasswordForgotPage/components/index.ts
+++ b/packages/quiz/src/pages/AuthPasswordForgotPage/components/index.ts
@@ -1,0 +1,5 @@
+export type {
+  AuthPasswordForgotFormFields,
+  AuthPasswordForgotPageUIProps,
+} from './AuthPasswordForgotPageUI'
+export { default as AuthPasswordForgotPageUI } from './AuthPasswordForgotPageUI'

--- a/packages/quiz/src/pages/AuthPasswordForgotPage/index.ts
+++ b/packages/quiz/src/pages/AuthPasswordForgotPage/index.ts
@@ -1,0 +1,1 @@
+export { default } from './AuthPasswordForgotPage'

--- a/packages/quiz/src/pages/AuthPasswordResetPage/AuthPasswordResetPage.tsx
+++ b/packages/quiz/src/pages/AuthPasswordResetPage/AuthPasswordResetPage.tsx
@@ -1,0 +1,54 @@
+import React, { FC, useEffect, useMemo, useRef, useState } from 'react'
+import { useNavigate, useSearchParams } from 'react-router-dom'
+
+import { isTokenExpired } from '../../api/api-utils.ts'
+import { useQuizServiceClient } from '../../api/use-quiz-service-client.tsx'
+
+import {
+  AuthPasswordResetFormFields,
+  AuthPasswordResetPageUI,
+} from './components'
+
+const AuthPasswordResetPage: FC = () => {
+  const navigate = useNavigate()
+
+  const [searchParams] = useSearchParams()
+  const token = useMemo(
+    () => searchParams.get('token') || undefined,
+    [searchParams],
+  )
+
+  const { resetPassword } = useQuizServiceClient()
+
+  const [isLoading, setIsLoading] = useState(false)
+  const [hasError, setHasError] = useState<boolean>(false)
+  const hasResetPasswordRef = useRef(false)
+
+  useEffect(() => {
+    setHasError(!token || isTokenExpired(token))
+  }, [token])
+
+  const handleSubmit = (values: AuthPasswordResetFormFields): void => {
+    if (token && !isLoading && !hasResetPasswordRef.current) {
+      setIsLoading(true)
+      hasResetPasswordRef.current = true
+      resetPassword(values, token)
+        .then(() => {
+          setHasError(false)
+          navigate('/auth/login')
+        })
+        .catch(() => setHasError(true))
+        .finally(() => setIsLoading(false))
+    }
+  }
+
+  return (
+    <AuthPasswordResetPageUI
+      loading={isLoading}
+      error={hasError}
+      onSubmit={handleSubmit}
+    />
+  )
+}
+
+export default AuthPasswordResetPage

--- a/packages/quiz/src/pages/AuthPasswordResetPage/components/AuthPasswordResetPageUI/AuthPasswordResetPageUI.stories.tsx
+++ b/packages/quiz/src/pages/AuthPasswordResetPage/components/AuthPasswordResetPageUI/AuthPasswordResetPageUI.stories.tsx
@@ -1,0 +1,40 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { withRouter } from 'storybook-addon-remix-react-router'
+
+import AuthPasswordResetPageUI from './AuthPasswordResetPageUI'
+
+const meta = {
+  title: 'Pages/AuthPasswordResetPage',
+  component: AuthPasswordResetPageUI,
+  decorators: [withRouter],
+  parameters: {
+    layout: 'fullscreen',
+  },
+} satisfies Meta<typeof AuthPasswordResetPageUI>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default = {
+  args: {
+    loading: false,
+    error: false,
+    onSubmit: () => undefined,
+  },
+} satisfies Story
+
+export const Loading = {
+  args: {
+    loading: true,
+    error: false,
+    onSubmit: () => undefined,
+  },
+} satisfies Story
+
+export const Error = {
+  args: {
+    loading: false,
+    error: true,
+    onSubmit: () => undefined,
+  },
+} satisfies Story

--- a/packages/quiz/src/pages/AuthPasswordResetPage/components/AuthPasswordResetPageUI/AuthPasswordResetPageUI.test.tsx
+++ b/packages/quiz/src/pages/AuthPasswordResetPage/components/AuthPasswordResetPageUI/AuthPasswordResetPageUI.test.tsx
@@ -1,0 +1,50 @@
+import { render } from '@testing-library/react'
+import React from 'react'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, expect, it } from 'vitest'
+
+import AuthPasswordResetPage from './AuthPasswordResetPageUI'
+
+describe('AuthPasswordResetPage', () => {
+  it('should render AuthPasswordResetPage', async () => {
+    const { container } = render(
+      <MemoryRouter>
+        <AuthPasswordResetPage
+          loading={false}
+          error={false}
+          onSubmit={() => undefined}
+        />
+      </MemoryRouter>,
+    )
+
+    expect(container).toMatchSnapshot()
+  })
+
+  it('should render AuthPasswordResetPage when loading', async () => {
+    const { container } = render(
+      <MemoryRouter>
+        <AuthPasswordResetPage
+          loading={true}
+          error={false}
+          onSubmit={() => undefined}
+        />
+      </MemoryRouter>,
+    )
+
+    expect(container).toMatchSnapshot()
+  })
+
+  it('should render AuthPasswordResetPage when error', async () => {
+    const { container } = render(
+      <MemoryRouter>
+        <AuthPasswordResetPage
+          loading={false}
+          error={true}
+          onSubmit={() => undefined}
+        />
+      </MemoryRouter>,
+    )
+
+    expect(container).toMatchSnapshot()
+  })
+})

--- a/packages/quiz/src/pages/AuthPasswordResetPage/components/AuthPasswordResetPageUI/AuthPasswordResetPageUI.tsx
+++ b/packages/quiz/src/pages/AuthPasswordResetPage/components/AuthPasswordResetPageUI/AuthPasswordResetPageUI.tsx
@@ -1,0 +1,169 @@
+import { faLock, faXmark } from '@fortawesome/free-solid-svg-icons'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import {
+  AuthPasswordResetRequestDto,
+  PASSWORD_MAX_LENGTH,
+  PASSWORD_MIN_LENGTH,
+  PASSWORD_REGEX,
+} from '@quiz/common'
+import React, { FC, FormEvent, useMemo, useState } from 'react'
+
+import {
+  Badge,
+  Button,
+  Page,
+  TextField,
+  Typography,
+} from '../../../../components'
+import styles from '../../../../styles/form.module.scss'
+
+export type AuthPasswordResetFormFields = AuthPasswordResetRequestDto
+
+type AuthPasswordResetWithConfirmationFormFields =
+  AuthPasswordResetFormFields & {
+    confirmPassword: string
+  }
+
+export interface AuthPasswordResetPageUIProps {
+  loading: boolean
+  error: boolean
+  onSubmit: (values: AuthPasswordResetFormFields) => void
+}
+
+const AuthPasswordResetPageUI: FC<AuthPasswordResetPageUIProps> = ({
+  loading,
+  error,
+  onSubmit,
+}) => {
+  const [formFields, setFormFields] =
+    useState<AuthPasswordResetWithConfirmationFormFields>({
+      password: '',
+      confirmPassword: '',
+    })
+
+  const handleChangeFormField = <
+    K extends keyof AuthPasswordResetWithConfirmationFormFields,
+  >(
+    key: K,
+    value: AuthPasswordResetWithConfirmationFormFields[K],
+  ) => {
+    setFormFields({ ...formFields, [key]: value })
+  }
+
+  const [validFormFields, setValidFormFields] = useState<{
+    [key in keyof AuthPasswordResetWithConfirmationFormFields]: boolean
+  }>({
+    password: false,
+    confirmPassword: false,
+  })
+
+  const isFormValid = useMemo(
+    () => Object.values(validFormFields).every((valid) => !!valid),
+    [validFormFields],
+  )
+
+  const handleChangeValidFormField = <
+    K extends keyof AuthPasswordResetWithConfirmationFormFields,
+  >(
+    key: K,
+    valid: boolean,
+  ) => {
+    if (validFormFields[key] !== valid) {
+      setValidFormFields((prevState) => {
+        return { ...prevState, [key]: valid }
+      })
+    }
+  }
+
+  const handleSubmit = (event: FormEvent) => {
+    event.preventDefault()
+    onSubmit({ password: formFields.password })
+  }
+
+  if (error) {
+    return (
+      <Page>
+        <Badge size="large" backgroundColor="red">
+          <FontAwesomeIcon icon={faXmark} />
+        </Badge>
+
+        <Typography variant="subtitle" size="small">
+          Oops! Something went wrong.
+        </Typography>
+
+        <Typography variant="text" size="medium">
+          The supplied link is invalid or has expired.
+        </Typography>
+      </Page>
+    )
+  }
+
+  return (
+    <Page>
+      <Typography variant="subtitle">Lock It Down!</Typography>
+      <Typography variant="text" size="medium">
+        Choose your dazzling new password and confirm it below. Let’s keep those
+        sneaky hackers out!
+      </Typography>
+      <form className={styles.form} onSubmit={handleSubmit}>
+        <TextField
+          id="password"
+          type="password"
+          placeholder="New Password"
+          value={formFields.password}
+          minLength={PASSWORD_MIN_LENGTH}
+          maxLength={PASSWORD_MAX_LENGTH}
+          regex={{
+            value: PASSWORD_REGEX,
+            message:
+              'Must include at least ≥2 uppercase, ≥2 lowercase, ≥2 digits, ≥2 symbols.',
+          }}
+          disabled={loading}
+          onChange={(value) =>
+            handleChangeFormField('password', value as string)
+          }
+          onValid={(valid) => handleChangeValidFormField('password', valid)}
+          required
+        />
+        <TextField
+          id="confirmPassword"
+          type="password"
+          placeholder="Confirm Password"
+          value={formFields.confirmPassword}
+          minLength={PASSWORD_MIN_LENGTH}
+          maxLength={PASSWORD_MAX_LENGTH}
+          regex={{
+            value: PASSWORD_REGEX,
+            message:
+              'Must include at least ≥2 uppercase, ≥2 lowercase, ≥2 digits, ≥2 symbols.',
+          }}
+          disabled={loading}
+          onChange={(value) =>
+            handleChangeFormField('confirmPassword', value as string)
+          }
+          onValid={(valid) =>
+            handleChangeValidFormField('confirmPassword', valid)
+          }
+          onAdditionalValidation={(value) => {
+            if (value !== formFields.password)
+              return 'Password must equal the new password.' as const
+            return true
+          }}
+          required
+        />
+        <Button
+          id="reset-password-button"
+          type="submit"
+          kind="call-to-action"
+          size="normal"
+          value="Lock It Down!"
+          icon={faLock}
+          loading={loading}
+          disabled={!isFormValid || loading}
+        />
+      </form>
+    </Page>
+  )
+}
+
+export default AuthPasswordResetPageUI

--- a/packages/quiz/src/pages/AuthPasswordResetPage/components/AuthPasswordResetPageUI/__snapshots__/AuthPasswordResetPageUI.test.tsx.snap
+++ b/packages/quiz/src/pages/AuthPasswordResetPage/components/AuthPasswordResetPageUI/__snapshots__/AuthPasswordResetPageUI.test.tsx.snap
@@ -1,0 +1,308 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`AuthPasswordResetPage > should render AuthPasswordResetPage 1`] = `
+<div>
+  <div
+    class="main"
+  >
+    <div
+      class="header"
+    >
+      <button
+        class="logo"
+      >
+        <img
+          alt="Klurigo"
+          class="icon"
+          src="/src/assets/images/klurigo-icon.svg"
+        />
+        <span
+          class="text"
+        >
+          Klurigo
+        </span>
+      </button>
+      <div
+        class="side"
+      >
+        <a
+          data-discover="true"
+          href="/auth/login"
+        >
+          Login
+        </a>
+      </div>
+    </div>
+    <div
+      class="content fullWidth centerAlign"
+    >
+      <div
+        class="typography subtitle full"
+      >
+        Lock It Down!
+      </div>
+      <div
+        class="typography text medium"
+      >
+        Choose your dazzling new password and confirm it below. Let’s keep those sneaky hackers out!
+      </div>
+      <form
+        class="form"
+      >
+        <div
+          class="inputContainer"
+        >
+          <div
+            class="textFieldInputContainer textFieldInputKindPrimary"
+          >
+            <input
+              class="textfield"
+              data-testid="test-password-textfield"
+              id="password"
+              maxlength="128"
+              minlength="8"
+              name="password"
+              placeholder="New Password"
+              type="password"
+              value=""
+            />
+          </div>
+        </div>
+        <div
+          class="inputContainer"
+        >
+          <div
+            class="textFieldInputContainer textFieldInputKindPrimary"
+          >
+            <input
+              class="textfield"
+              data-testid="test-confirmPassword-textfield"
+              id="confirmPassword"
+              maxlength="128"
+              minlength="8"
+              name="confirmPassword"
+              placeholder="Confirm Password"
+              type="password"
+              value=""
+            />
+          </div>
+        </div>
+        <div
+          class="buttonInputContainer buttonInputKindCallToAction"
+        >
+          <button
+            data-testid="test-reset-password-button-button"
+            disabled=""
+            id="reset-password-button"
+            name="reset-password-button"
+            type="submit"
+          >
+            <svg
+              aria-hidden="true"
+              class="svg-inline--fa fa-lock "
+              data-icon="lock"
+              data-prefix="fas"
+              focusable="false"
+              role="img"
+              viewBox="0 0 448 512"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M144 144l0 48 160 0 0-48c0-44.2-35.8-80-80-80s-80 35.8-80 80zM80 192l0-48C80 64.5 144.5 0 224 0s144 64.5 144 144l0 48 16 0c35.3 0 64 28.7 64 64l0 192c0 35.3-28.7 64-64 64L64 512c-35.3 0-64-28.7-64-64L0 256c0-35.3 28.7-64 64-64l16 0z"
+                fill="currentColor"
+              />
+            </svg>
+            <span>
+              Lock It Down!
+            </span>
+          </button>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`AuthPasswordResetPage > should render AuthPasswordResetPage when error 1`] = `
+<div>
+  <div
+    class="main"
+  >
+    <div
+      class="header"
+    >
+      <button
+        class="logo"
+      >
+        <img
+          alt="Klurigo"
+          class="icon"
+          src="/src/assets/images/klurigo-icon.svg"
+        />
+        <span
+          class="text"
+        >
+          Klurigo
+        </span>
+      </button>
+      <div
+        class="side"
+      >
+        <a
+          data-discover="true"
+          href="/auth/login"
+        >
+          Login
+        </a>
+      </div>
+    </div>
+    <div
+      class="content fullWidth centerAlign"
+    >
+      <div
+        class="badge large red"
+      >
+        <svg
+          aria-hidden="true"
+          class="svg-inline--fa fa-xmark "
+          data-icon="xmark"
+          data-prefix="fas"
+          focusable="false"
+          role="img"
+          viewBox="0 0 384 512"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M342.6 150.6c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0L192 210.7 86.6 105.4c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3L146.7 256 41.4 361.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0L192 301.3 297.4 406.6c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3L237.3 256 342.6 150.6z"
+            fill="currentColor"
+          />
+        </svg>
+      </div>
+      <div
+        class="typography subtitle small"
+      >
+        Oops! Something went wrong.
+      </div>
+      <div
+        class="typography text medium"
+      >
+        The supplied link is invalid or has expired.
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`AuthPasswordResetPage > should render AuthPasswordResetPage when loading 1`] = `
+<div>
+  <div
+    class="main"
+  >
+    <div
+      class="header"
+    >
+      <button
+        class="logo"
+      >
+        <img
+          alt="Klurigo"
+          class="icon"
+          src="/src/assets/images/klurigo-icon.svg"
+        />
+        <span
+          class="text"
+        >
+          Klurigo
+        </span>
+      </button>
+      <div
+        class="side"
+      >
+        <a
+          data-discover="true"
+          href="/auth/login"
+        >
+          Login
+        </a>
+      </div>
+    </div>
+    <div
+      class="content fullWidth centerAlign"
+    >
+      <div
+        class="typography subtitle full"
+      >
+        Lock It Down!
+      </div>
+      <div
+        class="typography text medium"
+      >
+        Choose your dazzling new password and confirm it below. Let’s keep those sneaky hackers out!
+      </div>
+      <form
+        class="form"
+      >
+        <div
+          class="inputContainer"
+        >
+          <div
+            class="textFieldInputContainer textFieldInputKindPrimary disabled"
+          >
+            <input
+              class="textfield"
+              data-testid="test-password-textfield"
+              disabled=""
+              id="password"
+              maxlength="128"
+              minlength="8"
+              name="password"
+              placeholder="New Password"
+              type="password"
+              value=""
+            />
+          </div>
+        </div>
+        <div
+          class="inputContainer"
+        >
+          <div
+            class="textFieldInputContainer textFieldInputKindPrimary disabled"
+          >
+            <input
+              class="textfield"
+              data-testid="test-confirmPassword-textfield"
+              disabled=""
+              id="confirmPassword"
+              maxlength="128"
+              minlength="8"
+              name="confirmPassword"
+              placeholder="Confirm Password"
+              type="password"
+              value=""
+            />
+          </div>
+        </div>
+        <div
+          class="buttonInputContainer buttonInputKindCallToAction"
+        >
+          <button
+            data-testid="test-reset-password-button-button"
+            disabled=""
+            id="reset-password-button"
+            name="reset-password-button"
+            type="submit"
+          >
+            <div
+              class="loadingSpinner"
+            >
+              <div />
+              <div />
+              <div />
+            </div>
+          </button>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>
+`;

--- a/packages/quiz/src/pages/AuthPasswordResetPage/components/AuthPasswordResetPageUI/index.ts
+++ b/packages/quiz/src/pages/AuthPasswordResetPage/components/AuthPasswordResetPageUI/index.ts
@@ -1,0 +1,5 @@
+export type {
+  AuthPasswordResetFormFields,
+  AuthPasswordResetPageUIProps,
+} from './AuthPasswordResetPageUI'
+export { default } from './AuthPasswordResetPageUI'

--- a/packages/quiz/src/pages/AuthPasswordResetPage/components/index.ts
+++ b/packages/quiz/src/pages/AuthPasswordResetPage/components/index.ts
@@ -1,0 +1,5 @@
+export type {
+  AuthPasswordResetFormFields,
+  AuthPasswordResetPageUIProps,
+} from './AuthPasswordResetPageUI'
+export { default as AuthPasswordResetPageUI } from './AuthPasswordResetPageUI'

--- a/packages/quiz/src/pages/AuthPasswordResetPage/index.ts
+++ b/packages/quiz/src/pages/AuthPasswordResetPage/index.ts
@@ -1,0 +1,1 @@
+export { default } from './AuthPasswordResetPage'

--- a/packages/quiz/src/pages/index.ts
+++ b/packages/quiz/src/pages/index.ts
@@ -1,5 +1,7 @@
 export { default as AuthGamePage } from './AuthGamePage'
 export { default as AuthLoginPage } from './AuthLoginPage'
+export { default as AuthPasswordForgotPage } from './AuthPasswordForgotPage'
+export { default as AuthPasswordResetPage } from './AuthPasswordResetPage'
 export { default as AuthRegisterPage } from './AuthRegisterPage'
 export { default as AuthVerifyPage } from './AuthVerifyPage'
 export { default as ErrorPage } from './ErrorPage'


### PR DESCRIPTION
- Fix reset link URL in UserService from `/auth/password_reset` to `/auth/password/reset`
- Extend `apiPatch` to accept an optional override token
- Add `sendPasswordResetEmail` and `resetPassword` methods to the QuizService client
- Introduce `AuthPasswordForgotPage` and `AuthPasswordResetPage` components, UIs, stories, and tests
- Register new routes for `/auth/password/forgot` and `/auth/password/reset`
- Add “Forgot your password?” link on the login page