### PR TITLE
fix(auth): prevent authentication state flicker on page load

### DIFF
--- a/packages/quiz/src/components/ProtectedRoute/ProtectedRoute.test.tsx
+++ b/packages/quiz/src/components/ProtectedRoute/ProtectedRoute.test.tsx
@@ -1,0 +1,125 @@
+import { TokenScope } from '@quiz/common'
+import { render, screen } from '@testing-library/react'
+import React from 'react'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import ProtectedRoute from './ProtectedRoute'
+
+// --- Mock AuthContext hook with mutable state ---
+type MockAuth = { isUserAuthenticated: boolean; isGameAuthenticated: boolean }
+let mockAuth: MockAuth = {
+  isUserAuthenticated: false,
+  isGameAuthenticated: false,
+}
+
+vi.mock('../../context/auth', () => ({
+  useAuthContext: () => mockAuth,
+}))
+
+function renderAt(path: string, ui: React.ReactNode) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route path="/" element={<div>Home</div>} />
+        <Route path="/protected" element={ui} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+describe('ProtectedRoute', () => {
+  beforeEach(() => {
+    mockAuth = { isUserAuthenticated: false, isGameAuthenticated: false }
+  })
+
+  it('renders children when User scope is authenticated (default props)', () => {
+    mockAuth.isUserAuthenticated = true
+
+    const { container } = renderAt(
+      '/protected',
+      <ProtectedRoute>
+        <div>Protected User</div>
+      </ProtectedRoute>,
+    )
+
+    expect(screen.getByText('Protected User')).toBeInTheDocument()
+
+    expect(container).toMatchSnapshot()
+  })
+
+  it('redirects to "/" when User scope is not authenticated (default authenticated=true)', () => {
+    mockAuth.isUserAuthenticated = false
+
+    const { container } = renderAt(
+      '/protected',
+      <ProtectedRoute>
+        <div>Protected User</div>
+      </ProtectedRoute>,
+    )
+
+    expect(screen.getByText('Home')).toBeInTheDocument()
+
+    expect(container).toMatchSnapshot()
+  })
+
+  it('renders children for guest-only route when User is NOT authenticated (authenticated=false)', () => {
+    mockAuth.isUserAuthenticated = false
+
+    const { container } = renderAt(
+      '/protected',
+      <ProtectedRoute authenticated={false}>
+        <div>Guest Only</div>
+      </ProtectedRoute>,
+    )
+
+    expect(screen.getByText('Guest Only')).toBeInTheDocument()
+
+    expect(container).toMatchSnapshot()
+  })
+
+  it('redirects for guest-only route when User IS authenticated (authenticated=false)', () => {
+    mockAuth.isUserAuthenticated = true
+
+    const { container } = renderAt(
+      '/protected',
+      <ProtectedRoute authenticated={false}>
+        <div>Guest Only</div>
+      </ProtectedRoute>,
+    )
+
+    expect(screen.getByText('Home')).toBeInTheDocument()
+
+    expect(container).toMatchSnapshot()
+  })
+
+  it('renders children when Game scope is authenticated', () => {
+    mockAuth.isGameAuthenticated = true
+
+    const { container } = renderAt(
+      '/protected',
+      <ProtectedRoute scope={TokenScope.Game}>
+        <div>Protected Game</div>
+      </ProtectedRoute>,
+    )
+
+    expect(screen.getByText('Protected Game')).toBeInTheDocument()
+
+    expect(container).toMatchSnapshot()
+  })
+
+  it('redirects when Game scope is NOT authenticated', () => {
+    mockAuth.isGameAuthenticated = false
+
+    const { container } = renderAt(
+      '/protected',
+      <ProtectedRoute scope={TokenScope.Game}>
+        <div>Protected Game</div>
+      </ProtectedRoute>,
+    )
+
+    expect(screen.getByText('Home')).toBeInTheDocument()
+
+    expect(container).toMatchSnapshot()
+  })
+})

