### PR TITLE
Add legacy player migration support to authentication flow

### DIFF
--- a/packages/quiz-service/src/app/app.module.ts
+++ b/packages/quiz-service/src/app/app.module.ts
@@ -18,6 +18,7 @@ import { AuthModule } from '../auth'
 import { GameModule } from '../game'
 import { HealthModule } from '../health'
 import { MediaModule } from '../media'
+import { MigrationModule } from '../migration'
 import { QuizModule } from '../quiz'
 import { UserModule } from '../user'
 
@@ -181,6 +182,7 @@ const isTestEnv = process.env.NODE_ENV === 'test'
     GameModule,
     HealthModule,
     MediaModule,
+    MigrationModule,
     QuizModule,
     UserModule,
   ],

--- a/packages/quiz-service/src/auth/auth.module.ts
+++ b/packages/quiz-service/src/auth/auth.module.ts
@@ -11,6 +11,7 @@ import * as jwt from 'jsonwebtoken'
 
 import { EnvironmentVariables } from '../app/config'
 import { GameModule } from '../game'
+import { MigrationModule } from '../migration'
 import { UserModule } from '../user'
 
 import { AuthController } from './controllers'
@@ -59,6 +60,7 @@ import { Token, TokenSchema } from './services/models/schemas'
     EventEmitterModule,
     HttpModule,
     GameModule,
+    forwardRef(() => MigrationModule),
     forwardRef(() => UserModule),
   ],
   controllers: [AuthController],

