### PR TITLE
feat(user-profile): allow omitting givenName and familyName on update

### DIFF
--- a/packages/quiz-service/src/user/controllers/user-profile.controller.e2e-spec.ts
+++ b/packages/quiz-service/src/user/controllers/user-profile.controller.e2e-spec.ts
@@ -139,6 +139,9 @@ describe('UserProfileController (e2e)', () => {
         .set({ Authorization: `Bearer ${accessToken}` })
         .send({
           authProvider: AuthProvider.Google,
+          email: MOCK_PRIMARY_USER_EMAIL,
+          givenName: MOCK_PRIMARY_USER_GIVEN_NAME,
+          familyName: MOCK_PRIMARY_USER_FAMILY_NAME,
           defaultNickname: MOCK_SECONDARY_USER_DEFAULT_NICKNAME,
         })
         .expect(200)
@@ -165,6 +168,9 @@ describe('UserProfileController (e2e)', () => {
         .send({
           authProvider: AuthProvider.Local,
           email: MOCK_PRIMARY_USER_EMAIL,
+          givenName: MOCK_PRIMARY_USER_GIVEN_NAME,
+          familyName: MOCK_PRIMARY_USER_FAMILY_NAME,
+          defaultNickname: MOCK_PRIMARY_USER_DEFAULT_NICKNAME,
         })
         .expect(200)
         .expect((res) => {
@@ -197,6 +203,9 @@ describe('UserProfileController (e2e)', () => {
         .send({
           authProvider: AuthProvider.Local,
           email: MOCK_PRIMARY_USER_EMAIL,
+          givenName: MOCK_PRIMARY_USER_GIVEN_NAME,
+          familyName: MOCK_PRIMARY_USER_FAMILY_NAME,
+          defaultNickname: MOCK_PRIMARY_USER_DEFAULT_NICKNAME,
         })
         .expect(200)
         .expect((res) => {
@@ -229,6 +238,9 @@ describe('UserProfileController (e2e)', () => {
         .send({
           authProvider: AuthProvider.Local,
           email: MOCK_PRIMARY_USER_EMAIL,
+          givenName: MOCK_PRIMARY_USER_GIVEN_NAME,
+          familyName: MOCK_PRIMARY_USER_FAMILY_NAME,
+          defaultNickname: MOCK_PRIMARY_USER_DEFAULT_NICKNAME,
         })
         .expect(200)
         .expect((res) => {
@@ -256,6 +268,9 @@ describe('UserProfileController (e2e)', () => {
         .set({ Authorization: `Bearer ${accessToken}` })
         .send({
           authProvider: AuthProvider.Local,
+          email: MOCK_PRIMARY_USER_EMAIL,
+          givenName: MOCK_PRIMARY_USER_GIVEN_NAME,
+          familyName: MOCK_PRIMARY_USER_FAMILY_NAME,
           defaultNickname,
         })
         .expect(200)
@@ -286,6 +301,9 @@ describe('UserProfileController (e2e)', () => {
         .set({ Authorization: `Bearer ${accessToken}` })
         .send({
           authProvider: AuthProvider.Google,
+          email: MOCK_PRIMARY_USER_EMAIL,
+          givenName: MOCK_PRIMARY_USER_GIVEN_NAME,
+          familyName: MOCK_PRIMARY_USER_FAMILY_NAME,
           defaultNickname,
         })
         .expect(200)
@@ -311,6 +329,10 @@ describe('UserProfileController (e2e)', () => {
         .set({ Authorization: `Bearer ${accessToken}` })
         .send({
           authProvider: AuthProvider.Local,
+          email: MOCK_PRIMARY_USER_EMAIL,
+          givenName: MOCK_PRIMARY_USER_GIVEN_NAME,
+          familyName: MOCK_PRIMARY_USER_FAMILY_NAME,
+          defaultNickname: MOCK_PRIMARY_USER_DEFAULT_NICKNAME,
         })
         .expect(200)
         .expect((res) => {
@@ -398,6 +420,9 @@ describe('UserProfileController (e2e)', () => {
         .set({ Authorization: `Bearer ${accessToken}` })
         .send({
           authProvider: AuthProvider.Google,
+          email: MOCK_PRIMARY_USER_EMAIL,
+          givenName: MOCK_PRIMARY_USER_GIVEN_NAME,
+          familyName: MOCK_PRIMARY_USER_FAMILY_NAME,
           defaultNickname: '',
         })
         .expect(400)

--- a/packages/quiz-service/src/user/services/user.service.ts
+++ b/packages/quiz-service/src/user/services/user.service.ts
@@ -268,11 +268,9 @@ export class UserService {
       updatedDetails = {
         ...updatedDetails,
         ...this.computeEmailUpdate(request.email, originalUser),
-        ...(request.givenName && { givenName: request.givenName }),
-        ...(request.familyName && { familyName: request.familyName }),
-        ...(request.defaultNickname && {
-          defaultNickname: request.defaultNickname,
-        }),
+        givenName: request.givenName,
+        familyName: request.familyName,
+        defaultNickname: request.defaultNickname,
       } as Partial<LocalUser>
     }
     if (request.authProvider === AuthProvider.Google) {

--- a/packages/quiz/src/pages/ProfileUserPage/ProfileUserPage.tsx
+++ b/packages/quiz/src/pages/ProfileUserPage/ProfileUserPage.tsx
@@ -4,6 +4,7 @@ import React, { FC, useState } from 'react'
 
 import { useQuizServiceClient } from '../../api/use-quiz-service-client.tsx'
 import { LoadingSpinner, Page } from '../../components'
+import { trimToUndefined } from '../../utils/helpers.ts'
 
 import { ProfileUserPageUI, UpdateUserDetailsFormFields } from './components'
 import { UpdateUserPasswordFormFields } from './components/ProfileUserPageUI/components'
@@ -23,6 +24,7 @@ const ProfileUserPage: FC = () => {
     data,
     isLoading: isLoadingUserProfile,
     isError,
+    refetch,
   } = useQuery({
     queryKey: ['myUserProfile'],
     queryFn: getUserProfile,
@@ -36,15 +38,17 @@ const ProfileUserPage: FC = () => {
           ? {
               authProvider: AuthProvider.Local,
               email: request.email,
-              givenName: request.givenName,
-              familyName: request.familyName,
+              givenName: trimToUndefined(request.givenName),
+              familyName: trimToUndefined(request.familyName),
               defaultNickname: request.defaultNickname,
             }
           : {
               authProvider: AuthProvider.Google,
               defaultNickname: request.defaultNickname,
             }),
-      }).finally(() => setIsSavingUserProfile(false))
+      })
+        .then(() => refetch())
+        .finally(() => setIsSavingUserProfile(false))
     }
   }
 

--- a/packages/quiz/src/utils/helpers.ts
+++ b/packages/quiz/src/utils/helpers.ts
@@ -1,3 +1,9 @@
+/**
+ * Combines multiple class name values into a single space-separated string.
+ *
+ * @param classes - An array of class name values (string, null, or undefined).
+ * @returns A single string containing all non-empty, trimmed class names joined by spaces.
+ */
 export const classNames = (...classes: (string | null | undefined)[]) => {
   return classes
     .filter((value) => !!value)
@@ -27,6 +33,14 @@ export const extractUrl = (
   }
 }
 
+/**
+ * Determines if a given value is a valid number within an optional range.
+ *
+ * @param value - The number to validate.
+ * @param min - The minimum allowable value (inclusive).
+ * @param max - The maximum allowable value (inclusive).
+ * @returns True if `value` is a number (not NaN) and between `min` and `max` if those bounds are provided; otherwise false.
+ */
 export const isValidNumber = (
   value: number | undefined,
   min?: number,
@@ -37,4 +51,16 @@ export const isValidNumber = (
     (min !== undefined && value < min) ||
     (max !== undefined && value > max)
   )
+}
+
+/**
+ * Trims whitespace from a string and returns undefined if the result is empty.
+ *
+ * @param value - The string to trim.
+ * @returns The trimmed string, or undefined if `value` is undefined or only contains whitespace.
+ */
+export const trimToUndefined = (
+  value: string | undefined,
+): string | undefined => {
+  return value?.trim() || undefined
 }


### PR DESCRIPTION
- Always include givenName, familyName and defaultNickname in UserService update payload, even when empty
- Use trimToUndefined in ProfileUserPage to strip blank names before sending
- Refetch myUserProfile query after update completes to refresh data