--- a/packages/quiz/src/components/ProtectedRoute/ProtectedRoute.tsx
+++ b/packages/quiz/src/components/ProtectedRoute/ProtectedRoute.tsx
@@ -47,7 +47,8 @@ const ProtectedRoute: FC<ProtectedRouteProps> = ({
    */
   const shouldRedirect = useMemo(() => {
     const isAllowed =
-      scope === TokenScope.Game ? isGameAuthenticated : isUserAuthenticated
+      (scope === TokenScope.Game && isGameAuthenticated) ||
+      (scope === TokenScope.User && isUserAuthenticated)
     return authenticated ? !isAllowed : isAllowed
   }, [scope, authenticated, isUserAuthenticated, isGameAuthenticated])
 

--- a/packages/quiz/src/components/ProtectedRoute/__snapshots__/ProtectedRoute.test.tsx.snap
+++ b/packages/quiz/src/components/ProtectedRoute/__snapshots__/ProtectedRoute.test.tsx.snap
@@ -1,0 +1,49 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`ProtectedRoute > redirects for guest-only route when User IS authenticated (authenticated=false) 1`] = `
+<div>
+  <div>
+    Home
+  </div>
+</div>
+`;
+
+exports[`ProtectedRoute > redirects to "/" when User scope is not authenticated (default authenticated=true) 1`] = `
+<div>
+  <div>
+    Home
+  </div>
+</div>
+`;
+
+exports[`ProtectedRoute > redirects when Game scope is NOT authenticated 1`] = `
+<div>
+  <div>
+    Home
+  </div>
+</div>
+`;
+
+exports[`ProtectedRoute > renders children for guest-only route when User is NOT authenticated (authenticated=false) 1`] = `
+<div>
+  <div>
+    Guest Only
+  </div>
+</div>
+`;
+
+exports[`ProtectedRoute > renders children when Game scope is authenticated 1`] = `
+<div>
+  <div>
+    Protected Game
+  </div>
+</div>
+`;
+
+exports[`ProtectedRoute > renders children when User scope is authenticated (default props) 1`] = `
+<div>
+  <div>
+    Protected User
+  </div>
+</div>
+`;

--- a/packages/quiz/src/context/auth/AuthContextProvider.test.tsx
+++ b/packages/quiz/src/context/auth/AuthContextProvider.test.tsx
@@ -1,0 +1,259 @@
+import { TokenScope, TokenType } from '@quiz/common'
+import { act, cleanup, render, waitFor } from '@testing-library/react'
+import React, { useContext, useEffect } from 'react'
+import { BrowserRouter } from 'react-router-dom'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { AUTH_LOCAL_STORAGE_KEY } from '../../utils/constants'
+
+import { AuthContext } from './auth-context'
+import AuthContextProvider from './AuthContextProvider'
+
+// --- Mocks ---
+const mockRevoke = vi.fn().mockResolvedValue({})
+vi.mock('../../api/use-quiz-service-client.tsx', () => ({
+  useQuizServiceClient: () => ({ revoke: mockRevoke }),
+}))
+
+const mockNavigate = vi.fn()
+vi.mock('react-router-dom', async (importActual) => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const actual = await importActual<any>()
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  }
+})
+
+const mockJwtDecode = vi.fn()
+// Keep the payload shape simple; we just need to see it flow through.
+vi.mock('jwt-decode', () => ({
+  jwtDecode: (token: string) =>
+    mockJwtDecode(token) ??
+    ({
+      sub: `sub:${token}`,
+      exp: 123,
+      authorities: ['ROLE_USER'],
+      // optional fields for game scope:
+      gameId: token.includes('game') ? 'game-123' : undefined,
+      participantType: token.includes('game') ? 'Player' : undefined,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any),
+}))
+
+// --- Test helpers ---
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function renderWithProvider(capture: (ctx: any) => void, ui?: React.ReactNode) {
+  const Probe: React.FC = () => {
+    const ctx = useContext(AuthContext)
+    useEffect(() => {
+      capture(ctx)
+    }, [ctx])
+    return ui ?? null
+  }
+  return render(
+    <BrowserRouter>
+      <AuthContextProvider>
+        <Probe />
+      </AuthContextProvider>
+    </BrowserRouter>,
+  )
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function setLocalStorageAuth(state: any) {
+  localStorage.setItem(AUTH_LOCAL_STORAGE_KEY, JSON.stringify(state))
+}
+
+// --- Lifecycle ---
+beforeEach(() => {
+  vi.useRealTimers()
+  localStorage.clear()
+  mockRevoke.mockClear()
+  mockNavigate.mockClear()
+  mockJwtDecode.mockClear()
+})
+
+afterEach(() => {
+  cleanup()
+})
+
+// --- Tests ---
+describe('AuthContextProvider', () => {
+  it('initializes from localStorage on first render (no flicker)', async () => {
+    // Pre-populate localStorage with a USER token so the first render is authenticated
+    setLocalStorageAuth({
+      USER: {
+        [TokenType.Access]: { token: 'user.access', exp: 1 },
+        [TokenType.Refresh]: { token: 'user.refresh', exp: 2 },
+      },
+      GAME: undefined,
+    })
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let ctx: any
+    const { container } = renderWithProvider((c) => (ctx = c))
+
+    await waitFor(() => {
+      expect(ctx).toBeTruthy()
+      expect(ctx.isUserAuthenticated).toBe(true)
+      expect(ctx.isGameAuthenticated).toBe(false)
+      expect(ctx.user?.ACCESS.token).toBe('user.access')
+    })
+
+    expect(container).toMatchSnapshot()
+  })
+
+  it('starts unauthenticated when localStorage is empty', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let ctx: any
+    const { container } = renderWithProvider((c) => (ctx = c))
+
+    await waitFor(() => {
+      expect(ctx.isUserAuthenticated).toBe(false)
+      expect(ctx.isGameAuthenticated).toBe(false)
+      expect(ctx.user).toBeUndefined()
+      expect(ctx.game).toBeUndefined()
+    })
+
+    expect(container).toMatchSnapshot()
+  })
+
+  it('setTokenPair(User) decodes tokens and persists to localStorage', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let ctx: any
+    const { container } = renderWithProvider((c) => (ctx = c))
+
+    await act(async () => {
+      ctx.setTokenPair(TokenScope.User, 'user.access.jwt', 'user.refresh.jwt')
+    })
+
+    await waitFor(() => {
+      // context updated
+      expect(ctx.isUserAuthenticated).toBe(true)
+      expect(ctx.user?.ACCESS.token).toBe('user.access.jwt')
+      expect(ctx.user?.REFRESH.token).toBe('user.refresh.jwt')
+      // persisted
+      const parsed = JSON.parse(localStorage.getItem(AUTH_LOCAL_STORAGE_KEY)!)
+      expect(parsed.USER.ACCESS.token).toBe('user.access.jwt')
+      expect(parsed.USER.REFRESH.token).toBe('user.refresh.jwt')
+    })
+
+    expect(container).toMatchSnapshot()
+  })
+
+  it('setTokenPair(Game) decodes game fields and persists to localStorage', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let ctx: any
+    const { container } = renderWithProvider((c) => (ctx = c))
+
+    await act(async () => {
+      ctx.setTokenPair(TokenScope.Game, 'game.access.jwt', 'game.refresh.jwt')
+    })
+
+    await waitFor(() => {
+      expect(ctx.isGameAuthenticated).toBe(true)
+      expect(ctx.game?.ACCESS.token).toBe('game.access.jwt')
+      expect(ctx.game?.REFRESH.token).toBe('game.refresh.jwt')
+      // game extras from mocked decoder
+      expect(ctx.game?.ACCESS.gameId).toBe('game-123')
+      expect(ctx.game?.ACCESS.participantType).toBe('Player')
+      // persisted
+      const parsed = JSON.parse(localStorage.getItem(AUTH_LOCAL_STORAGE_KEY)!)
+      expect(parsed.GAME.ACCESS.token).toBe('game.access.jwt')
+    })
+
+    expect(container).toMatchSnapshot()
+  })
+
+  it('clears per-scope auth with revokeUser/revokeGame (calls API, navigates, updates storage)', async () => {
+    // seed both scopes
+    setLocalStorageAuth({
+      USER: {
+        [TokenType.Access]: { token: 'u.acc', exp: 1 },
+        [TokenType.Refresh]: { token: 'u.ref', exp: 2 },
+      },
+      GAME: {
+        [TokenType.Access]: { token: 'g.acc', exp: 3 },
+        [TokenType.Refresh]: { token: 'g.ref', exp: 4 },
+      },
+    })
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let ctx: any
+    const { container } = renderWithProvider((c) => (ctx = c))
+
+    // revoke user first
+    await act(async () => {
+      await ctx.revokeUser()
+    })
+
+    await waitFor(() => {
+      expect(mockRevoke).toHaveBeenCalledWith({ token: 'u.acc' }) // access is preferred
+      expect(mockNavigate).toHaveBeenCalledWith('/')
+      expect(ctx.user).toBeUndefined()
+      // game still present
+      expect(ctx.game).toBeTruthy()
+    })
+
+    // revoke game next
+    await act(async () => {
+      await ctx.revokeGame()
+    })
+
+    await waitFor(() => {
+      expect(mockRevoke).toHaveBeenCalledWith({ token: 'g.acc' })
+      expect(ctx.game).toBeUndefined()
+      // storage cleared entirely when both scopes are empty
+      expect(localStorage.getItem(AUTH_LOCAL_STORAGE_KEY)).toBeNull()
+    })
+
+    expect(container).toMatchSnapshot()
+  })
+
+  it('removes storage entry when both scopes are cleared', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let ctx: any
+    const { container } = renderWithProvider((c) => (ctx = c))
+
+    await act(async () => {
+      ctx.setTokenPair(TokenScope.User, 'user.acc', 'user.ref')
+      ctx.setTokenPair(TokenScope.Game, 'game.acc', 'game.ref')
+    })
+    expect(localStorage.getItem(AUTH_LOCAL_STORAGE_KEY)).toBeTruthy()
+
+    await act(async () => {
+      await ctx.revokeUser()
+    })
+    await act(async () => {
+      await ctx.revokeGame()
+    })
+
+    await waitFor(() => {
+      expect(localStorage.getItem(AUTH_LOCAL_STORAGE_KEY)).toBeNull()
+    })
+
+    expect(container).toMatchSnapshot()
+  })
+
+  it('removes storage when the last remaining scope is cleared', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let ctx: any
+    const { container } = renderWithProvider((c) => (ctx = c))
+
+    await act(async () => {
+      ctx.setTokenPair(TokenScope.User, 'user.acc', 'user.ref')
+    })
+    expect(localStorage.getItem(AUTH_LOCAL_STORAGE_KEY)).toBeTruthy()
+
+    await act(async () => {
+      await ctx.revokeUser()
+    })
+
+    await waitFor(() => {
+      expect(localStorage.getItem(AUTH_LOCAL_STORAGE_KEY)).toBeNull()
+    })
+
+    expect(container).toMatchSnapshot()
+  })
+})

