### PR TITLE
feat(ui): normalize button styles and enhance appearance

### DIFF
--- a/packages/quiz/src/components/Card/Card.module.scss
+++ b/packages/quiz/src/components/Card/Card.module.scss
@@ -138,6 +138,12 @@
   }
 
   button {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    -moz-appearance: none;
+    -o-appearance: none;
+    -webkit-appearance: none;
     appearance: none;
     outline: none;
     border: none;

--- a/packages/quiz/src/components/IconTooltip/IconTooltip.module.scss
+++ b/packages/quiz/src/components/IconTooltip/IconTooltip.module.scss
@@ -11,6 +11,7 @@
   border: none;
   font-family: inherit;
   outline: none;
+  color: colors.$white;
 
   @include helpers.mobile {
     @include helpers.fontSize(variables.$mobile-control-normal-font-size);
@@ -22,6 +23,11 @@
 
   @include helpers.desktop {
     @include helpers.fontSize(variables.$desktop-control-normal-font-size);
+  }
+
+  &:hover {
+    cursor: pointer;
+    color: colors.$gray-1;
   }
 }
 

--- a/packages/quiz/src/pages/QuizCreatorPage/components/QuizCreatorPageUI/__snapshots__/QuizCreatorPageUI.test.tsx.snap
+++ b/packages/quiz/src/pages/QuizCreatorPage/components/QuizCreatorPageUI/__snapshots__/QuizCreatorPageUI.test.tsx.snap
@@ -311,7 +311,7 @@ exports[`QuizCreatorPageUI > renders QuizCreatorPageUI for classic mode 1`] = `
             >
               <svg
                 aria-hidden="true"
-                class="svg-inline--fa fa-circle-plus "
+                class="svg-inline--fa fa-circle-plus fa-width-auto "
                 data-icon="circle-plus"
                 data-prefix="fas"
                 role="img"

--- a/packages/quiz/src/pages/QuizCreatorPage/components/QuizCreatorPageUI/components/QuestionPicker/QuestionPicker.module.scss
+++ b/packages/quiz/src/pages/QuizCreatorPage/components/QuizCreatorPageUI/components/QuestionPicker/QuestionPicker.module.scss
@@ -1,3 +1,4 @@
+@use 'sass:color';
 @use '../../../../../../styles/colors';
 @use '../../../../../../styles/helpers';
 @use '../../../../../../styles/variables';
@@ -58,6 +59,10 @@ $outline-offset: helpers.pxToRem(2px);
     flex-direction: column;
 
     .addQuestionButton {
+      -moz-appearance: none;
+      -o-appearance: none;
+      -webkit-appearance: none;
+      appearance: none;
       display: flex;
       flex-direction: column;
       justify-content: center;
@@ -80,6 +85,11 @@ $outline-offset: helpers.pxToRem(2px);
 
       @include helpers.desktop {
         @include helpers.fontSize(32px);
+      }
+
+      &:hover {
+        color: color.mix(colors.$white, colors.$yellow-2, 30%);
+        outline-color: color.mix(colors.$white, colors.$yellow-2, 30%);
       }
     }
   }

--- a/packages/quiz/src/pages/QuizCreatorPage/components/QuizCreatorPageUI/components/QuestionPicker/QuestionPicker.tsx
+++ b/packages/quiz/src/pages/QuizCreatorPage/components/QuizCreatorPageUI/components/QuestionPicker/QuestionPicker.tsx
@@ -101,7 +101,7 @@ const QuestionPicker: FC<QuestionPickerProps> = ({
         <button
           className={styles.addQuestionButton}
           onClick={handleAddItemButtonClick}>
-          <FontAwesomeIcon icon={faPlusCircle} />
+          <FontAwesomeIcon icon={faPlusCircle} widthAuto />
         </button>
       </div>
       <ConfirmDialog

--- a/packages/quiz/src/pages/QuizDetailsPage/components/QuizDetailsPageUI/QuizDetailsPageUI.module.scss
+++ b/packages/quiz/src/pages/QuizDetailsPage/components/QuizDetailsPageUI/QuizDetailsPageUI.module.scss
@@ -43,6 +43,7 @@
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
+    align-items: center;
 
     @include helpers.mobile {
       gap: calc(#{variables.$mobile-narrow-layout-gutter} * 0.5);

--- a/packages/quiz/src/styles/form.module.scss
+++ b/packages/quiz/src/styles/form.module.scss
@@ -1,3 +1,4 @@
+@use './colors';
 @use './helpers';
 @use './variables';
 
@@ -63,6 +64,8 @@
         outline: none;
         text-decoration: underline;
         cursor: pointer;
+        color: colors.$white;
+        text-underline-offset: helpers.pxToRem(2px);
 
         @include helpers.mobile {
           @include helpers.fontSize(variables.$mobile-control-small-font-size);


### PR DESCRIPTION
- Center and strip default browser styling on buttons in Card & QuestionPicker
- Add flex centering and reset appearance (moz, webkit, o) on all buttons
- Update IconTooltip: default white color, pointer cursor and gray hover color
- Add hover color mix and outline-color adjustments to QuestionPicker’s add button
- Align items vertically in QuizDetailsPage labels
- Update form link style: white color and underline-offset
- Pass widthAuto prop to FontAwesomeIcon in QuestionPicker
