### PR TITLE
feat(user-auth): refactor MigrationContextProvider

### DIFF
--- a/packages/quiz/src/context/migration/MigrationContextProvider.tsx
+++ b/packages/quiz/src/context/migration/MigrationContextProvider.tsx
@@ -1,39 +1,120 @@
-import React, { FC, ReactNode, useMemo } from 'react'
+import React, {
+  FC,
+  ReactNode,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react'
+import { useSearchParams } from 'react-router-dom'
 
 import { MigrationContext, MigrationContextType } from './migration-context.tsx'
 
+const LEGACY_HOST = 'quiz.emilhornlund.com'
+const TARGET_HOST = 'klurigo.com'
+
 /**
- * Props for the `MigrationContextProvider` component.
+ * Safely parse a JSON‐stringified object containing an `id` field.
  *
- * @property children - The child components to be wrapped by the provider.
+ * @param value - A JSON string like `{"id":"…"}`
+ * @returns The extracted `id` if parsing succeeds, otherwise `undefined`
  */
-export interface MigrationContextProvider {
-  children: ReactNode | ReactNode[]
+const extractObjectIdFromString = (
+  value: string | undefined,
+): string | undefined => {
+  try {
+    const parsedIdObject: { id: string } | undefined = value
+      ? (JSON.parse(value) as { id: string })
+      : undefined
+    return parsedIdObject?.id
+  } catch (
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    error
+  ) {
+    return undefined
+  }
 }
 
 /**
+ * Props for the MigrationContextProvider component.
  *
- * @param children
- * @constructor
+ * @property children - The React nodes to be wrapped by the provider.
  */
-const MigrationContextProvider: FC<MigrationContextProvider> = ({
+export interface MigrationContextProviderProps {
+  children: ReactNode
+}
+
+/**
+ * The `MigrationContextProvider` component.
+ *
+ * @param children - The React nodes to be wrapped by the provider.
+ */
+const MigrationContextProvider: FC<MigrationContextProviderProps> = ({
   children,
 }) => {
-  const clientId = useMemo(() => {
-    const clientObject = localStorage.getItem('client') || undefined
-    return clientObject && (JSON.parse(clientObject) as { id: string }).id
-  }, [])
+  const [searchParams] = useSearchParams()
 
-  const playerId = useMemo(() => {
-    const playerObject = localStorage.getItem('player') || undefined
-    return playerObject && (JSON.parse(playerObject) as { id: string }).id
-  }, [])
+  const [clientId, setClientId] = useState<string | undefined>(undefined)
+  const [playerId, setPlayerId] = useState<string | undefined>(undefined)
 
-  const handleCompleteMigration = () => {
+  const tmpLegacyPlayerId = searchParams.get('legacyPlayerId')
+
+  const hasRedirected = useRef<boolean>(false)
+
+  useEffect(() => {
+    if (hasRedirected.current) return
+
+    let newClientId: string | undefined
+    const rawClient = localStorage.getItem('client')
+    if (rawClient) {
+      newClientId = extractObjectIdFromString(rawClient)
+      if (newClientId) {
+        setClientId(newClientId)
+      }
+    }
+
+    let newPlayerId: string | undefined
+    if (tmpLegacyPlayerId) {
+      newPlayerId = tmpLegacyPlayerId
+      localStorage.setItem('player', JSON.stringify({ id: newPlayerId }))
+      setPlayerId(newPlayerId)
+    } else {
+      const rawPlayer = localStorage.getItem('player')
+      if (rawPlayer && !tmpLegacyPlayerId) {
+        newPlayerId = extractObjectIdFromString(rawPlayer)
+        if (newPlayerId) {
+          setPlayerId(newPlayerId)
+        }
+      }
+    }
+
+    const url = new URL(window.location.href)
+
+    if (url.host === LEGACY_HOST) {
+      if (newPlayerId) {
+        url.searchParams.set('legacyPlayerId', newPlayerId)
+      }
+
+      const searchParamString =
+        url.searchParams.size > 0 ? `?${url.searchParams.toString()}` : ''
+
+      hasRedirected.current = true
+
+      window.location.replace(
+        `https://${TARGET_HOST}${url.pathname}${searchParamString}`,
+      )
+    }
+  }, [tmpLegacyPlayerId])
+
+  const handleCompleteMigration: () => void = useCallback((): void => {
     localStorage.removeItem('client')
     localStorage.removeItem('player')
     localStorage.removeItem('token')
-  }
+
+    setClientId(undefined)
+    setPlayerId(undefined)
+  }, [])
 
   const value = useMemo<MigrationContextType>(
     () => ({
@@ -42,7 +123,7 @@ const MigrationContextProvider: FC<MigrationContextProvider> = ({
       migrated: !clientId && !playerId,
       completeMigration: handleCompleteMigration,
     }),
-    [clientId, playerId],
+    [clientId, playerId, handleCompleteMigration],
   )
 
   return (

--- a/packages/quiz/src/context/migration/index.ts
+++ b/packages/quiz/src/context/migration/index.ts
@@ -1,4 +1,5 @@
 export type { MigrationContextType } from './migration-context'
+export type { MigrationContextProviderProps } from './MigrationContextProvider'
 export { MigrationContext } from './migration-context'
 export { default } from './MigrationContextProvider'
 export { useMigrationContext } from './use-migration-context'


### PR DESCRIPTION
- Add extractObjectIdFromString helper for safe JSON parsing
- Consolidate client/player ID loading and URL-param override into a single useEffect
- Use URLSearchParams.set and window.location.replace to ensure idempotent, history-safe redirects
- Update MigrationContextProviderProps and wrap cleanup in useCallback