--- a/packages/quiz/src/context/auth/AuthContextProvider.tsx
+++ b/packages/quiz/src/context/auth/AuthContextProvider.tsx
@@ -17,6 +17,23 @@ import { AUTH_LOCAL_STORAGE_KEY } from '../../utils/constants.ts'
 import { AuthContext, AuthContextType } from './auth-context.tsx'
 
 /**
+ * Reads and parses the initial authentication state from localStorage.
+ *
+ * @returns The parsed `AuthState` if available, otherwise an empty state
+ *          with both `USER` and `GAME` set to `undefined`.
+ */
+function readInitialAuthState(): AuthState {
+  try {
+    const json = localStorage.getItem(AUTH_LOCAL_STORAGE_KEY)
+    return json
+      ? (JSON.parse(json) as AuthState)
+      : { USER: undefined, GAME: undefined }
+  } catch {
+    return { USER: undefined, GAME: undefined }
+  }
+}
+
+/**
  * Props for the `AuthContextProvider` component.
  *
  * @property children - The child components to be wrapped by the provider.
@@ -49,10 +66,9 @@ const AuthContextProvider: FC<AuthContextProviderProps> = ({ children }) => {
   /**
    * In-memory store of decoded token payloads per TokenScope and TokenType.
    */
-  const [authState, setAuthState] = useState<AuthState>({
-    USER: undefined,
-    GAME: undefined,
-  })
+  const [authState, setAuthState] = useState<AuthState>(() =>
+    readInitialAuthState(),
+  )
 
   /**
    * `true` if there is a valid token pair in the User scope.
@@ -63,17 +79,6 @@ const AuthContextProvider: FC<AuthContextProviderProps> = ({ children }) => {
    * `true` if there is a valid token pair in the Game scope.
    */
   const isGameAuthenticated = useMemo(() => !!authState.GAME, [authState])
