### PR TITLE
refactor(player-migration) replace legacyPlayerId with secure migrationToken

### DIFF
--- a/packages/quiz-service/src/auth/controllers/auth.controller.ts
+++ b/packages/quiz-service/src/auth/controllers/auth.controller.ts
@@ -4,7 +4,6 @@ import {
   Headers,
   HttpCode,
   HttpStatus,
-  ParseUUIDPipe,
   Patch,
   Post,
   Query,
@@ -61,7 +60,7 @@ export class AuthController {
    * @param authLoginRequest - Request containing the user's email and password.
    * @param ipAddress - The client's IP address, extracted via the `@IpAddress()` decorator.
    * @param userAgent - The client's User-Agent header, extracted via the `@UserAgent()` decorator.
-   * @param legacyPlayerId - Optional player ID from the old system to migrate player data.
+   * @param migrationToken - Optional migration token identifying the legacy anonymous user.
    * @returns Promise resolving to an AuthResponse with both tokens.
    */
   @Public()
@@ -72,10 +71,10 @@ export class AuthController {
       'Verifies user credentials and issues a new access token and refresh token.',
   })
   @ApiQuery({
-    name: 'legacyPlayerId',
-    description: 'Optional player ID from the legacy system for migration',
+    name: 'migrationToken',
+    description:
+      'Optional migration token identifying the legacy anonymous user.',
     type: String,
-    format: 'uuid',
     required: false,
   })
   @ApiBody({
@@ -94,14 +93,14 @@ export class AuthController {
     @Body() authLoginRequest: AuthLoginRequest,
     @IpAddress() ipAddress: string,
     @UserAgent() userAgent: string,
-    @Query('legacyPlayerId', new ParseUUIDPipe({ optional: true }))
-    legacyPlayerId?: string,
+    @Query('migrationToken')
+    migrationToken?: string,
   ): Promise<AuthResponse> {
     return this.authService.login(
       authLoginRequest,
       ipAddress,
       userAgent,
-      legacyPlayerId,
+      migrationToken,
     )
   }
 
@@ -112,16 +111,16 @@ export class AuthController {
    * @param request   - Request containing the Google OAuth `code` and `codeVerifier`.
    * @param ipAddress - The client's IP address, extracted via the `@IpAddress()` decorator.
    * @param userAgent - The client's User-Agent header, extracted via the `@UserAgent()` decorator.
-   * @param legacyPlayerId - Optional player ID from the old system to migrate player data.
+   * @param migrationToken - Optional player ID from the old system to migrate player data.
    * @returns Promise resolving to an AuthResponse with both tokens.
    */
   @Public()
   @Post('/google/exchange')
   @ApiQuery({
-    name: 'legacyPlayerId',
-    description: 'Optional player ID from the legacy system for migration',
+    name: 'migrationToken',
+    description:
+      'Optional migration token identifying the legacy anonymous user.',
     type: String,
-    format: 'uuid',
     required: false,
   })
   @ApiBody({
@@ -142,15 +141,15 @@ export class AuthController {
     @Body() request: AuthGoogleExchangeRequest,
     @IpAddress() ipAddress: string,
     @UserAgent() userAgent: string,
-    @Query('legacyPlayerId', new ParseUUIDPipe({ optional: true }))
-    legacyPlayerId?: string,
+    @Query('migrationToken')
+    migrationToken?: string,
   ): Promise<AuthResponse> {
     return this.authService.loginGoogle(
       request.code,
       request.codeVerifier,
       ipAddress,
       userAgent,
-      legacyPlayerId,
+      migrationToken,
     )
   }
 

--- a/packages/quiz-service/src/auth/services/auth.service.ts
+++ b/packages/quiz-service/src/auth/services/auth.service.ts
@@ -74,7 +74,7 @@ export class AuthService {
    * @param authLoginRequestDto - DTO containing the user's email and password.
    * @param ipAddress - The client's IP address, used for logging and token metadata.
    * @param userAgent - The client's User-Agent string, used for logging and token metadata.
-   * @param legacyPlayerId - Optional player ID from the old system to migrate player data.
+   * @param migrationToken - Optional migration token identifying the legacy anonymous user.
    * @returns Promise resolving to an AuthResponseDto with access & refresh tokens.
    * @throws BadCredentialsException if credentials are invalid.
    */
@@ -82,16 +82,16 @@ export class AuthService {
     authLoginRequestDto: AuthLoginRequestDto,
     ipAddress: string,
     userAgent: string,
-    legacyPlayerId?: string,
+    migrationToken?: string,
   ): Promise<AuthResponseDto> {
     const { _id: userId } = await this.userService.verifyUserCredentialsOrThrow(
       authLoginRequestDto.email,
       authLoginRequestDto.password,
     )
 
-    if (legacyPlayerId) {
+    if (migrationToken) {
       await this.migrationService.migrateLegacyPlayerUser<LocalUser>(
-        legacyPlayerId,
+        migrationToken,
         userId,
       )
     }
@@ -115,7 +115,7 @@ export class AuthService {
    * @param codeVerifier - The PKCE code verifier originally used to generate the code challenge.
    * @param ipAddress - The client's IP address, used for logging and token metadata.
    * @param userAgent - The client's User-Agent string, used for logging and token metadata.
-   * @param legacyPlayerId - Optional player ID from the old system to migrate player data.
+   * @param migrationToken - Optional migration token identifying the legacy anonymous user.
    * @returns A promise resolving to an AuthResponseDto containing the issued tokens.
    */
   public async loginGoogle(
@@ -123,8 +123,7 @@ export class AuthService {
     codeVerifier: string,
     ipAddress: string,
     userAgent: string,
-
-    legacyPlayerId?: string,
+    migrationToken?: string,
   ): Promise<AuthResponseDto> {
     const accessToken = await this.googleAuthService.exchangeCodeForAccessToken(
       code,
@@ -135,7 +134,7 @@ export class AuthService {
 
     const { _id: userId } = await this.userService.verifyOrCreateGoogleUser(
       profile,
-      legacyPlayerId,
+      migrationToken,
     )
 
     const tokenPair = await this.signTokenPair(

--- a/packages/quiz-service/src/user/controllers/user.controller.ts
+++ b/packages/quiz-service/src/user/controllers/user.controller.ts
@@ -3,7 +3,6 @@ import {
   Controller,
   HttpCode,
   HttpStatus,
-  ParseUUIDPipe,
   Post,
   Query,
 } from '@nestjs/common'
@@ -42,7 +41,7 @@ export class UserController {
    * Creates a new user account.
    *
    * @param createUserRequest DTO containing email, password, and optional names.
-   * @param legacyPlayerId - Optional player ID from the old system to migrate player data.
+   * @param migrationToken - Optional migration token identifying the legacy anonymous user.
    * @returns The newly created user’s details.
    */
   @Public()
@@ -58,10 +57,10 @@ export class UserController {
       'Registers a new user with email, password, and optional names.',
   })
   @ApiQuery({
-    name: 'legacyPlayerId',
-    description: 'Optional player ID from the legacy system for migration',
+    name: 'migrationToken',
+    description:
+      'Optional migration token identifying the legacy anonymous user.',
     type: String,
-    format: 'uuid',
     required: false,
   })
   @ApiBody({
@@ -81,9 +80,9 @@ export class UserController {
   @HttpCode(HttpStatus.CREATED)
   public async createUser(
     @Body() createUserRequest: CreateUserRequest,
-    @Query('legacyPlayerId', new ParseUUIDPipe({ optional: true }))
-    legacyPlayerId?: string,
+    @Query('migrationToken')
+    migrationToken?: string,
   ): Promise<CreateUserResponse> {
-    return this.userService.createUser(createUserRequest, legacyPlayerId)
+    return this.userService.createUser(createUserRequest, migrationToken)
   }
 }

--- a/packages/quiz-service/src/user/exceptions/index.ts
+++ b/packages/quiz-service/src/user/exceptions/index.ts
@@ -1,3 +1,4 @@
 export * from './bad-credentials.exception'
 export * from './email-not-unique.exception'
 export * from './user-not-found.exception'
+export * from './user-not-found-by-migration-token.exception'

--- a/packages/quiz-service/src/user/exceptions/user-not-found-by-migration-token.exception.ts
+++ b/packages/quiz-service/src/user/exceptions/user-not-found-by-migration-token.exception.ts
@@ -1,0 +1,12 @@
+import { NotFoundException } from '@nestjs/common'
+
+/**
+ * Thrown when the user was not found by its migration token (HTTP 404).
+ *
+ * @extends {NotFoundException}
+ */
+export class UserNotFoundByMigrationTokenException extends NotFoundException {
+  constructor() {
+    super('User was not found by migration token')
+  }
+}

--- a/packages/quiz-service/src/user/repositories/models/schemas/user.schema.ts
+++ b/packages/quiz-service/src/user/repositories/models/schemas/user.schema.ts
@@ -47,6 +47,11 @@ interface IUser {
   lastLoggedInAt?: Date
 
   /**
+   * Array of migration tokens associated with the user, used during client‐player data migrations.
+   */
+  migrationTokens?: string[]
+
+  /**
    * Timestamp when the user was created (ISO-8601 string).
    */
   createdAt: Date
@@ -121,6 +126,12 @@ export class User implements IUser {
    */
   @Prop({ type: Date, required: false })
   lastLoggedInAt?: Date
+
+  /**
+   * Array of migration tokens associated with the user, used during client‐player data migrations.
+   */
+  @Prop({ type: [String], required: false })
+  migrationTokens?: string[]
 
   /**
    * Timestamp when the user was created (ISO-8601 string).
@@ -198,6 +209,11 @@ export class LocalUser implements IUser {
   lastLoggedInAt?: Date
 
   /**
+   * Array of migration tokens associated with the user, used during client‐player data migrations.
+   */
+  migrationTokens?: string[]
+
+  /**
    * Timestamp when the user was created (ISO-8601 string).
    */
   createdAt: Date
@@ -262,6 +278,11 @@ export class GoogleUser implements IUser {
   lastLoggedInAt?: Date
 
   /**
+   * Array of migration tokens associated with the user, used during client‐player data migrations.
+   */
+  migrationTokens?: string[]
+
+  /**
    * Timestamp when the user was created (ISO-8601 string).
    */
   createdAt: Date
@@ -321,6 +342,11 @@ export class NoneUser implements IUser {
    * Date and time of the user's last successful login.
    */
   lastLoggedInAt?: Date
+
+  /**
+   * Array of migration tokens associated with the user, used during client‐player data migrations.
+   */
+  migrationTokens?: string[]
 
   /**
    * Timestamp when the user was created (ISO-8601 string).

--- a/packages/quiz-service/src/user/services/user.service.ts
+++ b/packages/quiz-service/src/user/services/user.service.ts
@@ -95,12 +95,12 @@ export class UserService {
    * Creates and persists a new local-auth user.
    *
    * @param requestDto       Data for the new user (email, password, optional names).
-   * @param legacyPlayerId   (Optional) UUID from the legacy system to migrate player data.
+   * @param migrationToken   Optional migration token identifying the legacy anonymous user.
    * @returns A Promise resolving to the created user’s details.
    */
   public async createUser(
     requestDto: CreateUserRequestDto,
-    legacyPlayerId?: string,
+    migrationToken?: string,
   ): Promise<CreateUserResponseDto> {
     const { email, password, givenName, familyName, defaultNickname } =
       requestDto
@@ -126,10 +126,10 @@ export class UserService {
     }
 
     let createdUser: LocalUser
-    if (legacyPlayerId) {
+    if (migrationToken) {
       createdUser =
         await this.migrationService.migrateLegacyPlayerUser<LocalUser>(
-          legacyPlayerId,
+          migrationToken,
           null,
           { ...details, authProvider: AuthProvider.Local },
         )
@@ -157,12 +157,12 @@ export class UserService {
    * Finds an existing Google user or creates a new one from OAuth profile.
    *
    * @param profile          The GoogleProfileDto containing info from Google.
-   * @param legacyPlayerId   (Optional) UUID from the legacy system to migrate player data.
+   * @param migrationToken   Optional migration token identifying the legacy anonymous user.
    * @returns A Promise resolving to the existing or newly created GoogleUser.
    */
   public async verifyOrCreateGoogleUser(
     profile: GoogleProfileDto,
-    legacyPlayerId?: string,
+    migrationToken?: string,
   ): Promise<GoogleUser> {
     const existingUser =
       await this.userRepository.findAndUpdateGoogleUserByGoogleId(profile.id, {
@@ -184,9 +184,9 @@ export class UserService {
     }
 
     if (existingUser) {
-      if (legacyPlayerId) {
+      if (migrationToken) {
         return this.migrationService.migrateLegacyPlayerUser<GoogleUser>(
-          legacyPlayerId,
+          migrationToken,
           existingUser._id,
         )
       }
@@ -206,10 +206,10 @@ export class UserService {
     }
 
     let createdUser: GoogleUser
-    if (legacyPlayerId) {
+    if (migrationToken) {
       createdUser =
         await this.migrationService.migrateLegacyPlayerUser<GoogleUser>(
-          legacyPlayerId,
+          migrationToken,
           null,
           {
             ...details,

--- a/packages/quiz-service/src/user/services/utils/user.utils.ts
+++ b/packages/quiz-service/src/user/services/utils/user.utils.ts
@@ -1,6 +1,6 @@
 import { AuthProvider } from '@quiz/common'
 
-import { GoogleUser, LocalUser, User } from '../../repositories'
+import { GoogleUser, LocalUser, NoneUser, User } from '../../repositories'
 
 /**
  * Type guard to check whether a User document is a local‐auth user.
@@ -24,4 +24,16 @@ export function isGoogleUser(
   user: User,
 ): user is GoogleUser & { authProvider: AuthProvider.Google } {
   return user.authProvider === AuthProvider.Google
+}
+
+/**
+ * Type guard to check whether a User document is a none migrated user.
+ *
+ * @param user - The User document to inspect.
+ * @returns True if `user.authProvider === AuthProvider.None`, narrowing to NoneUser.
+ */
+export function isNoneMigratedUser(
+  user: User,
+): user is NoneUser & { authProvider: AuthProvider.None } {
+  return user.authProvider === AuthProvider.None
 }

--- a/packages/quiz-service/test-utils/data/user.data.ts
+++ b/packages/quiz-service/test-utils/data/user.data.ts
@@ -2,6 +2,7 @@ import { AuthProvider } from '@quiz/common'
 import { v4 as uuidv4 } from 'uuid'
 
 import { GoogleUser, LocalUser, NoneUser } from '../../src/user/repositories'
+import { computeMigrationToken } from '../utils'
 
 export const MOCK_PRIMARY_USER_EMAIL = 'user@example.com'
 export const MOCK_PRIMARY_USER_GIVEN_NAME = 'John'
@@ -115,13 +116,19 @@ export function buildMockQuaternaryUser(user?: Partial<LocalUser>): LocalUser {
   }
 }
 
-export function buildMockLegacyPlayerUser(): NoneUser {
+export function buildMockNoneMigratedPlayerUser(
+  user?: Partial<NoneUser>,
+): NoneUser {
+  const userId = user?._id ?? uuidv4()
   const now = new Date()
   return {
-    _id: uuidv4(),
+    _id: userId,
     authProvider: AuthProvider.None,
     email: 'n/a@na.na',
+    defaultNickname: '',
+    migrationTokens: [computeMigrationToken(uuidv4(), userId)],
     createdAt: now,
     updatedAt: now,
+    ...(user ?? {}),
   }
 }

--- a/packages/quiz-service/test-utils/utils/bootstrap.ts
+++ b/packages/quiz-service/test-utils/utils/bootstrap.ts
@@ -10,9 +10,9 @@ import { configureApp } from '../../src/app/utils'
 import { GoogleAuthService } from '../../src/auth/services'
 import { GoogleProfileDto } from '../../src/auth/services/models'
 import { PexelsMediaSearchService } from '../../src/media/services'
+import { MOCK_PRIMARY_GOOGLE_USER_ID, MOCK_PRIMARY_USER_EMAIL } from '../data'
 import {
   MOCK_GOOGLE_ACCESS_TOKEN_VALID,
-  MOCK_GOOGLE_PROFILE_DTO,
   MOCK_GOOGLE_VALID_CODE,
   MOCK_GOOGLE_VALID_CODE_VERIFIER,
 } from '../data/google-auth.data'
@@ -54,7 +54,15 @@ const mockGoogleAuthService = {
     accessToken: string,
   ): Promise<GoogleProfileDto> => {
     if (accessToken === MOCK_GOOGLE_ACCESS_TOKEN_VALID) {
-      return MOCK_GOOGLE_PROFILE_DTO
+      return {
+        id: MOCK_PRIMARY_GOOGLE_USER_ID,
+        email: MOCK_PRIMARY_USER_EMAIL,
+        verified_email: true,
+        name: 'Jane Doe',
+        given_name: 'Jane',
+        family_name: 'Doe',
+        picture: 'http://img',
+      }
     }
     throw new UnauthorizedException('Access token is invalid or has expired.')
   },

--- a/packages/quiz-service/test-utils/utils/index.ts
+++ b/packages/quiz-service/test-utils/utils/index.ts
@@ -1,2 +1,3 @@
 export * from './auth.utils'
 export * from './bootstrap'
+export * from './migration.utils'

--- a/packages/quiz-service/test-utils/utils/migration.utils.ts
+++ b/packages/quiz-service/test-utils/utils/migration.utils.ts
@@ -1,0 +1,24 @@
+import { createHash } from 'crypto'
+
+/**
+ * Computes a URL-safe, Base64-encoded SHA-256 hash to use as a migration token.
+ *
+ * The token is derived from the `clientId` and `playerId`.
+ *
+ * @param clientId - The unique identifier of the client.
+ * @param playerId - The unique identifier of the player.
+ * @returns A URL-safe Base64-encoded SHA-256 hash string representing the migration token.
+ */
+export function computeMigrationToken(
+  clientId: string,
+  playerId: string,
+): string {
+  const data = Buffer.from(`${clientId}:${playerId}`, 'utf-8')
+  const hash = createHash('sha256').update(data).digest()
+
+  return hash
+    .toString('base64')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=/g, '')
+}

--- a/packages/quiz/src/context/migration/migration-context.tsx
+++ b/packages/quiz/src/context/migration/migration-context.tsx
@@ -4,15 +4,9 @@ import { createContext } from 'react'
  * Defines the shape of the migration context value.
  *
  * Provides:
- * - `clientId`: The legacy client ID retrieved from localStorage, if any.
- * - `playerId`: The legacy player ID retrieved from localStorage, if any.
- * - `migrated`: Whether migration has already been completed.
  * - `completeMigration`: Function to clear legacy identifiers and mark migration as done.
  */
 export interface MigrationContextType {
-  clientId?: string
-  playerId?: string
-  migrated: boolean
   completeMigration: () => void
 }
 
@@ -20,13 +14,8 @@ export interface MigrationContextType {
  * React context for migration state.
  *
  * Defaults to:
- * - `clientId` and `playerId` undefined
- * - `migrated` false
  * - `completeMigration` no-op
  */
 export const MigrationContext = createContext<MigrationContextType>({
-  clientId: undefined,
-  playerId: undefined,
-  migrated: false,
   completeMigration: () => undefined,
 })

--- a/packages/quiz/src/pages/AuthRegisterPage/AuthRegisterPage.tsx
+++ b/packages/quiz/src/pages/AuthRegisterPage/AuthRegisterPage.tsx
@@ -8,15 +8,14 @@ import { AuthRegisterPageUI, CreateUserFormFields } from './components'
 const AuthRegisterPage: FC = () => {
   const navigate = useNavigate()
 
-  const { login, register } = useQuizServiceClient()
+  const { register } = useQuizServiceClient()
 
   const [isLoading, setIsLoading] = useState<boolean>(false)
 
   const handleSubmit = (values: CreateUserFormFields) => {
     setIsLoading(true)
     register(values)
-      .then(() => login({ email: values.email, password: values.password }))
-      .then(() => navigate('/'))
+      .then(() => navigate('/auth/login'))
       .finally(() => setIsLoading(false))
   }
 

--- a/packages/quiz/src/utils/use-local-storage.tsx
+++ b/packages/quiz/src/utils/use-local-storage.tsx
@@ -1,0 +1,68 @@
+import { useState } from 'react'
+
+function setItem(key: string, value: unknown) {
+  try {
+    window.localStorage.setItem(key, JSON.stringify(value))
+  } catch (err) {
+    console.error(`Failed to set local storage item for key '${key}'`, err)
+  }
+}
+
+function getItem<T>(key: string): T | undefined {
+  try {
+    const data = window.localStorage.getItem(key)
+    return data ? (JSON.parse(data) as T) : undefined
+  } catch (err) {
+    console.error(`Failed to get local storage item for key '${key}'`, err)
+  }
+}
+
+function removeItem(key: string) {
+  try {
+    window.localStorage.removeItem(key)
+  } catch (err) {
+    console.error(`Failed to remove local storage item for key '${key}'`, err)
+  }
+}
+
+type DispatchAction<T> = T | ((prevState: T) => T)
+
+/**
+ * React hook for persisting state to `localStorage`.
+ *
+ * Retrieves an initial value from `localStorage` if available, and updates it
+ * whenever the setter function is called. Also provides a method to clear the state.
+ *
+ * @param key - The `localStorage` key under which the value is stored.
+ * @param initialValue - The initial value used if no data is found in `localStorage`.
+ * @returns A tuple containing:
+ *   - `value`: The current value.
+ *   - `setValue`: A function to update the value (accepts a new value or updater function).
+ *   - `clear`: A function to remove the value from both state and `localStorage`.
+ */
+export default function useLocalStorage<T>(key: string, initialValue: T) {
+  const [value, setValue] = useState(() => {
+    const data = getItem(key)
+    return (data || initialValue) as T
+  })
+
+  function handleDispatch(action: DispatchAction<T>) {
+    if (typeof action === 'function') {
+      setValue((prevState) => {
+        const newValue = (action as (prevState: T) => T)(prevState)
+        setItem(key, newValue)
+        return newValue
+      })
+    } else {
+      setValue(action)
+      setItem(key, action)
+    }
+  }
+
+  function clearState() {
+    setValue(undefined as T)
+    removeItem(key)
+  }
+
+  return [value, handleDispatch, clearState] as const
+}

--- a/tools/mongodb-migrator/src/transformers/user.transformers.ts
+++ b/tools/mongodb-migrator/src/transformers/user.transformers.ts
@@ -1,5 +1,8 @@
+import { createHash } from 'crypto'
+
 import {
   BSONDocument,
+  ClientPlayerMapper,
   extractValue,
   extractValueOrThrow,
   toDate,
@@ -9,16 +12,21 @@ import {
  * Transforms a document from the `players` collection into a `users` document format.
  *
  * @param document - A single document from the original `players` collection.
+ * @param clientPlayerMapper - Mapper used for client/player ID lookups.
  * @returns The transformed `users`-format document.
  */
 export function transformPlayerOrUserDocument(
   document: BSONDocument,
+  clientPlayerMapper: ClientPlayerMapper,
 ): BSONDocument {
+  const userId = extractValueOrThrow<string>(document, {}, '_id')
   return {
-    _id: extractValueOrThrow<string>(document, {}, '_id'),
+    _id: userId,
     __v: 0,
     authProvider: extractValue<string>(document, {}, 'authProvider') || 'NONE',
-    email: extractValue<string>(document, {}, 'email'),
+    email:
+      extractValue<string>(document, {}, 'email') ||
+      `non-migrated-${userId}@klurigo.com`,
     givenName: extractValue<string>(document, {}, 'givenName'),
     familyName: extractValue<string>(document, {}, 'familyName'),
     defaultNickname: extractValue<string>(
@@ -30,6 +38,11 @@ export function transformPlayerOrUserDocument(
     lastLoggedInAt: toDate(
       extractValue<string>(document, {}, 'lastLoggedInAt'),
     ),
+    migrationTokens:
+      extractValue<string[]>(document, {}, 'migrationTokens') ||
+      clientPlayerMapper.clients
+        .filter((client) => client.player.id === userId)
+        .map((client) => computeMigrationToken(client.id, client.player.id)),
     createdAt: toDate(
       extractValueOrThrow<string>(document, {}, 'createdAt', 'created'),
     ),
@@ -37,4 +50,24 @@ export function transformPlayerOrUserDocument(
       extractValueOrThrow<string>(document, {}, 'updatedAt', 'modified'),
     ),
   }
+}
+
+/**
+ * Computes a URL-safe, Base64-encoded SHA-256 hash to use as a migration token.
+ *
+ * The token is derived from the `clientId` and `playerId`.
+ *
+ * @param clientId - The unique identifier of the client.
+ * @param playerId - The unique identifier of the player.
+ * @returns A URL-safe Base64-encoded SHA-256 hash string representing the migration token.
+ */
+function computeMigrationToken(clientId: string, playerId: string): string {
+  const data = Buffer.from(`${clientId}:${playerId}`, 'utf-8')
+  const hash = createHash('sha256').update(data).digest()
+
+  return hash
+    .toString('base64')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=/g, '')
 }

--- a/tools/mongodb-migrator/src/utils/collection.utils.ts
+++ b/tools/mongodb-migrator/src/utils/collection.utils.ts
@@ -327,7 +327,10 @@ function transformOriginalDocument(
         return transformQuizDocument(originalDocument)
       case COLLECTION_NAME_PLAYERS:
       case COLLECTION_NAME_USERS:
-        return transformPlayerOrUserDocument(originalDocument)
+        return transformPlayerOrUserDocument(
+          originalDocument,
+          clientPlayerMapper,
+        )
       case COLLECTION_NAME_TOKENS:
         return transformTokenDocument(originalDocument)
       default:


### PR DESCRIPTION
- Introduce a URL-safe SHA-256 `migrationToken` (derived from `clientId:playerId`) and store it in `User.migrationTokens`
- Add `removeMigrationTokenForUserOrThrow()` in `UserRepository`, throwing 404 when the token is invalid
- Update `MigrationService` to consume and remove the token, then perform in-place updates or merge/delete flows
- Replace all `legacyPlayerId` query params, method signatures, decorators and pipes with `migrationToken` in controllers, services and tests, and adjust expected 404/409 responses
- Add `computeMigrationToken` helpers in test-utils and migration tool
- Adapt frontend: persist token via `useLocalStorage`, derive it in `MigrationContext`, and include it in `/auth/login`, `/auth/google/exchange` and `/users` calls