--- a/packages/quiz-service/src/auth/services/auth.service.spec.ts
+++ b/packages/quiz-service/src/auth/services/auth.service.spec.ts
@@ -25,6 +25,8 @@ describe('AuthService', () => {
       /* eventEmitter   */ eventEmitter,
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       /* configService  */ {} as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      /* configService  */ {} as any,
     )
 
     // Override the internal logger so we can spy on .error()

--- a/packages/quiz-service/src/auth/services/google-auth.service.ts
+++ b/packages/quiz-service/src/auth/services/google-auth.service.ts
@@ -62,7 +62,7 @@ export class GoogleAuthService {
       return data.access_token
     } catch (error) {
       const { message, stack } = error as Error
-      this.logger.error(
+      this.logger.warn(
         `Failed to exchange code for access token: '${message}'.`,
         stack,
       )
@@ -93,7 +93,7 @@ export class GoogleAuthService {
       return response.data
     } catch (error) {
       const { message, stack } = error as Error
-      this.logger.error(
+      this.logger.warn(
         `Failed to fetch Google user profile: '${message}'.`,
         stack,
       )

--- a/packages/quiz-service/src/game/game.module.ts
+++ b/packages/quiz-service/src/game/game.module.ts
@@ -65,6 +65,6 @@ import {
     GameTaskTransitionService,
     GameTaskTransitionScheduler,
   ],
-  exports: [GameRepository],
+  exports: [GameRepository, GameResultRepository],
 })
 export class GameModule {}

--- a/packages/quiz-service/src/game/repositories/models/schemas/task.schema.ts
+++ b/packages/quiz-service/src/game/repositories/models/schemas/task.schema.ts
@@ -170,13 +170,7 @@ export class QuestionTask {
   questionIndex: number
 
   @Prop({ type: [QuestionTaskBaseAnswerSchema], required: true })
-  answers: (QuestionTaskBaseAnswer &
-    (
-      | QuestionTaskMultiChoiceAnswer
-      | QuestionTaskRangeAnswer
-      | QuestionTaskTrueFalseAnswer
-      | QuestionTaskTypeAnswerAnswer
-    ))[]
+  answers: QuestionTaskAnswer[]
 
   @Prop({ type: Date, default: () => new Date() })
   presented?: Date
@@ -231,13 +225,7 @@ export class QuestionResultTaskItem {
   nickname: string
 
   @Prop({ type: QuestionTaskBaseAnswerSchema, required: false })
-  answer?: QuestionTaskBaseAnswer &
-    (
-      | QuestionTaskMultiChoiceAnswer
-      | QuestionTaskRangeAnswer
-      | QuestionTaskTrueFalseAnswer
-      | QuestionTaskTypeAnswerAnswer
-    )
+  answer?: QuestionTaskAnswer
 
   @Prop({ type: Boolean, required: true })
   correct: boolean

--- a/packages/quiz-service/src/migration/index.ts
+++ b/packages/quiz-service/src/migration/index.ts
@@ -1,0 +1,1 @@
+export * from './migration.module'

--- a/packages/quiz-service/src/migration/migration.module.ts
+++ b/packages/quiz-service/src/migration/migration.module.ts
@@ -1,0 +1,22 @@
+import { forwardRef, Module } from '@nestjs/common'
+
+import { GameModule } from '../game'
+import { QuizModule } from '../quiz'
+import { UserModule } from '../user'
+
+import { MigrationService } from './services'
+
+/**
+ * Module for managing user-related operations.
+ */
+@Module({
+  imports: [
+    forwardRef(() => GameModule),
+    forwardRef(() => QuizModule),
+    forwardRef(() => UserModule),
+  ],
+  controllers: [],
+  providers: [MigrationService],
+  exports: [MigrationService],
+})
+export class MigrationModule {}

--- a/packages/quiz-service/src/migration/services/index.ts
+++ b/packages/quiz-service/src/migration/services/index.ts
@@ -1,0 +1,1 @@
+export * from './migration.service'

--- a/packages/quiz-service/src/migration/services/migration.service.spec.ts
+++ b/packages/quiz-service/src/migration/services/migration.service.spec.ts
@@ -1,0 +1,164 @@
+import { BadRequestException, ConflictException } from '@nestjs/common'
+import { AuthProvider } from '@quiz/common'
+
+import { GameRepository, GameResultRepository } from '../../game/repositories'
+import { QuizRepository } from '../../quiz/repositories'
+import { User, UserRepository } from '../../user/repositories'
+
+import { MigrationService } from './migration.service'
+
+describe('MigrationService', () => {
+  let svc: MigrationService
+  let gameRepo: jest.Mocked<GameRepository>
+  let gameResultRepo: jest.Mocked<GameResultRepository>
+  let quizRepo: jest.Mocked<QuizRepository>
+  let userRepo: jest.Mocked<UserRepository>
+
+  const LEGACY_ID = 'legacy-id'
+  const EXISTING_ID = 'existing-id'
+  const UPDATE: Partial<User> = { email: 'new@example.com' }
+
+  beforeEach(() => {
+    gameRepo = {
+      updateGameParticipant: jest.fn().mockResolvedValue(undefined),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any
+
+    gameResultRepo = {
+      updateGameResultParticipant: jest.fn().mockResolvedValue(undefined),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any
+
+    quizRepo = {
+      updateQuizOwner: jest.fn().mockResolvedValue(undefined),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any
+
+    userRepo = {
+      findUserById: jest.fn(),
+      findUserByIdAndUpdateOrThrow: jest.fn(),
+      createUser: jest.fn(),
+      findUserByIdOrThrow: jest.fn(),
+      deleteUserById: jest.fn(),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any
+
+    svc = new MigrationService(gameRepo, gameResultRepo, quizRepo, userRepo)
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    jest.spyOn((svc as any).logger, 'log').mockImplementation()
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    jest.spyOn((svc as any).logger, 'warn').mockImplementation()
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    jest.spyOn((svc as any).logger, 'error').mockImplementation()
+  })
+
+  it('should update in place when legacy exists and updateDetails provided', async () => {
+    const fakeUser = { _id: LEGACY_ID, authProvider: AuthProvider.None } as User
+    userRepo.findUserById.mockResolvedValue(fakeUser)
+    userRepo.findUserByIdAndUpdateOrThrow.mockResolvedValue({
+      ...fakeUser,
+      ...UPDATE,
+    })
+
+    const result = await svc.migrateLegacyPlayerUser<User>(
+      LEGACY_ID,
+      undefined,
+      UPDATE,
+    )
+    expect(userRepo.findUserById).toHaveBeenCalledWith(LEGACY_ID)
+    expect(userRepo.findUserByIdAndUpdateOrThrow).toHaveBeenCalledWith(
+      LEGACY_ID,
+      UPDATE,
+    )
+    expect(result.email).toBe(UPDATE.email)
+  })
+
+  it('should create new when user not found and updateDetails provided', async () => {
+    userRepo.findUserById.mockResolvedValue(null)
+    userRepo.createUser.mockResolvedValue({ _id: LEGACY_ID, ...UPDATE } as User)
+
+    const result = await svc.migrateLegacyPlayerUser<User>(
+      LEGACY_ID,
+      undefined,
+      UPDATE,
+    )
+    expect(userRepo.createUser).toHaveBeenCalledWith({
+      _id: LEGACY_ID,
+      ...UPDATE,
+    })
+    expect(result._id).toBe(LEGACY_ID)
+  })
+
+  it('should merge when existingUserId given and legacy valid', async () => {
+    const legacyUser = {
+      _id: LEGACY_ID,
+      authProvider: AuthProvider.None,
+    } as User
+    const existingUser = {
+      _id: EXISTING_ID,
+      authProvider: AuthProvider.Local,
+    } as User
+
+    userRepo.findUserById.mockResolvedValue(legacyUser)
+    userRepo.findUserByIdOrThrow.mockResolvedValue(existingUser)
+
+    const result = await svc.migrateLegacyPlayerUser<User>(
+      LEGACY_ID,
+      EXISTING_ID,
+      undefined,
+    )
+    expect(gameRepo.updateGameParticipant).toHaveBeenCalledWith(
+      LEGACY_ID,
+      EXISTING_ID,
+    )
+    expect(gameResultRepo.updateGameResultParticipant).toHaveBeenCalledWith(
+      LEGACY_ID,
+      EXISTING_ID,
+    )
+    expect(quizRepo.updateQuizOwner).toHaveBeenCalledWith(
+      LEGACY_ID,
+      EXISTING_ID,
+    )
+    expect(userRepo.deleteUserById).toHaveBeenCalledWith(LEGACY_ID)
+    expect(result).toBe(existingUser)
+  })
+
+  it('should throw when merge fails inside try', async () => {
+    const legacyUser = {
+      _id: LEGACY_ID,
+      authProvider: AuthProvider.None,
+    } as User
+    userRepo.findUserById.mockResolvedValue(legacyUser)
+    userRepo.findUserByIdOrThrow.mockResolvedValue({ _id: EXISTING_ID } as User)
+    gameRepo.updateGameParticipant.mockRejectedValue(new Error('oops'))
+
+    await expect(
+      svc.migrateLegacyPlayerUser<User>(LEGACY_ID, EXISTING_ID, undefined),
+    ).rejects.toBeInstanceOf(BadRequestException)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((svc as any).logger.warn).toHaveBeenCalled()
+  })
+
+  it('should conflict when legacy already migrated', async () => {
+    const migratedUser = {
+      _id: LEGACY_ID,
+      authProvider: AuthProvider.Google,
+    } as User
+    userRepo.findUserById.mockResolvedValue(migratedUser)
+
+    await expect(
+      svc.migrateLegacyPlayerUser<User>(LEGACY_ID, undefined, undefined),
+    ).rejects.toBeInstanceOf(ConflictException)
+  })
+
+  it('should fatal-error when no args and no user found', async () => {
+    userRepo.findUserById.mockResolvedValue(null)
+
+    await expect(
+      svc.migrateLegacyPlayerUser<User>(LEGACY_ID, undefined, undefined),
+    ).rejects.toBeInstanceOf(BadRequestException)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((svc as any).logger.error).toHaveBeenCalled()
+  })
+})

--- a/packages/quiz-service/src/migration/services/migration.service.ts
+++ b/packages/quiz-service/src/migration/services/migration.service.ts
@@ -1,0 +1,136 @@
+import {
+  BadRequestException,
+  ConflictException,
+  Injectable,
+  Logger,
+} from '@nestjs/common'
+import { AuthProvider } from '@quiz/common'
+
+import { GameRepository, GameResultRepository } from '../../game/repositories'
+import { QuizRepository } from '../../quiz/repositories'
+import { User, UserRepository } from '../../user/repositories'
+
+/**
+ * Service for migrating data from legacy (anonymous) users into real accounts,
+ * or updating legacy-only user details in place.
+ */
+@Injectable()
+export class MigrationService {
+  // Logger instance for recording migration service operations.
+  private readonly logger: Logger = new Logger(MigrationService.name)
+
+  /**
+   * Initializes the MigrationService.
+   *
+   * @param gameRepository        Repository for game document operations.
+   * @param gameResultRepository  Repository for game-result document operations.
+   * @param quizRepository        Repository for quiz document operations.
+   * @param userRepository        Repository for user document operations.
+   */
+  constructor(
+    private readonly gameRepository: GameRepository,
+    private readonly gameResultRepository: GameResultRepository,
+    private readonly quizRepository: QuizRepository,
+    private readonly userRepository: UserRepository,
+  ) {}
+
+  /**
+   * Migrate data from a legacy anonymous user into an existing account,
+   * or update a legacy user’s details in place if no target account is given.
+   *
+   * @param legacyPlayerId   ID of the anonymous/legacy user.
+   * @param existingUserId   (Optional) ID of the existing user to merge into.
+   * @param updateDetails    (Optional) New details to set when updating in place.
+   * @returns A Promise resolving to the User document after migration or update.
+   */
+  public async migrateLegacyPlayerUser<T extends User>(
+    legacyPlayerId: string,
+    existingUserId?: string,
+    updateDetails?: Partial<T>,
+  ): Promise<T> {
+    const legacyPlayerUser =
+      await this.userRepository.findUserById(legacyPlayerId)
+
+    const isLegacyPlayerValid =
+      legacyPlayerUser && legacyPlayerUser.authProvider === AuthProvider.None
+
+    const isLegacyPlayerMigrated =
+      legacyPlayerUser && legacyPlayerUser.authProvider !== AuthProvider.None
+
+    // Simulate user creation, update details but skip data migration
+    if (!existingUserId && updateDetails && isLegacyPlayerValid) {
+      this.logger.log(`Migrating legacy player '${legacyPlayerId}'.`)
+
+      return this.userRepository.findUserByIdAndUpdateOrThrow<T>(
+        legacyPlayerId,
+        updateDetails,
+      )
+    }
+    // Create an actual new user in case of the legacy player does not exist
+    else if (!existingUserId && updateDetails && !legacyPlayerUser) {
+      this.logger.log(`Create new user from legacy player '${legacyPlayerId}'.`)
+      return this.userRepository.createUser<T>({
+        _id: legacyPlayerId,
+        ...updateDetails,
+      })
+    }
+    // An already migrated user exists
+    else if (existingUserId && !updateDetails) {
+      this.logger.log(
+        `Migrating legacy player '${legacyPlayerId}' to '${existingUserId}'.`,
+      )
+
+      const migratedUser =
+        await this.userRepository.findUserByIdOrThrow<T>(existingUserId)
+
+      // Associate the legacy player with the already migrated user
+      if (isLegacyPlayerValid) {
+        try {
+          await this.gameRepository.updateGameParticipant(
+            legacyPlayerId,
+            existingUserId,
+          )
+
+          await this.gameResultRepository.updateGameResultParticipant(
+            legacyPlayerId,
+            existingUserId,
+          )
+
+          await this.quizRepository.updateQuizOwner(
+            legacyPlayerId,
+            existingUserId,
+          )
+
+          await this.userRepository.deleteUserById(legacyPlayerId)
+        } catch (error) {
+          const { message, stack } = error as Error
+          this.logger.warn(
+            `Failed to migrate legacy player '${legacyPlayerId}': '${message}'.`,
+            stack,
+          )
+          throw new BadRequestException(
+            `Failed to migrate legacy player '${legacyPlayerId}'`,
+          )
+        }
+      }
+
+      return migratedUser
+    }
+    // Legacy player already migrated
+    else if (isLegacyPlayerMigrated) {
+      this.logger.log(
+        `Unable to migrate legacy player '${legacyPlayerId}', already migrated.`,
+      )
+      throw new ConflictException(
+        `Unable to migrate legacy player '${legacyPlayerId}', already migrated`,
+      )
+    }
+
+    this.logger.error(
+      `Fatal error: Unable to migrate legacy player '${legacyPlayerId}', should not reach here.`,
+    )
+    throw new BadRequestException(
+      `Unable to migrate legacy player '${legacyPlayerId}'`,
+    )
+  }
+}

--- a/packages/quiz-service/src/quiz/repositories/quiz.repository.ts
+++ b/packages/quiz-service/src/quiz/repositories/quiz.repository.ts
@@ -141,4 +141,33 @@ export class QuizRepository {
 
     this.logger.log(`Deleted quiz by id '${quizId}'.`)
   }
+
+  /**
+   * Updates the owner field on all quizzes from one user to another.
+   *
+   * @param fromUserId  The ID of the current quiz owner.
+   * @param toUserId    The ID of the new quiz owner.
+   * @returns A Promise that resolves once all matching quizzes have been updated.
+   */
+  public async updateQuizOwner(
+    fromUserId: string,
+    toUserId: string,
+  ): Promise<void> {
+    this.logger.log(
+      `Updating quiz owner from '${fromUserId}' to '${toUserId}'.`,
+    )
+
+    try {
+      await this.quizModel.updateMany(
+        { owner: fromUserId },
+        { $set: { owner: toUserId } },
+      )
+    } catch (error) {
+      const { message, stack } = error as Error
+      this.logger.warn(
+        `Unable update quiz owner from '${fromUserId} to '${toUserId}': ${message}`,
+        stack,
+      )
+    }
+  }
 }

--- a/packages/quiz-service/src/user/controllers/user.controller.ts
+++ b/packages/quiz-service/src/user/controllers/user.controller.ts
@@ -1,4 +1,12 @@
-import { Body, Controller, HttpCode, HttpStatus, Post } from '@nestjs/common'
+import {
+  Body,
+  Controller,
+  HttpCode,
+  HttpStatus,
+  ParseUUIDPipe,
+  Post,
+  Query,
+} from '@nestjs/common'
 import {
   ApiBadRequestResponse,
   ApiBearerAuth,
@@ -6,6 +14,7 @@ import {
   ApiConflictResponse,
   ApiOkResponse,
   ApiOperation,
+  ApiQuery,
   ApiTags,
 } from '@nestjs/swagger'
 import { Throttle } from '@nestjs/throttler'
@@ -33,6 +42,7 @@ export class UserController {
    * Creates a new user account.
    *
    * @param createUserRequest DTO containing email, password, and optional names.
+   * @param legacyPlayerId - Optional player ID from the old system to migrate player data.
    * @returns The newly created user’s details.
    */
   @Public()
@@ -46,6 +56,13 @@ export class UserController {
     summary: 'Create new user',
     description:
       'Registers a new user with email, password, and optional names.',
+  })
+  @ApiQuery({
+    name: 'legacyPlayerId',
+    description: 'Optional player ID from the legacy system for migration',
+    type: String,
+    format: 'uuid',
+    required: false,
   })
   @ApiBody({
     description: 'Payload for creating a new user.',
@@ -64,7 +81,9 @@ export class UserController {
   @HttpCode(HttpStatus.CREATED)
   public async createUser(
     @Body() createUserRequest: CreateUserRequest,
+    @Query('legacyPlayerId', new ParseUUIDPipe({ optional: true }))
+    legacyPlayerId?: string,
   ): Promise<CreateUserResponse> {
-    return this.userService.createUser(createUserRequest)
+    return this.userService.createUser(createUserRequest, legacyPlayerId)
   }
 }

--- a/packages/quiz-service/src/user/repositories/models/schemas/user.schema.ts
+++ b/packages/quiz-service/src/user/repositories/models/schemas/user.schema.ts
@@ -81,7 +81,7 @@ export class User implements IUser {
    */
   @Prop({
     type: String,
-    enum: [AuthProvider.Local, AuthProvider.Google],
+    enum: [AuthProvider.None, AuthProvider.Local, AuthProvider.Google],
     required: true,
   })
   authProvider: AuthProvider
@@ -276,3 +276,64 @@ export class GoogleUser implements IUser {
  * Schema factory for the GoogleUser class.
  */
 export const GoogleUserSchema = SchemaFactory.createForClass(GoogleUser)
+
+/**
+ * Schema for a user with no external auth provider (anonymous/legacy player).
+ */
+@Schema({ _id: false })
+export class NoneUser implements IUser {
+  /**
+   * The user’s unique identifier.
+   */
+  _id: string
+
+  /**
+   * The user’s authentication provider, None in for this discriminator.
+   */
+  authProvider!: AuthProvider.None
+
+  /**
+   * The user’s unique email address.
+   */
+  email: string
+
+  /**
+   * The user’s unverified email address (optional).
+   */
+  unverifiedEmail?: string
+
+  /**
+   * The user’s given name (optional).
+   */
+  givenName?: string
+
+  /**
+   * The user’s family name (optional).
+   */
+  familyName?: string
+
+  /**
+   * The user’s default nickname used for when participating in games (optional).
+   */
+  defaultNickname?: string
+
+  /**
+   * Date and time of the user's last successful login.
+   */
+  lastLoggedInAt?: Date
+
+  /**
+   * Timestamp when the user was created (ISO-8601 string).
+   */
+  createdAt: Date
+
+  /**
+   * Timestamp when the user was last updated (ISO-8601 string).
+   */
+  updatedAt: Date
+}
+
+/**
+ * Schema factory for the NoneUser class.
+ */
+export const NoneUserSchema = SchemaFactory.createForClass(NoneUser)

--- a/packages/quiz-service/src/user/user.module.ts
+++ b/packages/quiz-service/src/user/user.module.ts
@@ -5,6 +5,7 @@ import { AuthProvider } from '@quiz/common'
 
 import { AuthModule } from '../auth'
 import { EmailModule } from '../email'
+import { MigrationModule } from '../migration'
 
 import {
   UserAuthController,
@@ -14,6 +15,7 @@ import {
 import {
   GoogleUserSchema,
   LocalUserSchema,
+  NoneUserSchema,
   User,
   UserRepository,
   UserSchema,
@@ -30,6 +32,7 @@ import { UserEventHandler, UserService } from './services'
         name: User.name,
         schema: UserSchema,
         discriminators: [
+          { name: AuthProvider.None, schema: NoneUserSchema },
           { name: AuthProvider.Local, schema: LocalUserSchema },
           { name: AuthProvider.Google, schema: GoogleUserSchema },
         ],
@@ -38,6 +41,7 @@ import { UserEventHandler, UserService } from './services'
     EventEmitterModule,
     forwardRef(() => AuthModule),
     EmailModule,
+    forwardRef(() => MigrationModule),
   ],
   controllers: [UserController, UserProfileController, UserAuthController],
   providers: [UserService, UserRepository, UserEventHandler],

--- a/packages/quiz-service/test-utils/data/data.utils.ts
+++ b/packages/quiz-service/test-utils/data/data.utils.ts
@@ -2,20 +2,25 @@ import {
   GameMode,
   GameParticipantType,
   GameStatus,
+  LanguageCode,
   MediaType,
   QuestionRangeAnswerMargin,
   QuestionType,
+  QuizCategory,
+  QuizVisibility,
 } from '@quiz/common'
 import { v4 as uuidv4 } from 'uuid'
 
 import {
   BaseTask,
   Game,
+  GameResult,
   LeaderboardTask,
   LeaderboardTaskItem,
   ParticipantBase,
   ParticipantHost,
   ParticipantPlayer,
+  PlayerMetric,
   PodiumTask,
   QuestionResultTask,
   QuestionResultTaskItem,
@@ -38,6 +43,7 @@ import {
   QuestionTypeAnswerDao,
   Quiz,
 } from '../../src/quiz/repositories/models/schemas'
+import { User } from '../../src/user/repositories'
 
 import { offsetSeconds } from './helpers.utils'
 
@@ -328,5 +334,122 @@ export function createMockQuitTaskDocument(
     status: 'completed',
     created: offsetSeconds(0),
     ...(task ?? {}),
+  }
+}
+
+export function createMockGameResultDocument(
+  gameResult?: Partial<GameResult>,
+): GameResult {
+  return {
+    _id: uuidv4(),
+    game: { _id: uuidv4() } as Game,
+    name: 'Trivia Battle',
+    hostParticipantId: MOCK_DEFAULT_PLAYER_ID,
+    players: [],
+    questions: [],
+    hosted: new Date(),
+    completed: new Date(),
+    ...(gameResult ?? {}),
+  }
+}
+
+export function createMockGameResultPlayerMetric(
+  playerMetric?: Partial<PlayerMetric>,
+): PlayerMetric {
+  return {
+    participantId: MOCK_DEFAULT_PLAYER_ID,
+    nickname: MOCK_DEFAULT_PLAYER_NICKNAME,
+    rank: 0,
+    correct: 0,
+    incorrect: 0,
+    unanswered: 0,
+    averageResponseTime: 0,
+    longestCorrectStreak: 0,
+    score: 0,
+    ...(playerMetric ?? {}),
+  }
+}
+
+export function createMockClassicQuiz(quiz?: Partial<Quiz>): Quiz {
+  return {
+    _id: uuidv4(),
+    title: 'Trivia Battle',
+    description: 'A fun and engaging trivia quiz for all ages.',
+    mode: GameMode.Classic,
+    visibility: QuizVisibility.Public,
+    category: QuizCategory.GeneralKnowledge,
+    imageCoverURL: 'https://example.com/question-cover-image.png',
+    languageCode: LanguageCode.English,
+    questions: [
+      {
+        type: QuestionType.MultiChoice,
+        text: 'What is the capital of Sweden?',
+        media: {
+          type: MediaType.Image,
+          url: 'https://example.com/question-image.png',
+        },
+        options: [
+          {
+            value: 'Stockholm',
+            correct: true,
+          },
+          {
+            value: 'Copenhagen',
+            correct: false,
+          },
+          {
+            value: 'London',
+            correct: false,
+          },
+          {
+            value: 'Berlin',
+            correct: false,
+          },
+        ],
+        points: 1000,
+        duration: 30,
+      },
+      {
+        type: QuestionType.Range,
+        text: 'Guess the temperature of the hottest day ever recorded.',
+        media: {
+          type: MediaType.Image,
+          url: 'https://example.com/question-image.png',
+        },
+        min: 0,
+        max: 100,
+        step: 0,
+        correct: 50,
+        margin: QuestionRangeAnswerMargin.Medium,
+        points: 1000,
+        duration: 30,
+      },
+      {
+        type: QuestionType.TrueFalse,
+        text: 'The earth is flat.',
+        media: {
+          type: MediaType.Image,
+          url: 'https://example.com/question-image.png',
+        },
+        correct: false,
+        points: 1000,
+        duration: 30,
+      },
+      {
+        type: QuestionType.TypeAnswer,
+        text: 'What is the capital of Denmark?',
+        media: {
+          type: MediaType.Image,
+          url: 'https://example.com/question-image.png',
+        },
+        options: ['Copenhagen'],
+        points: 1000,
+        duration: 30,
+      },
+    ],
+    owner: { _id: uuidv4() } as User,
+    created: new Date(),
+    updated: new Date(),
+    ...(quiz ?? {}),
   }
 }

--- a/packages/quiz-service/test-utils/data/user.data.ts
+++ b/packages/quiz-service/test-utils/data/user.data.ts
@@ -1,7 +1,7 @@
 import { AuthProvider } from '@quiz/common'
 import { v4 as uuidv4 } from 'uuid'
 
-import { GoogleUser, LocalUser } from '../../src/user/repositories'
+import { GoogleUser, LocalUser, NoneUser } from '../../src/user/repositories'
 
 export const MOCK_PRIMARY_USER_EMAIL = 'user@example.com'
 export const MOCK_PRIMARY_USER_GIVEN_NAME = 'John'
@@ -112,5 +112,16 @@ export function buildMockQuaternaryUser(user?: Partial<LocalUser>): LocalUser {
     createdAt: now,
     updatedAt: now,
     ...(user ?? {}),
+  }
+}
+
+export function buildMockLegacyPlayerUser(): NoneUser {
+  const now = new Date()
+  return {
+    _id: uuidv4(),
+    authProvider: AuthProvider.None,
+    email: 'n/a@na.na',
+    createdAt: now,
+    updatedAt: now,
   }
 }

--- a/packages/quiz/src/pages/AuthLoginPage/AuthLoginPage.tsx
+++ b/packages/quiz/src/pages/AuthLoginPage/AuthLoginPage.tsx
@@ -53,7 +53,6 @@ const AuthLoginPage: FC = () => {
     params.append('code_challenge', codeChallenge)
     params.append('code_challenge_method', 'S256')
 
-    console.log('https://accounts.google.com/o/oauth2/auth?', params.toString())
     window.location.href = `https://accounts.google.com/o/oauth2/auth?${params}`
   }
 

--- a/packages/quiz/src/utils/use-event-source.tsx
+++ b/packages/quiz/src/utils/use-event-source.tsx
@@ -46,7 +46,6 @@ export const useEventSource = (
       eventSourceRef.current = eventSource
 
       eventSource.onopen = () => {
-        console.log('Connection opened')
         setConnectionStatus(ConnectionStatus.CONNECTED)
       }
 


### PR DESCRIPTION
- Wire MigrationModule into AppModule, AuthModule and UserModule
- Extend AuthController and UserController to accept optional `legacyPlayerId` query parameter
- Update AuthService and UserService to call MigrationService when `legacyPlayerId` is provided
- Implement MigrationService for merging or updating legacy anonymous user data
- Add `updateGameParticipant` and `updateGameResultParticipant` methods to GameRepository and GameResultRepository
- Extend QuizRepository with `updateQuizOwner` to reassign quiz ownership
- Enrich test-utils with legacy player mocks and data creators for GameResult and Quiz
- Expand e2e specs for `/auth/login`, `/auth/google/exchange` and `/users` to cover all legacy-migration scenarios
- Enhance logging and JSDoc across newly added services and repository methods
