### PR TITLE
feat(migration): remove migrationToken from URL after retrieval

### DIFF
--- a/packages/quiz/src/context/migration/MigrationContextProvider.tsx
+++ b/packages/quiz/src/context/migration/MigrationContextProvider.tsx
@@ -34,7 +34,7 @@ export interface MigrationContextProviderProps {
 const MigrationContextProvider: FC<MigrationContextProviderProps> = ({
   children,
 }) => {
-  const [searchParams] = useSearchParams()
+  const [searchParams, setSearchParams] = useSearchParams()
 
   const [client, , clearClient] = useLocalStorage<{ id: string } | undefined>(
     'client',
@@ -69,6 +69,8 @@ const MigrationContextProvider: FC<MigrationContextProviderProps> = ({
       if (!migrated) {
         if (migrationTokenSearchParam) {
           newMigrationToken = migrationTokenSearchParam
+          searchParams.delete('migrationToken')
+          setSearchParams(searchParams)
           notifySuccess(
             'Yay, migration is in hand! Are you set for more brain-busting quizzes?',
           )
@@ -105,6 +107,8 @@ const MigrationContextProvider: FC<MigrationContextProviderProps> = ({
     migrated,
     migrationTokenSearchParam,
     setMigrationToken,
+    searchParams,
+    setSearchParams,
   ])
 
   const handleCompleteMigration: () => void = useCallback((): void => {


### PR DESCRIPTION
- Updated MigrationContextProvider to call `searchParams.delete('migrationToken')` and update the URL via `setSearchParams` after reading the token.
- Prevents the migration token from persisting in the browser address bar.
- Enhances security and improves user experience by cleaning up sensitive query parameters.