### PR TITLE
feat(auth): scope revoke and await profile sync after login

### DIFF
--- a/packages/quiz/src/api/use-quiz-service-client.tsx
+++ b/packages/quiz/src/api/use-quiz-service-client.tsx
@@ -239,12 +239,12 @@ export const useQuizServiceClient = () => {
         email: request.email,
         password: request.password,
       },
-    ).then((res) => {
+    ).then(async (res) => {
       setTokenPair(TokenScope.User, res.accessToken, res.refreshToken)
       if (!migrated && !!migrationToken) {
         completeMigration()
       }
-      fetchCurrentUser(res.accessToken)
+      await fetchCurrentUser(res.accessToken)
       return res
     })
 
@@ -261,12 +261,12 @@ export const useQuizServiceClient = () => {
     apiPost<AuthResponseDto>(
       `/auth/google/exchange${parseQueryParams({ ...(!migrated && migrationToken ? { migrationToken } : {}) })}`,
       request,
-    ).then((res) => {
+    ).then(async (res) => {
       setTokenPair(TokenScope.User, res.accessToken, res.refreshToken)
       if (!migrated && !!migrationToken) {
         completeMigration()
       }
-      fetchCurrentUser(res.accessToken)
+      await fetchCurrentUser(res.accessToken)
       return res
     })
 
@@ -307,11 +307,17 @@ export const useQuizServiceClient = () => {
    * effectively logging out the user and preventing further use of that token.
    *
    * @param request - An object containing the token to be revoked.
+   * @param scope - The TokenScope (User or Game) whose token to revoke.
    * @returns A promise that resolves when the token has been successfully revoked.
    */
-  const revoke = (request: AuthRevokeRequestDto): Promise<void> =>
+  const revoke = (
+    request: AuthRevokeRequestDto,
+    scope: TokenScope,
+  ): Promise<void> =>
     apiPost<void>('/auth/revoke', request).then(() => {
-      clearCurrentUser()
+      if (scope === TokenScope.User) {
+        clearCurrentUser()
+      }
     })
 
   /**

--- a/packages/quiz/src/context/auth/AuthContextProvider.test.tsx
+++ b/packages/quiz/src/context/auth/AuthContextProvider.test.tsx
@@ -189,7 +189,7 @@ describe('AuthContextProvider', () => {
     })
 
     await waitFor(() => {
-      expect(mockRevoke).toHaveBeenCalledWith({ token: 'u.acc' }) // access is preferred
+      expect(mockRevoke).toHaveBeenCalledWith({ token: 'u.acc' }, 'USER') // access is preferred
       expect(mockNavigate).toHaveBeenCalledWith('/')
       expect(ctx.user).toBeUndefined()
       // game still present
@@ -202,7 +202,7 @@ describe('AuthContextProvider', () => {
     })
 
     await waitFor(() => {
-      expect(mockRevoke).toHaveBeenCalledWith({ token: 'g.acc' })
+      expect(mockRevoke).toHaveBeenCalledWith({ token: 'g.acc' }, 'GAME')
       expect(ctx.game).toBeUndefined()
       // storage cleared entirely when both scopes are empty
       expect(localStorage.getItem(AUTH_LOCAL_STORAGE_KEY)).toBeNull()

--- a/packages/quiz/src/context/auth/AuthContextProvider.tsx
+++ b/packages/quiz/src/context/auth/AuthContextProvider.tsx
@@ -193,7 +193,7 @@ const AuthContextProvider: FC<AuthContextProviderProps> = ({ children }) => {
       const token =
         authState[scope]?.ACCESS.token || authState[scope]?.REFRESH.token
       if (token) {
-        revoke({ token }).then(() => {
+        revoke({ token }, scope).then(() => {
           clearAuthState(scope)
           navigate('/')
         })


### PR DESCRIPTION
- Add `scope` parameter to `revoke(...)` and clear UserContext only when revoking `TokenScope.User`.
- Update `AuthContextProvider` to pass the current scope into `revoke`.
- Await `fetchCurrentUser` after login/register to avoid UI races with profile loading.

Prevents unintended profile clears on game-token revocation and ensures the UI has a fresh user profile immediately after authentication.
