### PR TITLE
feat(player-migration) add error handling for legacy migration and update e2e tests to expect success

### DIFF
--- a/packages/quiz-service/src/auth/services/auth.service.ts
+++ b/packages/quiz-service/src/auth/services/auth.service.ts
@@ -90,10 +90,18 @@ export class AuthService {
     )
 
     if (migrationToken) {
-      await this.migrationService.migrateLegacyPlayerUser<LocalUser>(
-        migrationToken,
-        userId,
-      )
+      try {
+        await this.migrationService.migrateLegacyPlayerUser<LocalUser>(
+          migrationToken,
+          userId,
+        )
+      } catch (error) {
+        const { message, stack } = error as Error
+        this.logger.debug(
+          `Failed to migrate legacy user '${userId}' while authenticate local user: '${message}'.`,
+          stack,
+        )
+      }
     }
 
     const tokenPair = await this.signTokenPair(

--- a/packages/quiz-service/src/user/controllers/user.controller.e2e-spec.ts
+++ b/packages/quiz-service/src/user/controllers/user.controller.e2e-spec.ts
@@ -181,7 +181,7 @@ describe('UserController (e2e)', () => {
         })
     })
 
-    it('should return 404 not found when creating a new user from a legacy player user that does not exist', async () => {
+    it('should succeed in creating a new user from a legacy player user that does not exist', async () => {
       return supertest(app.getHttpServer())
         .post(`/api/users`)
         .query({ migrationToken: 'n/a' })
@@ -192,12 +192,17 @@ describe('UserController (e2e)', () => {
           familyName: MOCK_PRIMARY_USER_FAMILY_NAME,
           defaultNickname: MOCK_PRIMARY_USER_DEFAULT_NICKNAME,
         })
-        .expect(404)
+        .expect(201)
         .expect((res) => {
           expect(res.body).toEqual({
-            message: 'User was not found by migration token',
-            status: 404,
-            timestamp: expect.any(String),
+            id: expect.any(String),
+            email: MOCK_PRIMARY_USER_EMAIL,
+            unverifiedEmail: MOCK_PRIMARY_USER_EMAIL,
+            givenName: MOCK_PRIMARY_USER_GIVEN_NAME,
+            familyName: MOCK_PRIMARY_USER_FAMILY_NAME,
+            defaultNickname: MOCK_PRIMARY_USER_DEFAULT_NICKNAME,
+            created: expect.any(String),
+            updated: expect.any(String),
           })
         })
     })


### PR DESCRIPTION
- Wrap all migrateLegacyPlayerUser calls in AuthService and UserService in try/catch to log failures at debug level and fallback to repository defaults
- Update AuthController e2e specs: • Change scenarios for non-existent legacy users to expect 200 instead of 404 • Extract userId from creation and reuse expectUserTokenPair(null) signature • Adjust expectUserTokenPair to accept null subject and assert `sub` fallback
- Update UserController e2e specs: • Change legacy-migration creation test to expect 201 and full user payload
- Bump expectUserTokenPair signature to `userId: string | null`