-
-  /**
-   * On mount, hydrates authState from localStorage if data exists.
-   */
-  useEffect(() => {
-    const jsonString = localStorage.getItem(AUTH_LOCAL_STORAGE_KEY)
-    if (jsonString) {
-      const newAuthState = JSON.parse(jsonString) as AuthState
-      setAuthState(newAuthState)
-    }
-  }, [])
 
   /**
    * Persists authState to localStorage whenever it changes.

--- a/packages/quiz/src/context/auth/__snapshots__/AuthContextProvider.test.tsx.snap
+++ b/packages/quiz/src/context/auth/__snapshots__/AuthContextProvider.test.tsx.snap
@@ -1,0 +1,15 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`AuthContextProvider > clears per-scope auth with revokeUser/revokeGame (calls API, navigates, updates storage) 1`] = `<div />`;
+
+exports[`AuthContextProvider > initializes from localStorage on first render (no flicker) 1`] = `<div />`;
+
+exports[`AuthContextProvider > removes storage entry when both scopes are cleared 1`] = `<div />`;
+
+exports[`AuthContextProvider > removes storage when the last remaining scope is cleared 1`] = `<div />`;
+
+exports[`AuthContextProvider > setTokenPair(Game) decodes game fields and persists to localStorage 1`] = `<div />`;
+
+exports[`AuthContextProvider > setTokenPair(User) decodes tokens and persists to localStorage 1`] = `<div />`;
+
+exports[`AuthContextProvider > starts unauthenticated when localStorage is empty 1`] = `<div />`;


### PR DESCRIPTION
- Added `readInitialAuthState()` to load initial authentication state directly from localStorage during state initialization.
- Removed post-mount hydration effect to ensure `authState` is immediately available on first render.
- Fixed `ProtectedRoute` logic to correctly evaluate allowed access based on matching scope and authentication state.

This ensures consistent auth state from the first render, avoiding UI flicker and incorrect redirects.