### PR TITLE
feat(user-context): add UserContext with profile sync and API override token

### DIFF
--- a/packages/quiz/src/context/user/UserContext.tsx
+++ b/packages/quiz/src/context/user/UserContext.tsx
@@ -1,0 +1,39 @@
+import { UserProfileResponseDto } from '@quiz/common'
+import { createContext } from 'react'
+
+/**
+ * The shape of the user context.
+ *
+ * @property currentUser - A minimal snapshot of the authenticated user's profile,
+ *                         or `undefined` when no user is loaded.
+ * @property setCurrentUser - Sets/replaces the current user snapshot.
+ * @property fetchCurrentUser - Fetches and stores the current user snapshot using an access token.
+ * @property clearCurrentUser - Clears the stored user snapshot.
+ */
+export type UserContextType = {
+  currentUser?: Pick<
+    UserProfileResponseDto,
+    'id' | 'email' | 'unverifiedEmail' | 'defaultNickname'
+  >
+  setCurrentUser: (
+    currentUser: Pick<
+      UserProfileResponseDto,
+      'id' | 'email' | 'unverifiedEmail' | 'defaultNickname'
+    >,
+  ) => void
+  fetchCurrentUser: (accessToken: string) => Promise<void>
+  clearCurrentUser: () => void
+}
+
+/**
+ * React context for managing the current user profile.
+ *
+ * The default value provides no-ops and `undefined` for `currentUser`. Use
+ * `<UserContextProvider>` to supply a real implementation.
+ */
+export const UserContext = createContext<UserContextType>({
+  currentUser: undefined,
+  setCurrentUser: () => undefined,
+  fetchCurrentUser: () => Promise.reject(),
+  clearCurrentUser: () => undefined,
+})

