### PR TITLE
feat(migration): introduce MigrationContext and integrate legacyPlayerId flow

### DIFF
--- a/packages/quiz/src/context/migration/MigrationContextProvider.tsx
+++ b/packages/quiz/src/context/migration/MigrationContextProvider.tsx
@@ -1,0 +1,55 @@
+import React, { FC, ReactNode, useMemo } from 'react'
+
+import { MigrationContext, MigrationContextType } from './migration-context.tsx'
+
+/**
+ * Props for the `MigrationContextProvider` component.
+ *
+ * @property children - The child components to be wrapped by the provider.
+ */
+export interface MigrationContextProvider {
+  children: ReactNode | ReactNode[]
+}
+
+/**
+ *
+ * @param children
+ * @constructor
+ */
+const MigrationContextProvider: FC<MigrationContextProvider> = ({
+  children,
+}) => {
+  const clientId = useMemo(() => {
+    const clientObject = localStorage.getItem('client') || undefined
+    return clientObject && (JSON.parse(clientObject) as { id: string }).id
+  }, [])
+
+  const playerId = useMemo(() => {
+    const playerObject = localStorage.getItem('player') || undefined
+    return playerObject && (JSON.parse(playerObject) as { id: string }).id
+  }, [])
+
+  const handleCompleteMigration = () => {
+    localStorage.removeItem('client')
+    localStorage.removeItem('player')
+    localStorage.removeItem('token')
+  }
+
+  const value = useMemo<MigrationContextType>(
+    () => ({
+      clientId,
+      playerId,
+      migrated: !clientId && !playerId,
+      completeMigration: handleCompleteMigration,
+    }),
+    [clientId, playerId],
+  )
+
+  return (
+    <MigrationContext.Provider value={value}>
+      {children}
+    </MigrationContext.Provider>
+  )
+}
+
+export default MigrationContextProvider

--- a/packages/quiz/src/context/migration/index.ts
+++ b/packages/quiz/src/context/migration/index.ts
@@ -1,0 +1,4 @@
+export type { MigrationContextType } from './migration-context'
+export { MigrationContext } from './migration-context'
+export { default } from './MigrationContextProvider'
+export { useMigrationContext } from './use-migration-context'

--- a/packages/quiz/src/context/migration/migration-context.tsx
+++ b/packages/quiz/src/context/migration/migration-context.tsx
@@ -1,0 +1,32 @@
+import { createContext } from 'react'
+
+/**
+ * Defines the shape of the migration context value.
+ *
+ * Provides:
+ * - `clientId`: The legacy client ID retrieved from localStorage, if any.
+ * - `playerId`: The legacy player ID retrieved from localStorage, if any.
+ * - `migrated`: Whether migration has already been completed.
+ * - `completeMigration`: Function to clear legacy identifiers and mark migration as done.
+ */
+export interface MigrationContextType {
+  clientId?: string
+  playerId?: string
+  migrated: boolean
+  completeMigration: () => void
+}
+
+/**
+ * React context for migration state.
+ *
+ * Defaults to:
+ * - `clientId` and `playerId` undefined
+ * - `migrated` false
+ * - `completeMigration` no-op
+ */
+export const MigrationContext = createContext<MigrationContextType>({
+  clientId: undefined,
+  playerId: undefined,
+  migrated: false,
+  completeMigration: () => undefined,
+})

--- a/packages/quiz/src/context/migration/use-migration-context.tsx
+++ b/packages/quiz/src/context/migration/use-migration-context.tsx
@@ -1,0 +1,11 @@
+import { useContext } from 'react'
+
+import { MigrationContext } from './migration-context'
+
+/**
+ * A custom hook for accessing the `MigrationContext`.
+ *
+ * @returns The current migration state and actions:
+ *          `{ clientId, playerId, migrated, completeMigration }`
+ */
+export const useMigrationContext = () => useContext(MigrationContext)

--- a/packages/quiz/src/main.tsx
+++ b/packages/quiz/src/main.tsx
@@ -8,6 +8,7 @@ import { Bounce, ToastContainer } from 'react-toastify'
 import { ProtectedRoute } from './components'
 import AuthContextProvider from './context/auth'
 import GameContextProvider from './context/game'
+import MigrationContextProvider from './context/migration'
 import {
   AuthGamePage,
   AuthGoogleCallbackPage,
@@ -39,7 +40,9 @@ const router = createBrowserRouter([
     path: '/',
     element: (
       <AuthContextProvider>
-        <Outlet />
+        <MigrationContextProvider>
+          <Outlet />
+        </MigrationContextProvider>
       </AuthContextProvider>
     ),
     children: [


### PR DESCRIPTION
- Add MigrationContextProvider with clientId, playerId, migrated flag, and completeMigration()
- Expose useMigrationContext hook for accessing migration state/actions
- Inject migrated & playerId into useQuizServiceClient
  - Append legacyPlayerId query param to login, Google exchange, and register calls when migration pending
  - Call completeMigration() once on first successful auth/register
- Wrap app routes in MigrationContextProvider in main.tsx
