### PR TITLE
fix(user-auth): preserve unverifiedEmail when updating to the same unverified address

### DIFF
--- a/packages/quiz-service/src/user/controllers/user-profile.controller.e2e-spec.ts
+++ b/packages/quiz-service/src/user/controllers/user-profile.controller.e2e-spec.ts
@@ -214,6 +214,38 @@ describe('UserProfileController (e2e)', () => {
         })
     })
 
+    it('should not unset the local user’s unverified email when the new email equals the old unverified email', async () => {
+      const { accessToken, user } = await createDefaultUserAndAuthenticate(
+        app,
+        {
+          email: MOCK_PRIMARY_USER_EMAIL,
+          unverifiedEmail: MOCK_PRIMARY_USER_EMAIL,
+        } as Partial<LocalUser>,
+      )
+
+      return supertest(app.getHttpServer())
+        .put('/api/profile/user')
+        .set({ Authorization: `Bearer ${accessToken}` })
+        .send({
+          authProvider: AuthProvider.Local,
+          email: MOCK_PRIMARY_USER_EMAIL,
+        })
+        .expect(200)
+        .expect((res) => {
+          expect(res.body).toEqual({
+            id: user._id,
+            email: MOCK_PRIMARY_USER_EMAIL,
+            unverifiedEmail: MOCK_PRIMARY_USER_EMAIL,
+            givenName: MOCK_PRIMARY_USER_GIVEN_NAME,
+            familyName: MOCK_PRIMARY_USER_FAMILY_NAME,
+            defaultNickname: MOCK_PRIMARY_USER_DEFAULT_NICKNAME,
+            authProvider: AuthProvider.Local,
+            created: expect.any(String),
+            updated: expect.any(String),
+          })
+        })
+    })
+
     it('should update the local user’s default nickname containing emojis successfully', async () => {
       const { accessToken, user } = await createDefaultUserAndAuthenticate(app)
 

--- a/packages/quiz-service/src/user/services/user.service.ts
+++ b/packages/quiz-service/src/user/services/user.service.ts
@@ -520,6 +520,9 @@ export class UserService {
       if (newEmail !== originalUser.email) {
         return { unverifiedEmail: newEmail }
       }
+      if (originalUser.email === originalUser.unverifiedEmail) {
+        return {}
+      }
       return {
         email: newEmail,
         unverifiedEmail: undefined,


### PR DESCRIPTION
- Add check in UserService.updateProfile to skip unsetting unverifiedEmail if original email equals unverifiedEmail
- Return an empty change set in that scenario to leave unverifiedEmail intact
- Add e2e test in UserProfileController spec to verify unverifiedEmail remains when new email matches it