### PR TITLE
refactor(mongodb-migrator): replace hardcoded '$UNKNOWN' with constant placeholder

### DIFF
--- a/tools/mongodb-migrator/src/transformers/game-results.transformers.ts
+++ b/tools/mongodb-migrator/src/transformers/game-results.transformers.ts
@@ -7,6 +7,7 @@ import {
   extractValue,
   extractValueOrThrow,
   toDate,
+  UNKNOWN_NICKNAME_PLACEHOLDER,
 } from '../utils'
 
 /**
@@ -37,7 +38,9 @@ export function transformGameResultsDocument(
           'participantId',
           'player',
         ),
-        nickname: extractValue<string>(player, {}, 'nickname') || '$UNKNOWN',
+        nickname:
+          extractValue<string>(player, {}, 'nickname') ||
+          UNKNOWN_NICKNAME_PLACEHOLDER,
         rank: extractValueOrThrow<number>(player, {}, 'rank'),
         correct: extractValue<number>(player, {}, 'correct'),
         incorrect: extractValue<number>(player, {}, 'incorrect'),

--- a/tools/mongodb-migrator/src/utils/collection.utils.ts
+++ b/tools/mongodb-migrator/src/utils/collection.utils.ts
@@ -27,6 +27,7 @@ import {
   COLLECTION_NAME_QUIZZES,
   COLLECTION_NAME_TOKENS,
   COLLECTION_NAME_USERS,
+  UNKNOWN_NICKNAME_PLACEHOLDER,
 } from './constants'
 import { extractValueOrThrow } from './extract-value.utils'
 import { JSONObject, writeJSONObject } from './json.utils'
@@ -165,7 +166,7 @@ export function filterUsers(collections: CollectionsRecord): CollectionsRecord {
 }
 
 /**
- * Replaces any placeholder `'$UNKNOWN'` nicknames in game‐results with the real
+ * Replaces any unknown nickname placeholder in game‐results with the real
  * participant nickname from the corresponding game.
  *
  * @param collections – Map containing `game_results` and `games`.
@@ -206,7 +207,7 @@ export function patchUnknownNicknameInGameResults(
       'players',
     ).map((player) => {
       const nickname = extractValueOrThrow<string>(player, {}, 'nickname')
-      if (nickname === '$UNKNOWN') {
+      if (nickname === UNKNOWN_NICKNAME_PLACEHOLDER) {
         const participantId = extractValueOrThrow<string>(
           player,
           {},
@@ -219,7 +220,7 @@ export function patchUnknownNicknameInGameResults(
         )?.nickname
         if (foundNickname) {
           console.log(
-            `Replacing '$UNKNOWNs' nickname with '${foundNickname}' in game result ${gameId} for player ${participantId}`,
+            `Replacing '${UNKNOWN_NICKNAME_PLACEHOLDER}' nickname with '${foundNickname}' in game result ${gameId} for player ${participantId}`,
           )
           return { ...player, nickname: foundNickname }
         }

--- a/tools/mongodb-migrator/src/utils/constants.ts
+++ b/tools/mongodb-migrator/src/utils/constants.ts
@@ -4,3 +4,5 @@ export const COLLECTION_NAME_GAMES = 'games'
 export const COLLECTION_NAME_GAME_RESULTS = 'game_results'
 export const COLLECTION_NAME_QUIZZES = 'quizzes'
 export const COLLECTION_NAME_TOKENS = 'tokens'
+
+export const UNKNOWN_NICKNAME_PLACEHOLDER = '__UNKNOWN_NICKNAME__'


### PR DESCRIPTION
- Introduced `UNKNOWN_NICKNAME_PLACEHOLDER` constant for unknown player nicknames.
- Updated transformers and utilities to use the new constant instead of a hardcoded value.
- Improved log messages and documentation to reflect the new placeholder name.

Ensures consistent handling of unknown nicknames across the migration process.
