### PR TITLE
chore(codecov): make component statuses informational

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -4,6 +4,12 @@ comment:
   require_changes: true
 
 component_management:
+  default_rules:
+    statuses:
+      - type: project
+        informational: true
+      - type: patch
+        informational: true
   individual_components:
     - component_id: quiz
       name: quiz


### PR DESCRIPTION
- Added default rules to mark all project and patch statuses for components as informational.
- Prevents PRs from being blocked due to coverage drops in individual components.

Ensures Codecov reports remain informational while still providing coverage insights.