--- a/packages/quiz/src/context/user/UserContextProvider.test.tsx
+++ b/packages/quiz/src/context/user/UserContextProvider.test.tsx
@@ -1,0 +1,173 @@
+import { render, waitFor } from '@testing-library/react'
+import React from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { UserContext, UserContextType } from './UserContext'
+import UserContextProvider from './UserContextProvider'
+
+// --- Mocks ------------------------------------------------------------------
+
+// Share a mock we can control in tests.
+const getUserProfileMock = vi.fn()
+
+vi.mock('../../api/use-quiz-service-client.tsx', () => ({
+  useQuizServiceClient: () => ({
+    getUserProfile: getUserProfileMock,
+  }),
+}))
+
+// Clean localStorage and reset mocks between tests.
+beforeEach(() => {
+  localStorage.clear()
+  vi.clearAllMocks()
+})
+
+// Simple helper to capture latest context value on every update.
+function renderWithCapture() {
+  let latest: UserContextType | null = null
+
+  const Capture = () => (
+    <UserContext.Consumer>
+      {(value) => {
+        latest = value
+        return null
+      }}
+    </UserContext.Consumer>
+  )
+
+  render(
+    <UserContextProvider>
+      <Capture />
+    </UserContextProvider>,
+  )
+
+  // Return a getter so tests always read the newest value.
+  return () => latest as UserContextType
+}
+
+const PROFILE_A = {
+  id: 'u-1',
+  email: 'a@example.com',
+  unverifiedEmail: undefined as string | undefined,
+  defaultNickname: 'Alpha',
+}
+
+const PROFILE_B = {
+  id: 'u-2',
+  email: 'b@example.com',
+  unverifiedEmail: 'b@pending.com',
+  defaultNickname: 'Beta',
+}
+
+// --- Tests -------------------------------------------------------------------
+
+describe('UserContextProvider', () => {
+  it('fetches and stores user profile', async () => {
+    const getCtx = renderWithCapture()
+    getUserProfileMock.mockResolvedValueOnce(PROFILE_A)
+
+    await getCtx().fetchCurrentUser('token-1')
+
+    await waitFor(() => {
+      expect(getCtx().currentUser).toEqual(PROFILE_A)
+    })
+    expect(getUserProfileMock).toHaveBeenCalledTimes(1)
+    expect(getUserProfileMock).toHaveBeenCalledWith('token-1')
+  })
+
+  it('deduplicates concurrent fetches for the same token (single request)', async () => {
+    const getCtx = renderWithCapture()
+    getUserProfileMock.mockResolvedValueOnce(PROFILE_A)
+
+    // Fire multiple calls rapidly with the same token.
+    await Promise.all([
+      getCtx().fetchCurrentUser('token-dup'),
+      getCtx().fetchCurrentUser('token-dup'),
+      getCtx().fetchCurrentUser('token-dup'),
+    ])
+
+    await waitFor(() => {
+      expect(getCtx().currentUser).toEqual(PROFILE_A)
+    })
+    expect(getUserProfileMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('allows fetching the same token again after the first request settles (inflight reset)', async () => {
+    const getCtx = renderWithCapture()
+    getUserProfileMock.mockResolvedValueOnce(PROFILE_A)
+
+    await getCtx().fetchCurrentUser('token-1')
+    await waitFor(() => {
+      expect(getCtx().currentUser).toEqual(PROFILE_A)
+    })
+    expect(getUserProfileMock).toHaveBeenCalledTimes(1)
+
+    // After completion, inflight should be cleared -> next call issues a new request.
+    getUserProfileMock.mockResolvedValueOnce(PROFILE_A)
+    await getCtx().fetchCurrentUser('token-1')
+
+    expect(getUserProfileMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('issues separate requests for different tokens', async () => {
+    const getCtx = renderWithCapture()
+    getUserProfileMock.mockImplementation((t: string) =>
+      t === 'tA' ? Promise.resolve(PROFILE_A) : Promise.resolve(PROFILE_B),
+    )
+
+    await Promise.all([
+      getCtx().fetchCurrentUser('tA'),
+      getCtx().fetchCurrentUser('tB'),
+    ])
+
+    await waitFor(() => {
+      // Last write wins (depends on resolution order) — assert at least that one completed.
+      expect([PROFILE_A, PROFILE_B]).toContainEqual(getCtx().currentUser!)
+    })
+    expect(getUserProfileMock).toHaveBeenCalledTimes(2)
+    expect(getUserProfileMock).toHaveBeenCalledWith('tA')
+    expect(getUserProfileMock).toHaveBeenCalledWith('tB')
+  })
+
+  it('clears currentUser when fetching fails', async () => {
+    const getCtx = renderWithCapture()
+
+    // Seed a value first to ensure it gets cleared on error.
+    getUserProfileMock.mockResolvedValueOnce(PROFILE_A)
+    await getCtx().fetchCurrentUser('ok')
+    await waitFor(() => expect(getCtx().currentUser).toEqual(PROFILE_A))
+
+    // Now fail a fetch and ensure it clears.
+    getUserProfileMock.mockRejectedValueOnce(new Error('boom'))
+    await getCtx().fetchCurrentUser('bad')
+
+    await waitFor(() => {
+      expect(getCtx().currentUser).toBeUndefined()
+    })
+  })
+
+  it('returns a resolved promise immediately when a same-token request is already in-flight', async () => {
+    const getCtx = renderWithCapture()
+
+    // Create a pending promise to keep the first call "in-flight".
+    let resolveFirst!: () => void
+    const first = new Promise<typeof PROFILE_A>((resolve) => {
+      resolveFirst = () => resolve(PROFILE_A)
+    })
+    getUserProfileMock.mockReturnValueOnce(first)
+
+    const p1 = getCtx().fetchCurrentUser('t-inflight')
+    const p2 = getCtx().fetchCurrentUser('t-inflight') // should dedupe and resolve quickly
+
+    // Second call should not trigger a second fetch.
+    expect(getUserProfileMock).toHaveBeenCalledTimes(1)
+
+    // Resolve the first request.
+    resolveFirst()
+    await Promise.all([p1, p2])
+
+    await waitFor(() => {
+      expect(getCtx().currentUser).toEqual(PROFILE_A)
+    })
+  })
+})

--- a/packages/quiz/src/context/user/UserContextProvider.tsx
+++ b/packages/quiz/src/context/user/UserContextProvider.tsx
@@ -1,0 +1,84 @@
+import React, { FC, ReactNode, useCallback, useMemo, useRef } from 'react'
+import { useLocalStorage } from 'usehooks-ts'
+
+import { useQuizServiceClient } from '../../api/use-quiz-service-client.tsx'
+
+import { UserContext, UserContextType } from './UserContext.tsx'
+
+/**
+ * Provides the current user profile to descendants.
+ *
+ * Exposes helpers to:
+ * - fetch and store the profile once using an access token, and
+ * - clear the stored profile (e.g., on revoke/logout).
+ */
+export interface UserContextProviderProps {
+  /** React children that will have access to the user context. */
+  children: ReactNode | ReactNode[]
+}
+
+/**
+ * Context provider for current user state.
+ *
+ * @param children - React nodes that should consume the user context.
+ */
+const UserContextProvider: FC<UserContextProviderProps> = ({ children }) => {
+  /**
+   * API client function for retrieving the current user's profile using an access token.
+   */
+  const { getUserProfile } = useQuizServiceClient()
+
+  /**
+   * Persisted snapshot of the current user profile.
+   * Defaults to `undefined` when no profile is loaded.
+   */
+  const [currentUser, setCurrentUser, clearCurrentUser] = useLocalStorage<
+    UserContextType['currentUser'] | undefined
+  >('currentUser', undefined)
+
+  /**
+   * Tracks the token of the currently in-flight `getUserProfile` request.
+   */
+  const inflight = useRef<string | null>(null)
+
+  /**
+   * Fetches the current user profile using the provided access token
+   * and stores a minimal snapshot of it.
+   *
+   * @param accessToken - The access token to authenticate the request.
+   */
+  const fetchCurrentUser = useCallback(
+    async (accessToken: string) => {
+      if (inflight.current === accessToken) return Promise.resolve()
+      inflight.current = accessToken
+      return getUserProfile(accessToken)
+        .then(({ id, email, unverifiedEmail, defaultNickname }) => {
+          setCurrentUser({ id, email, unverifiedEmail, defaultNickname })
+        })
+        .catch(() => {
+          clearCurrentUser()
+        })
+        .finally(() => {
+          if (inflight.current === accessToken) inflight.current = null
+        })
+    },
+    [getUserProfile, setCurrentUser, clearCurrentUser],
+  )
+
+  /**
+   * Memoized context value to avoid unnecessary re-renders.
+   */
+  const value = useMemo<UserContextType>(
+    () => ({
+      currentUser,
+      setCurrentUser,
+      fetchCurrentUser,
+      clearCurrentUser,
+    }),
+    [currentUser, setCurrentUser, fetchCurrentUser, clearCurrentUser],
+  )
+
+  return <UserContext.Provider value={value}>{children}</UserContext.Provider>
+}
+
+export default UserContextProvider

--- a/packages/quiz/src/context/user/index.ts
+++ b/packages/quiz/src/context/user/index.ts
@@ -1,0 +1,5 @@
+export type { UserContextType } from './UserContext'
+export type { UserContextProviderProps } from './UserContextProvider'
+export { UserContext } from './UserContext'
+export { default } from './UserContextProvider'
+export { useUserContext } from './useUserContext'

--- a/packages/quiz/src/context/user/useUserContext.tsx
+++ b/packages/quiz/src/context/user/useUserContext.tsx
@@ -1,0 +1,13 @@
+import { useContext } from 'react'
+
+import { UserContext } from './UserContext.tsx'
+
+/**
+ * Hook to access the user context.
+ *
+ * Use this inside a `<UserContextProvider>` to read and mutate the
+ * current user state.
+ *
+ * @returns The user context value.
+ */
+export const useUserContext = () => useContext(UserContext)

--- a/packages/quiz/src/main.tsx
+++ b/packages/quiz/src/main.tsx
@@ -9,6 +9,7 @@ import { ProtectedRoute } from './components'
 import AuthContextProvider from './context/auth'
 import GameContextProvider from './context/game'
 import MigrationContextProvider from './context/migration'
+import UserContextProvider from './context/user'
 import {
   AuthGamePage,
   AuthGoogleCallbackPage,
@@ -39,11 +40,13 @@ const router = createBrowserRouter([
   {
     path: '/',
     element: (
-      <AuthContextProvider>
-        <MigrationContextProvider>
-          <Outlet />
-        </MigrationContextProvider>
-      </AuthContextProvider>
+      <UserContextProvider>
+        <AuthContextProvider>
+          <MigrationContextProvider>
+            <Outlet />
+          </MigrationContextProvider>
+        </AuthContextProvider>
+      </UserContextProvider>
     ),
     children: [
       {

--- a/packages/quiz/src/pages/ProfileUserPage/ProfileUserPage.tsx
+++ b/packages/quiz/src/pages/ProfileUserPage/ProfileUserPage.tsx
@@ -4,6 +4,7 @@ import React, { FC, useState } from 'react'
 
 import { useQuizServiceClient } from '../../api/use-quiz-service-client.tsx'
 import { LoadingSpinner, Page } from '../../components'
+import { useUserContext } from '../../context/user'
 import { trimToUndefined } from '../../utils/helpers.ts'
 
 import { ProfileUserPageUI, UpdateUserDetailsFormFields } from './components'
@@ -17,6 +18,8 @@ const ProfileUserPage: FC = () => {
     resendVerificationEmail,
   } = useQuizServiceClient()
 
+  const { setCurrentUser } = useUserContext()
+
   const [isSavingUserProfile, setIsSavingUserProfile] = useState(false)
   const [isSavingUserPassword, setIsSavingUserPassword] = useState(false)
 
@@ -27,7 +30,7 @@ const ProfileUserPage: FC = () => {
     refetch,
   } = useQuery({
     queryKey: ['myUserProfile'],
-    queryFn: getUserProfile,
+    queryFn: () => getUserProfile(undefined),
   })
 
   const handleChange = (request: UpdateUserDetailsFormFields): void => {
@@ -47,6 +50,9 @@ const ProfileUserPage: FC = () => {
               defaultNickname: request.defaultNickname,
             }),
       })
+        .then(({ id, email, unverifiedEmail, defaultNickname }) => {
+          setCurrentUser({ id, email, unverifiedEmail, defaultNickname })
+        })
         .then(() => refetch())
         .finally(() => setIsSavingUserProfile(false))
     }


### PR DESCRIPTION
- Introduce UserContext, provider, and hook to expose `currentUser`, with localStorage persistence.
- Add in-flight deduplication using a ref to prevent duplicate profile fetches; include comprehensive unit tests.
- Extend `apiGet`/`getUserProfile` to accept an `overrideToken`; fetch profile after login/register and clear it on revoke.
- Wire `UserContextProvider` at the app root and update Profile page to set context after profile updates and adjust queryFn.
- Add JSDoc across new context files and provider internals.

Ensures the user profile stays in sync with authentication events while eliminating bursty requests and simplifying consumption across the app.