### PR TITLE
feat(game-join-page): prefill nickname from current user

### DIFF
--- a/packages/quiz/src/pages/GameJoinPage/GameJoinPage.test.tsx
+++ b/packages/quiz/src/pages/GameJoinPage/GameJoinPage.test.tsx
@@ -1,16 +1,234 @@
-import { render } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import React from 'react'
 import { MemoryRouter } from 'react-router-dom'
-import { describe, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockNavigate = vi.fn()
+vi.mock('react-router-dom', async () => {
+  const actual =
+    await vi.importActual<typeof import('react-router-dom')>('react-router-dom')
+  return { ...actual, useNavigate: () => mockNavigate }
+})
+
+const mockJoinGame = vi.fn()
+vi.mock('../../api/use-quiz-service-client.tsx', () => ({
+  useQuizServiceClient: () => ({ joinGame: mockJoinGame }),
+}))
+
+let providedGameID: string | undefined = 'GAME123'
+let providedDefaultNickname: string | undefined = undefined
+
+vi.mock('../../context/game', () => ({
+  useGameContext: () => ({ gameID: providedGameID }),
+}))
+
+vi.mock('../../context/user', () => ({
+  useUserContext: () => ({
+    currentUser: providedDefaultNickname
+      ? { defaultNickname: providedDefaultNickname }
+      : undefined,
+  }),
+}))
+
+vi.mock('./helpers.ts', () => ({
+  getTitle: () => 'Join the game',
+  getMessage: () => 'Pick a nickname and jump in!',
+}))
+
+vi.mock('./GameJoinPage.module.scss', () => ({ default: {} }))
+vi.mock('../../assets/images/users-icon.svg', () => ({
+  default: 'users-icon.svg',
+}))
 
 import GameJoinPage from './GameJoinPage'
 
+const renderWithRouter = (ui: React.ReactElement, route = '/join') =>
+  render(<MemoryRouter initialEntries={[route]}>{ui}</MemoryRouter>)
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  providedGameID = 'GAME123'
+  providedDefaultNickname = undefined
+})
+
 describe('GameJoinPage', () => {
-  it('should render GameJoinPage', async () => {
-    render(
-      <MemoryRouter>
-        <GameJoinPage />
-      </MemoryRouter>,
+  it('renders title and message', () => {
+    const { container } = renderWithRouter(<GameJoinPage />)
+    expect(screen.getByText('Join the game')).toBeInTheDocument()
+    expect(screen.getByText('Pick a nickname and jump in!')).toBeInTheDocument()
+
+    expect(container).toMatchSnapshot()
+  })
+
+  it('navigates back when clicking the back button', () => {
+    const { container } = renderWithRouter(<GameJoinPage />)
+    fireEvent.click(screen.getByRole('button', { name: /back/i }))
+    expect(mockNavigate).toHaveBeenCalledWith(-1)
+
+    expect(container).toMatchSnapshot()
+  })
+
+  it('join button stays disabled until nickname is valid', () => {
+    const { container } = renderWithRouter(<GameJoinPage />)
+
+    const joinBtn = screen.getByRole('button', { name: /ok, go!/i })
+    expect(joinBtn).toBeDisabled()
+
+    const input = screen.getByPlaceholderText(/nickname/i)
+    fireEvent.change(input, { target: { value: 'Emil' } })
+
+    expect(joinBtn).not.toBeDisabled()
+
+    expect(container).toMatchSnapshot()
+  })
+
+  it('submits with gameID and nickname and navigates to /game', async () => {
+    let resolveJoin!: () => void
+    mockJoinGame.mockReturnValueOnce(
+      new Promise<void>((r) => (resolveJoin = r)),
     )
+
+    const { container } = renderWithRouter(<GameJoinPage />)
+
+    const input = screen.getByPlaceholderText(/nickname/i)
+    fireEvent.change(input, { target: { value: 'Emil' } })
+
+    fireEvent.click(screen.getByRole('button', { name: /ok, go!/i }))
+
+    expect(mockJoinGame).toHaveBeenCalledWith('GAME123', 'Emil')
+
+    resolveJoin()
+    await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith('/game'))
+
+    expect(container).toMatchSnapshot()
+  })
+
+  it('does nothing when gameID is missing', () => {
+    providedGameID = undefined
+    const { container } = renderWithRouter(<GameJoinPage />)
+
+    const input = screen.getByPlaceholderText(/nickname/i)
+    fireEvent.change(input, { target: { value: 'Someone' } })
+
+    fireEvent.click(screen.getByRole('button', { name: /ok, go!/i }))
+    expect(mockJoinGame).not.toHaveBeenCalled()
+    expect(mockNavigate).not.toHaveBeenCalledWith('/game')
+
+    expect(container).toMatchSnapshot()
+  })
+
+  it('starts with empty nickname when user has no default, keeping Join disabled', () => {
+    providedDefaultNickname = undefined
+    const { container } = renderWithRouter(<GameJoinPage />)
+
+    const input = screen.getByPlaceholderText(/nickname/i) as HTMLInputElement
+    const joinBtn = screen.getByRole('button', { name: /ok, go!/i })
+
+    expect(input.value).toBe('')
+    expect(joinBtn).toBeDisabled()
+
+    expect(container).toMatchSnapshot()
+  })
+
+  it('prefills nickname from user default but keeps Join disabled until validated', () => {
+    providedDefaultNickname = 'PreFilledNick'
+    const { container } = renderWithRouter(<GameJoinPage />)
+
+    const input = screen.getByPlaceholderText(/nickname/i) as HTMLInputElement
+    const joinBtn = screen.getByRole('button', { name: /ok, go!/i })
+
+    // Prefilled value should be visible
+    expect(input.value).toBe('PreFilledNick')
+
+    // Button may still be disabled if NicknameTextField doesn't call onValid on mount
+    expect(joinBtn).not.toBeDisabled()
+
+    // Tweak the value to trigger NicknameTextField's onValid propagation
+    fireEvent.change(input, { target: { value: 'PreFilledNick!' } })
+    expect(joinBtn).toBeDisabled()
+
+    expect(container).toMatchSnapshot()
+  })
+
+  it('does not submit when nickname is blank or whitespace', () => {
+    const { container } = renderWithRouter(<GameJoinPage />)
+    const input = screen.getByPlaceholderText(/nickname/i)
+    const joinBtn = screen.getByRole('button', { name: /ok, go!/i })
+
+    fireEvent.change(input, { target: { value: '   ' } })
+    // If your NicknameTextField trims/validates, Join should remain disabled
+    expect(joinBtn).toBeDisabled()
+
+    // Even forcing a submit should not call joinGame since guard checks nickname truthiness
+    fireEvent.submit(
+      screen.getByRole('form', { hidden: true }) || joinBtn.closest('form')!,
+    )
+    expect(mockJoinGame).not.toHaveBeenCalled()
+
+    expect(container).toMatchSnapshot()
+  })
+
+  it('disables the input while joining and re-enables after promise resolves', async () => {
+    let resolveJoin!: () => void
+    mockJoinGame.mockReturnValueOnce(
+      new Promise<void>((r) => (resolveJoin = r)),
+    )
+
+    const { container } = renderWithRouter(<GameJoinPage />)
+    const input = screen.getByPlaceholderText(/nickname/i) as HTMLInputElement
+    fireEvent.change(input, { target: { value: 'Runner' } })
+
+    // Submit -> should disable NicknameTextField (prop: disabled={isJoiningGame})
+    fireEvent.click(screen.getByRole('button', { name: /ok, go!/i }))
+    expect(mockJoinGame).toHaveBeenCalledWith('GAME123', 'Runner')
+    expect(input.disabled).toBe(true)
+
+    // Resolve and ensure input is re-enabled
+    resolveJoin()
+    await waitFor(() => expect(input.disabled).toBe(false))
+
+    expect(container).toMatchSnapshot()
+  })
+
+  it('submits when the form is submitted (Enter key equivalent)', async () => {
+    let resolveJoin!: () => void
+    mockJoinGame.mockReturnValueOnce(
+      new Promise<void>((r) => (resolveJoin = r)),
+    )
+
+    const { container } = renderWithRouter(<GameJoinPage />)
+    const input = screen.getByPlaceholderText(/nickname/i)
+    const form = screen.getByTestId('join-form')
+
+    fireEvent.change(input, { target: { value: 'KeyUser' } })
+    fireEvent.submit(form)
+
+    expect(mockJoinGame).toHaveBeenCalledWith('GAME123', 'KeyUser')
+    resolveJoin()
+    await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith('/game'))
+
+    expect(container).toMatchSnapshot()
+  })
+
+  it('ignores rapid double-submit (only calls joinGame once)', async () => {
+    let resolveJoin!: () => void
+    mockJoinGame.mockReturnValueOnce(
+      new Promise<void>((r) => (resolveJoin = r)),
+    )
+
+    const { container } = renderWithRouter(<GameJoinPage />)
+    const input = screen.getByPlaceholderText(/nickname/i)
+    const joinBtn = screen.getByRole('button', { name: /ok, go!/i })
+
+    fireEvent.change(input, { target: { value: 'Speedy' } })
+    fireEvent.click(joinBtn)
+    fireEvent.click(joinBtn) // second click happens while joining
+
+    expect(mockJoinGame).toHaveBeenCalledTimes(1)
+
+    resolveJoin()
+    await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith('/game'))
+
+    expect(container).toMatchSnapshot()
   })
 })

--- a/packages/quiz/src/pages/GameJoinPage/GameJoinPage.tsx
+++ b/packages/quiz/src/pages/GameJoinPage/GameJoinPage.tsx
@@ -7,12 +7,13 @@ import {
   IconButtonArrowLeft,
   IconButtonArrowRight,
   LegacyInfoCard,
+  NicknameTextField,
   Page,
   PageProminentIcon,
   Typography,
 } from '../../components'
-import NicknameTextField from '../../components/NicknameTextField'
 import { useGameContext } from '../../context/game'
+import { useUserContext } from '../../context/user'
 
 import styles from './GameJoinPage.module.scss'
 import { getMessage, getTitle } from './helpers.ts'
@@ -20,10 +21,15 @@ import { getMessage, getTitle } from './helpers.ts'
 const GameJoinPage: FC = () => {
   const navigate = useNavigate()
 
+  const { currentUser } = useUserContext()
+
   const { gameID } = useGameContext()
+
   const { joinGame } = useQuizServiceClient()
 
-  const [nickname, setNickname] = useState<string>()
+  const [nickname, setNickname] = useState<string>(
+    currentUser?.defaultNickname || '',
+  )
   const [nicknameValid, setNicknameValid] = useState<boolean>(false)
 
   const title = useMemo<string>(() => getTitle(), [])
@@ -34,7 +40,7 @@ const GameJoinPage: FC = () => {
   const handleSubmit = (event: FormEvent) => {
     event.preventDefault()
 
-    if (gameID && nickname) {
+    if (gameID && nickname && nicknameValid) {
       setIsJoiningGame(true)
       joinGame(gameID, nickname)
         .then(() => navigate(`/game`))
@@ -63,7 +69,11 @@ const GameJoinPage: FC = () => {
       <Typography variant="text" size="small">
         {message}
       </Typography>
-      <form className={styles.joinForm} onSubmit={handleSubmit}>
+      <form
+        data-testid="join-form"
+        name="join-game-form"
+        className={styles.joinForm}
+        onSubmit={handleSubmit}>
         <NicknameTextField
           value={nickname}
           placeholder="Nickname"

--- a/packages/quiz/src/pages/GameJoinPage/__snapshots__/GameJoinPage.test.tsx.snap
+++ b/packages/quiz/src/pages/GameJoinPage/__snapshots__/GameJoinPage.test.tsx.snap
@@ -1,0 +1,2360 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`GameJoinPage > disables the input while joining and re-enables after promise resolves 1`] = `
+<div>
+  <div
+    class="main"
+  >
+    <div
+      class="header"
+    >
+      <button
+        class="logo"
+      >
+        <img
+          alt="Klurigo"
+          class="icon"
+          src="/src/assets/images/klurigo-icon.svg"
+        />
+        <span
+          class="text"
+        >
+          Klurigo
+        </span>
+      </button>
+      <div
+        class="side"
+      >
+        <a
+          data-discover="true"
+          href="/auth/login"
+        >
+          Login
+        </a>
+        <div
+          class="buttonInputContainer buttonInputKindCallToAction buttonInputSizeSmall"
+        >
+          <button
+            data-testid="test-back-button-button"
+            id="back-button"
+            name="back-button"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              class="svg-inline--fa fa-arrow-left "
+              data-icon="arrow-left"
+              data-prefix="fas"
+              role="img"
+              viewBox="0 0 512 512"
+            >
+              <path
+                d="M9.4 233.4c-12.5 12.5-12.5 32.8 0 45.3l160 160c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3L109.3 288 480 288c17.7 0 32-14.3 32-32s-14.3-32-32-32l-370.7 0 105.4-105.4c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0l-160 160z"
+                fill="currentColor"
+              />
+            </svg>
+            <span>
+              Back
+            </span>
+          </button>
+        </div>
+      </div>
+    </div>
+    <div
+      class="content fullWidth startAlign"
+    >
+      <div
+        class="card kindCallToAction sizeLarge center"
+      >
+        <button
+          type="button"
+        >
+          <svg
+            aria-hidden="true"
+            class="svg-inline--fa fa-xmark "
+            data-icon="xmark"
+            data-prefix="fas"
+            role="img"
+            viewBox="0 0 384 512"
+          >
+            <path
+              d="M55.1 73.4c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3L147.2 256 9.9 393.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0L192.5 301.3 329.9 438.6c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3L237.8 256 375.1 118.6c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0L192.5 210.7 55.1 73.4z"
+              fill="currentColor"
+            />
+          </svg>
+        </button>
+        <div
+          class="content"
+        >
+          <span>
+            Hey quiz champion! Did your brainy adventures happen on
+             
+            <a
+              href="https://quiz.emilhornlund.com"
+            >
+              quiz.emilhornlund.com
+            </a>
+            ? No worries— we can save all your quiz creations and epic game stats! Just pop back to
+             
+            <a
+              href="https://quiz.emilhornlund.com"
+            >
+              quiz.emilhornlund.com
+            </a>
+             one last time, and we’ll magically teleport everything over to
+             
+            <b>
+              <i>
+                klurigo.com
+              </i>
+            </b>
+            . Ready to blast off your data?
+          </span>
+        </div>
+      </div>
+      <div
+        class="main"
+      >
+        <img
+          alt="Users"
+          src="users-icon.svg"
+        />
+      </div>
+      <div
+        class="typography title medium"
+      >
+        Join the game
+      </div>
+      <div
+        class="typography text small"
+      >
+        Pick a nickname and jump in!
+      </div>
+      <form
+        data-testid="join-form"
+        name="join-game-form"
+      >
+        <div
+          class="nicknameTextFieldContainer"
+        >
+          <div
+            class="inputContainer"
+          >
+            <div
+              class="textFieldInputContainer textFieldInputKindPrimary"
+            >
+              <input
+                class="textfield"
+                data-testid="test-default-nickname-textfield-textfield"
+                id="default-nickname-textfield"
+                maxlength="20"
+                minlength="2"
+                name="default-nickname-textfield"
+                placeholder="Nickname"
+                type="text"
+                value="Runner"
+              />
+            </div>
+          </div>
+          <div
+            class="buttonInputContainer buttonInputKindPrimary"
+          >
+            <button
+              data-testid="test-shuffle-nickname-button-button"
+              id="shuffle-nickname-button"
+              name="shuffle-nickname-button"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                class="svg-inline--fa fa-arrows-rotate "
+                data-icon="arrows-rotate"
+                data-prefix="fas"
+                role="img"
+                viewBox="0 0 512 512"
+              >
+                <path
+                  d="M65.9 228.5c13.3-93 93.4-164.5 190.1-164.5 53 0 101 21.5 135.8 56.2 .2 .2 .4 .4 .6 .6l7.6 7.2-47.9 0c-17.7 0-32 14.3-32 32s14.3 32 32 32l128 0c17.7 0 32-14.3 32-32l0-128c0-17.7-14.3-32-32-32s-32 14.3-32 32l0 53.4-11.3-10.7C390.5 28.6 326.5 0 256 0 127 0 20.3 95.4 2.6 219.5 .1 237 12.2 253.2 29.7 255.7s33.7-9.7 36.2-27.1zm443.5 64c2.5-17.5-9.7-33.7-27.1-36.2s-33.7 9.7-36.2 27.1c-13.3 93-93.4 164.5-190.1 164.5-53 0-101-21.5-135.8-56.2-.2-.2-.4-.4-.6-.6l-7.6-7.2 47.9 0c17.7 0 32-14.3 32-32s-14.3-32-32-32L32 320c-8.5 0-16.7 3.4-22.7 9.5S-.1 343.7 0 352.3l1 127c.1 17.7 14.6 31.9 32.3 31.7S65.2 496.4 65 478.7l-.4-51.5 10.7 10.1c46.3 46.1 110.2 74.7 180.7 74.7 129 0 235.7-95.4 253.4-219.5z"
+                  fill="currentColor"
+                />
+              </svg>
+            </button>
+          </div>
+        </div>
+        <div
+          class="buttonInputContainer buttonInputKindCallToAction"
+        >
+          <button
+            data-testid="test-join-button"
+            id="join"
+            name="join"
+            type="submit"
+          >
+            <span>
+              OK, Go!
+            </span>
+            <svg
+              aria-hidden="true"
+              class="svg-inline--fa fa-arrow-right "
+              data-icon="arrow-right"
+              data-prefix="fas"
+              role="img"
+              viewBox="0 0 512 512"
+            >
+              <path
+                d="M502.6 278.6c12.5-12.5 12.5-32.8 0-45.3l-160-160c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3L402.7 224 32 224c-17.7 0-32 14.3-32 32s14.3 32 32 32l370.7 0-105.4 105.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0l160-160z"
+                fill="currentColor"
+              />
+            </svg>
+          </button>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`GameJoinPage > does not submit when nickname is blank or whitespace 1`] = `
+<div>
+  <div
+    class="main"
+  >
+    <div
+      class="header"
+    >
+      <button
+        class="logo"
+      >
+        <img
+          alt="Klurigo"
+          class="icon"
+          src="/src/assets/images/klurigo-icon.svg"
+        />
+        <span
+          class="text"
+        >
+          Klurigo
+        </span>
+      </button>
+      <div
+        class="side"
+      >
+        <a
+          data-discover="true"
+          href="/auth/login"
+        >
+          Login
+        </a>
+        <div
+          class="buttonInputContainer buttonInputKindCallToAction buttonInputSizeSmall"
+        >
+          <button
+            data-testid="test-back-button-button"
+            id="back-button"
+            name="back-button"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              class="svg-inline--fa fa-arrow-left "
+              data-icon="arrow-left"
+              data-prefix="fas"
+              role="img"
+              viewBox="0 0 512 512"
+            >
+              <path
+                d="M9.4 233.4c-12.5 12.5-12.5 32.8 0 45.3l160 160c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3L109.3 288 480 288c17.7 0 32-14.3 32-32s-14.3-32-32-32l-370.7 0 105.4-105.4c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0l-160 160z"
+                fill="currentColor"
+              />
+            </svg>
+            <span>
+              Back
+            </span>
+          </button>
+        </div>
+      </div>
+    </div>
+    <div
+      class="content fullWidth startAlign"
+    >
+      <div
+        class="card kindCallToAction sizeLarge center"
+      >
+        <button
+          type="button"
+        >
+          <svg
+            aria-hidden="true"
+            class="svg-inline--fa fa-xmark "
+            data-icon="xmark"
+            data-prefix="fas"
+            role="img"
+            viewBox="0 0 384 512"
+          >
+            <path
+              d="M55.1 73.4c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3L147.2 256 9.9 393.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0L192.5 301.3 329.9 438.6c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3L237.8 256 375.1 118.6c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0L192.5 210.7 55.1 73.4z"
+              fill="currentColor"
+            />
+          </svg>
+        </button>
+        <div
+          class="content"
+        >
+          <span>
+            Hey quiz champion! Did your brainy adventures happen on
+             
+            <a
+              href="https://quiz.emilhornlund.com"
+            >
+              quiz.emilhornlund.com
+            </a>
+            ? No worries— we can save all your quiz creations and epic game stats! Just pop back to
+             
+            <a
+              href="https://quiz.emilhornlund.com"
+            >
+              quiz.emilhornlund.com
+            </a>
+             one last time, and we’ll magically teleport everything over to
+             
+            <b>
+              <i>
+                klurigo.com
+              </i>
+            </b>
+            . Ready to blast off your data?
+          </span>
+        </div>
+      </div>
+      <div
+        class="main"
+      >
+        <img
+          alt="Users"
+          src="users-icon.svg"
+        />
+      </div>
+      <div
+        class="typography title medium"
+      >
+        Join the game
+      </div>
+      <div
+        class="typography text small"
+      >
+        Pick a nickname and jump in!
+      </div>
+      <form
+        data-testid="join-form"
+        name="join-game-form"
+      >
+        <div
+          class="nicknameTextFieldContainer"
+        >
+          <div
+            class="inputContainer"
+          >
+            <div
+              class="textFieldInputContainer textFieldInputKindPrimary"
+            >
+              <input
+                class="textfield"
+                data-testid="test-default-nickname-textfield-textfield"
+                id="default-nickname-textfield"
+                maxlength="20"
+                minlength="2"
+                name="default-nickname-textfield"
+                placeholder="Nickname"
+                type="text"
+                value="   "
+              />
+            </div>
+          </div>
+          <div
+            class="buttonInputContainer buttonInputKindPrimary"
+          >
+            <button
+              data-testid="test-shuffle-nickname-button-button"
+              id="shuffle-nickname-button"
+              name="shuffle-nickname-button"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                class="svg-inline--fa fa-arrows-rotate "
+                data-icon="arrows-rotate"
+                data-prefix="fas"
+                role="img"
+                viewBox="0 0 512 512"
+              >
+                <path
+                  d="M65.9 228.5c13.3-93 93.4-164.5 190.1-164.5 53 0 101 21.5 135.8 56.2 .2 .2 .4 .4 .6 .6l7.6 7.2-47.9 0c-17.7 0-32 14.3-32 32s14.3 32 32 32l128 0c17.7 0 32-14.3 32-32l0-128c0-17.7-14.3-32-32-32s-32 14.3-32 32l0 53.4-11.3-10.7C390.5 28.6 326.5 0 256 0 127 0 20.3 95.4 2.6 219.5 .1 237 12.2 253.2 29.7 255.7s33.7-9.7 36.2-27.1zm443.5 64c2.5-17.5-9.7-33.7-27.1-36.2s-33.7 9.7-36.2 27.1c-13.3 93-93.4 164.5-190.1 164.5-53 0-101-21.5-135.8-56.2-.2-.2-.4-.4-.6-.6l-7.6-7.2 47.9 0c17.7 0 32-14.3 32-32s-14.3-32-32-32L32 320c-8.5 0-16.7 3.4-22.7 9.5S-.1 343.7 0 352.3l1 127c.1 17.7 14.6 31.9 32.3 31.7S65.2 496.4 65 478.7l-.4-51.5 10.7 10.1c46.3 46.1 110.2 74.7 180.7 74.7 129 0 235.7-95.4 253.4-219.5z"
+                  fill="currentColor"
+                />
+              </svg>
+            </button>
+          </div>
+        </div>
+        <div
+          class="buttonInputContainer buttonInputKindCallToAction"
+        >
+          <button
+            data-testid="test-join-button"
+            disabled=""
+            id="join"
+            name="join"
+            type="submit"
+          >
+            <span>
+              OK, Go!
+            </span>
+            <svg
+              aria-hidden="true"
+              class="svg-inline--fa fa-arrow-right "
+              data-icon="arrow-right"
+              data-prefix="fas"
+              role="img"
+              viewBox="0 0 512 512"
+            >
+              <path
+                d="M502.6 278.6c12.5-12.5 12.5-32.8 0-45.3l-160-160c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3L402.7 224 32 224c-17.7 0-32 14.3-32 32s14.3 32 32 32l370.7 0-105.4 105.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0l160-160z"
+                fill="currentColor"
+              />
+            </svg>
+          </button>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`GameJoinPage > does nothing when gameID is missing 1`] = `
+<div>
+  <div
+    class="main"
+  >
+    <div
+      class="header"
+    >
+      <button
+        class="logo"
+      >
+        <img
+          alt="Klurigo"
+          class="icon"
+          src="/src/assets/images/klurigo-icon.svg"
+        />
+        <span
+          class="text"
+        >
+          Klurigo
+        </span>
+      </button>
+      <div
+        class="side"
+      >
+        <a
+          data-discover="true"
+          href="/auth/login"
+        >
+          Login
+        </a>
+        <div
+          class="buttonInputContainer buttonInputKindCallToAction buttonInputSizeSmall"
+        >
+          <button
+            data-testid="test-back-button-button"
+            id="back-button"
+            name="back-button"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              class="svg-inline--fa fa-arrow-left "
+              data-icon="arrow-left"
+              data-prefix="fas"
+              role="img"
+              viewBox="0 0 512 512"
+            >
+              <path
+                d="M9.4 233.4c-12.5 12.5-12.5 32.8 0 45.3l160 160c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3L109.3 288 480 288c17.7 0 32-14.3 32-32s-14.3-32-32-32l-370.7 0 105.4-105.4c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0l-160 160z"
+                fill="currentColor"
+              />
+            </svg>
+            <span>
+              Back
+            </span>
+          </button>
+        </div>
+      </div>
+    </div>
+    <div
+      class="content fullWidth startAlign"
+    >
+      <div
+        class="card kindCallToAction sizeLarge center"
+      >
+        <button
+          type="button"
+        >
+          <svg
+            aria-hidden="true"
+            class="svg-inline--fa fa-xmark "
+            data-icon="xmark"
+            data-prefix="fas"
+            role="img"
+            viewBox="0 0 384 512"
+          >
+            <path
+              d="M55.1 73.4c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3L147.2 256 9.9 393.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0L192.5 301.3 329.9 438.6c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3L237.8 256 375.1 118.6c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0L192.5 210.7 55.1 73.4z"
+              fill="currentColor"
+            />
+          </svg>
+        </button>
+        <div
+          class="content"
+        >
+          <span>
+            Hey quiz champion! Did your brainy adventures happen on
+             
+            <a
+              href="https://quiz.emilhornlund.com"
+            >
+              quiz.emilhornlund.com
+            </a>
+            ? No worries— we can save all your quiz creations and epic game stats! Just pop back to
+             
+            <a
+              href="https://quiz.emilhornlund.com"
+            >
+              quiz.emilhornlund.com
+            </a>
+             one last time, and we’ll magically teleport everything over to
+             
+            <b>
+              <i>
+                klurigo.com
+              </i>
+            </b>
+            . Ready to blast off your data?
+          </span>
+        </div>
+      </div>
+      <div
+        class="main"
+      >
+        <img
+          alt="Users"
+          src="users-icon.svg"
+        />
+      </div>
+      <div
+        class="typography title medium"
+      >
+        Join the game
+      </div>
+      <div
+        class="typography text small"
+      >
+        Pick a nickname and jump in!
+      </div>
+      <form
+        data-testid="join-form"
+        name="join-game-form"
+      >
+        <div
+          class="nicknameTextFieldContainer"
+        >
+          <div
+            class="inputContainer"
+          >
+            <div
+              class="textFieldInputContainer textFieldInputKindPrimary"
+            >
+              <input
+                class="textfield"
+                data-testid="test-default-nickname-textfield-textfield"
+                id="default-nickname-textfield"
+                maxlength="20"
+                minlength="2"
+                name="default-nickname-textfield"
+                placeholder="Nickname"
+                type="text"
+                value="Someone"
+              />
+            </div>
+          </div>
+          <div
+            class="buttonInputContainer buttonInputKindPrimary"
+          >
+            <button
+              data-testid="test-shuffle-nickname-button-button"
+              id="shuffle-nickname-button"
+              name="shuffle-nickname-button"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                class="svg-inline--fa fa-arrows-rotate "
+                data-icon="arrows-rotate"
+                data-prefix="fas"
+                role="img"
+                viewBox="0 0 512 512"
+              >
+                <path
+                  d="M65.9 228.5c13.3-93 93.4-164.5 190.1-164.5 53 0 101 21.5 135.8 56.2 .2 .2 .4 .4 .6 .6l7.6 7.2-47.9 0c-17.7 0-32 14.3-32 32s14.3 32 32 32l128 0c17.7 0 32-14.3 32-32l0-128c0-17.7-14.3-32-32-32s-32 14.3-32 32l0 53.4-11.3-10.7C390.5 28.6 326.5 0 256 0 127 0 20.3 95.4 2.6 219.5 .1 237 12.2 253.2 29.7 255.7s33.7-9.7 36.2-27.1zm443.5 64c2.5-17.5-9.7-33.7-27.1-36.2s-33.7 9.7-36.2 27.1c-13.3 93-93.4 164.5-190.1 164.5-53 0-101-21.5-135.8-56.2-.2-.2-.4-.4-.6-.6l-7.6-7.2 47.9 0c17.7 0 32-14.3 32-32s-14.3-32-32-32L32 320c-8.5 0-16.7 3.4-22.7 9.5S-.1 343.7 0 352.3l1 127c.1 17.7 14.6 31.9 32.3 31.7S65.2 496.4 65 478.7l-.4-51.5 10.7 10.1c46.3 46.1 110.2 74.7 180.7 74.7 129 0 235.7-95.4 253.4-219.5z"
+                  fill="currentColor"
+                />
+              </svg>
+            </button>
+          </div>
+        </div>
+        <div
+          class="buttonInputContainer buttonInputKindCallToAction"
+        >
+          <button
+            data-testid="test-join-button"
+            id="join"
+            name="join"
+            type="submit"
+          >
+            <span>
+              OK, Go!
+            </span>
+            <svg
+              aria-hidden="true"
+              class="svg-inline--fa fa-arrow-right "
+              data-icon="arrow-right"
+              data-prefix="fas"
+              role="img"
+              viewBox="0 0 512 512"
+            >
+              <path
+                d="M502.6 278.6c12.5-12.5 12.5-32.8 0-45.3l-160-160c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3L402.7 224 32 224c-17.7 0-32 14.3-32 32s14.3 32 32 32l370.7 0-105.4 105.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0l160-160z"
+                fill="currentColor"
+              />
+            </svg>
+          </button>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`GameJoinPage > ignores rapid double-submit (only calls joinGame once) 1`] = `
+<div>
+  <div
+    class="main"
+  >
+    <div
+      class="header"
+    >
+      <button
+        class="logo"
+      >
+        <img
+          alt="Klurigo"
+          class="icon"
+          src="/src/assets/images/klurigo-icon.svg"
+        />
+        <span
+          class="text"
+        >
+          Klurigo
+        </span>
+      </button>
+      <div
+        class="side"
+      >
+        <a
+          data-discover="true"
+          href="/auth/login"
+        >
+          Login
+        </a>
+        <div
+          class="buttonInputContainer buttonInputKindCallToAction buttonInputSizeSmall"
+        >
+          <button
+            data-testid="test-back-button-button"
+            id="back-button"
+            name="back-button"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              class="svg-inline--fa fa-arrow-left "
+              data-icon="arrow-left"
+              data-prefix="fas"
+              role="img"
+              viewBox="0 0 512 512"
+            >
+              <path
+                d="M9.4 233.4c-12.5 12.5-12.5 32.8 0 45.3l160 160c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3L109.3 288 480 288c17.7 0 32-14.3 32-32s-14.3-32-32-32l-370.7 0 105.4-105.4c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0l-160 160z"
+                fill="currentColor"
+              />
+            </svg>
+            <span>
+              Back
+            </span>
+          </button>
+        </div>
+      </div>
+    </div>
+    <div
+      class="content fullWidth startAlign"
+    >
+      <div
+        class="card kindCallToAction sizeLarge center"
+      >
+        <button
+          type="button"
+        >
+          <svg
+            aria-hidden="true"
+            class="svg-inline--fa fa-xmark "
+            data-icon="xmark"
+            data-prefix="fas"
+            role="img"
+            viewBox="0 0 384 512"
+          >
+            <path
+              d="M55.1 73.4c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3L147.2 256 9.9 393.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0L192.5 301.3 329.9 438.6c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3L237.8 256 375.1 118.6c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0L192.5 210.7 55.1 73.4z"
+              fill="currentColor"
+            />
+          </svg>
+        </button>
+        <div
+          class="content"
+        >
+          <span>
+            Hey quiz champion! Did your brainy adventures happen on
+             
+            <a
+              href="https://quiz.emilhornlund.com"
+            >
+              quiz.emilhornlund.com
+            </a>
+            ? No worries— we can save all your quiz creations and epic game stats! Just pop back to
+             
+            <a
+              href="https://quiz.emilhornlund.com"
+            >
+              quiz.emilhornlund.com
+            </a>
+             one last time, and we’ll magically teleport everything over to
+             
+            <b>
+              <i>
+                klurigo.com
+              </i>
+            </b>
+            . Ready to blast off your data?
+          </span>
+        </div>
+      </div>
+      <div
+        class="main"
+      >
+        <img
+          alt="Users"
+          src="users-icon.svg"
+        />
+      </div>
+      <div
+        class="typography title medium"
+      >
+        Join the game
+      </div>
+      <div
+        class="typography text small"
+      >
+        Pick a nickname and jump in!
+      </div>
+      <form
+        data-testid="join-form"
+        name="join-game-form"
+      >
+        <div
+          class="nicknameTextFieldContainer"
+        >
+          <div
+            class="inputContainer"
+          >
+            <div
+              class="textFieldInputContainer textFieldInputKindPrimary"
+            >
+              <input
+                class="textfield"
+                data-testid="test-default-nickname-textfield-textfield"
+                id="default-nickname-textfield"
+                maxlength="20"
+                minlength="2"
+                name="default-nickname-textfield"
+                placeholder="Nickname"
+                type="text"
+                value="Speedy"
+              />
+            </div>
+          </div>
+          <div
+            class="buttonInputContainer buttonInputKindPrimary"
+          >
+            <button
+              data-testid="test-shuffle-nickname-button-button"
+              id="shuffle-nickname-button"
+              name="shuffle-nickname-button"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                class="svg-inline--fa fa-arrows-rotate "
+                data-icon="arrows-rotate"
+                data-prefix="fas"
+                role="img"
+                viewBox="0 0 512 512"
+              >
+                <path
+                  d="M65.9 228.5c13.3-93 93.4-164.5 190.1-164.5 53 0 101 21.5 135.8 56.2 .2 .2 .4 .4 .6 .6l7.6 7.2-47.9 0c-17.7 0-32 14.3-32 32s14.3 32 32 32l128 0c17.7 0 32-14.3 32-32l0-128c0-17.7-14.3-32-32-32s-32 14.3-32 32l0 53.4-11.3-10.7C390.5 28.6 326.5 0 256 0 127 0 20.3 95.4 2.6 219.5 .1 237 12.2 253.2 29.7 255.7s33.7-9.7 36.2-27.1zm443.5 64c2.5-17.5-9.7-33.7-27.1-36.2s-33.7 9.7-36.2 27.1c-13.3 93-93.4 164.5-190.1 164.5-53 0-101-21.5-135.8-56.2-.2-.2-.4-.4-.6-.6l-7.6-7.2 47.9 0c17.7 0 32-14.3 32-32s-14.3-32-32-32L32 320c-8.5 0-16.7 3.4-22.7 9.5S-.1 343.7 0 352.3l1 127c.1 17.7 14.6 31.9 32.3 31.7S65.2 496.4 65 478.7l-.4-51.5 10.7 10.1c46.3 46.1 110.2 74.7 180.7 74.7 129 0 235.7-95.4 253.4-219.5z"
+                  fill="currentColor"
+                />
+              </svg>
+            </button>
+          </div>
+        </div>
+        <div
+          class="buttonInputContainer buttonInputKindCallToAction"
+        >
+          <button
+            data-testid="test-join-button"
+            id="join"
+            name="join"
+            type="submit"
+          >
+            <span>
+              OK, Go!
+            </span>
+            <svg
+              aria-hidden="true"
+              class="svg-inline--fa fa-arrow-right "
+              data-icon="arrow-right"
+              data-prefix="fas"
+              role="img"
+              viewBox="0 0 512 512"
+            >
+              <path
+                d="M502.6 278.6c12.5-12.5 12.5-32.8 0-45.3l-160-160c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3L402.7 224 32 224c-17.7 0-32 14.3-32 32s14.3 32 32 32l370.7 0-105.4 105.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0l160-160z"
+                fill="currentColor"
+              />
+            </svg>
+          </button>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`GameJoinPage > join button stays disabled until nickname is valid 1`] = `
+<div>
+  <div
+    class="main"
+  >
+    <div
+      class="header"
+    >
+      <button
+        class="logo"
+      >
+        <img
+          alt="Klurigo"
+          class="icon"
+          src="/src/assets/images/klurigo-icon.svg"
+        />
+        <span
+          class="text"
+        >
+          Klurigo
+        </span>
+      </button>
+      <div
+        class="side"
+      >
+        <a
+          data-discover="true"
+          href="/auth/login"
+        >
+          Login
+        </a>
+        <div
+          class="buttonInputContainer buttonInputKindCallToAction buttonInputSizeSmall"
+        >
+          <button
+            data-testid="test-back-button-button"
+            id="back-button"
+            name="back-button"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              class="svg-inline--fa fa-arrow-left "
+              data-icon="arrow-left"
+              data-prefix="fas"
+              role="img"
+              viewBox="0 0 512 512"
+            >
+              <path
+                d="M9.4 233.4c-12.5 12.5-12.5 32.8 0 45.3l160 160c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3L109.3 288 480 288c17.7 0 32-14.3 32-32s-14.3-32-32-32l-370.7 0 105.4-105.4c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0l-160 160z"
+                fill="currentColor"
+              />
+            </svg>
+            <span>
+              Back
+            </span>
+          </button>
+        </div>
+      </div>
+    </div>
+    <div
+      class="content fullWidth startAlign"
+    >
+      <div
+        class="card kindCallToAction sizeLarge center"
+      >
+        <button
+          type="button"
+        >
+          <svg
+            aria-hidden="true"
+            class="svg-inline--fa fa-xmark "
+            data-icon="xmark"
+            data-prefix="fas"
+            role="img"
+            viewBox="0 0 384 512"
+          >
+            <path
+              d="M55.1 73.4c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3L147.2 256 9.9 393.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0L192.5 301.3 329.9 438.6c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3L237.8 256 375.1 118.6c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0L192.5 210.7 55.1 73.4z"
+              fill="currentColor"
+            />
+          </svg>
+        </button>
+        <div
+          class="content"
+        >
+          <span>
+            Hey quiz champion! Did your brainy adventures happen on
+             
+            <a
+              href="https://quiz.emilhornlund.com"
+            >
+              quiz.emilhornlund.com
+            </a>
+            ? No worries— we can save all your quiz creations and epic game stats! Just pop back to
+             
+            <a
+              href="https://quiz.emilhornlund.com"
+            >
+              quiz.emilhornlund.com
+            </a>
+             one last time, and we’ll magically teleport everything over to
+             
+            <b>
+              <i>
+                klurigo.com
+              </i>
+            </b>
+            . Ready to blast off your data?
+          </span>
+        </div>
+      </div>
+      <div
+        class="main"
+      >
+        <img
+          alt="Users"
+          src="users-icon.svg"
+        />
+      </div>
+      <div
+        class="typography title medium"
+      >
+        Join the game
+      </div>
+      <div
+        class="typography text small"
+      >
+        Pick a nickname and jump in!
+      </div>
+      <form
+        data-testid="join-form"
+        name="join-game-form"
+      >
+        <div
+          class="nicknameTextFieldContainer"
+        >
+          <div
+            class="inputContainer"
+          >
+            <div
+              class="textFieldInputContainer textFieldInputKindPrimary"
+            >
+              <input
+                class="textfield"
+                data-testid="test-default-nickname-textfield-textfield"
+                id="default-nickname-textfield"
+                maxlength="20"
+                minlength="2"
+                name="default-nickname-textfield"
+                placeholder="Nickname"
+                type="text"
+                value="Emil"
+              />
+            </div>
+          </div>
+          <div
+            class="buttonInputContainer buttonInputKindPrimary"
+          >
+            <button
+              data-testid="test-shuffle-nickname-button-button"
+              id="shuffle-nickname-button"
+              name="shuffle-nickname-button"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                class="svg-inline--fa fa-arrows-rotate "
+                data-icon="arrows-rotate"
+                data-prefix="fas"
+                role="img"
+                viewBox="0 0 512 512"
+              >
+                <path
+                  d="M65.9 228.5c13.3-93 93.4-164.5 190.1-164.5 53 0 101 21.5 135.8 56.2 .2 .2 .4 .4 .6 .6l7.6 7.2-47.9 0c-17.7 0-32 14.3-32 32s14.3 32 32 32l128 0c17.7 0 32-14.3 32-32l0-128c0-17.7-14.3-32-32-32s-32 14.3-32 32l0 53.4-11.3-10.7C390.5 28.6 326.5 0 256 0 127 0 20.3 95.4 2.6 219.5 .1 237 12.2 253.2 29.7 255.7s33.7-9.7 36.2-27.1zm443.5 64c2.5-17.5-9.7-33.7-27.1-36.2s-33.7 9.7-36.2 27.1c-13.3 93-93.4 164.5-190.1 164.5-53 0-101-21.5-135.8-56.2-.2-.2-.4-.4-.6-.6l-7.6-7.2 47.9 0c17.7 0 32-14.3 32-32s-14.3-32-32-32L32 320c-8.5 0-16.7 3.4-22.7 9.5S-.1 343.7 0 352.3l1 127c.1 17.7 14.6 31.9 32.3 31.7S65.2 496.4 65 478.7l-.4-51.5 10.7 10.1c46.3 46.1 110.2 74.7 180.7 74.7 129 0 235.7-95.4 253.4-219.5z"
+                  fill="currentColor"
+                />
+              </svg>
+            </button>
+          </div>
+        </div>
+        <div
+          class="buttonInputContainer buttonInputKindCallToAction"
+        >
+          <button
+            data-testid="test-join-button"
+            id="join"
+            name="join"
+            type="submit"
+          >
+            <span>
+              OK, Go!
+            </span>
+            <svg
+              aria-hidden="true"
+              class="svg-inline--fa fa-arrow-right "
+              data-icon="arrow-right"
+              data-prefix="fas"
+              role="img"
+              viewBox="0 0 512 512"
+            >
+              <path
+                d="M502.6 278.6c12.5-12.5 12.5-32.8 0-45.3l-160-160c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3L402.7 224 32 224c-17.7 0-32 14.3-32 32s14.3 32 32 32l370.7 0-105.4 105.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0l160-160z"
+                fill="currentColor"
+              />
+            </svg>
+          </button>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`GameJoinPage > navigates back when clicking the back button 1`] = `
+<div>
+  <div
+    class="main"
+  >
+    <div
+      class="header"
+    >
+      <button
+        class="logo"
+      >
+        <img
+          alt="Klurigo"
+          class="icon"
+          src="/src/assets/images/klurigo-icon.svg"
+        />
+        <span
+          class="text"
+        >
+          Klurigo
+        </span>
+      </button>
+      <div
+        class="side"
+      >
+        <a
+          data-discover="true"
+          href="/auth/login"
+        >
+          Login
+        </a>
+        <div
+          class="buttonInputContainer buttonInputKindCallToAction buttonInputSizeSmall"
+        >
+          <button
+            data-testid="test-back-button-button"
+            id="back-button"
+            name="back-button"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              class="svg-inline--fa fa-arrow-left "
+              data-icon="arrow-left"
+              data-prefix="fas"
+              role="img"
+              viewBox="0 0 512 512"
+            >
+              <path
+                d="M9.4 233.4c-12.5 12.5-12.5 32.8 0 45.3l160 160c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3L109.3 288 480 288c17.7 0 32-14.3 32-32s-14.3-32-32-32l-370.7 0 105.4-105.4c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0l-160 160z"
+                fill="currentColor"
+              />
+            </svg>
+            <span>
+              Back
+            </span>
+          </button>
+        </div>
+      </div>
+    </div>
+    <div
+      class="content fullWidth startAlign"
+    >
+      <div
+        class="card kindCallToAction sizeLarge center"
+      >
+        <button
+          type="button"
+        >
+          <svg
+            aria-hidden="true"
+            class="svg-inline--fa fa-xmark "
+            data-icon="xmark"
+            data-prefix="fas"
+            role="img"
+            viewBox="0 0 384 512"
+          >
+            <path
+              d="M55.1 73.4c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3L147.2 256 9.9 393.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0L192.5 301.3 329.9 438.6c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3L237.8 256 375.1 118.6c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0L192.5 210.7 55.1 73.4z"
+              fill="currentColor"
+            />
+          </svg>
+        </button>
+        <div
+          class="content"
+        >
+          <span>
+            Hey quiz champion! Did your brainy adventures happen on
+             
+            <a
+              href="https://quiz.emilhornlund.com"
+            >
+              quiz.emilhornlund.com
+            </a>
+            ? No worries— we can save all your quiz creations and epic game stats! Just pop back to
+             
+            <a
+              href="https://quiz.emilhornlund.com"
+            >
+              quiz.emilhornlund.com
+            </a>
+             one last time, and we’ll magically teleport everything over to
+             
+            <b>
+              <i>
+                klurigo.com
+              </i>
+            </b>
+            . Ready to blast off your data?
+          </span>
+        </div>
+      </div>
+      <div
+        class="main"
+      >
+        <img
+          alt="Users"
+          src="users-icon.svg"
+        />
+      </div>
+      <div
+        class="typography title medium"
+      >
+        Join the game
+      </div>
+      <div
+        class="typography text small"
+      >
+        Pick a nickname and jump in!
+      </div>
+      <form
+        data-testid="join-form"
+        name="join-game-form"
+      >
+        <div
+          class="nicknameTextFieldContainer"
+        >
+          <div
+            class="inputContainer"
+          >
+            <div
+              class="textFieldInputContainer textFieldInputKindPrimary"
+            >
+              <input
+                class="textfield"
+                data-testid="test-default-nickname-textfield-textfield"
+                id="default-nickname-textfield"
+                maxlength="20"
+                minlength="2"
+                name="default-nickname-textfield"
+                placeholder="Nickname"
+                type="text"
+                value=""
+              />
+            </div>
+          </div>
+          <div
+            class="buttonInputContainer buttonInputKindPrimary"
+          >
+            <button
+              data-testid="test-shuffle-nickname-button-button"
+              id="shuffle-nickname-button"
+              name="shuffle-nickname-button"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                class="svg-inline--fa fa-arrows-rotate "
+                data-icon="arrows-rotate"
+                data-prefix="fas"
+                role="img"
+                viewBox="0 0 512 512"
+              >
+                <path
+                  d="M65.9 228.5c13.3-93 93.4-164.5 190.1-164.5 53 0 101 21.5 135.8 56.2 .2 .2 .4 .4 .6 .6l7.6 7.2-47.9 0c-17.7 0-32 14.3-32 32s14.3 32 32 32l128 0c17.7 0 32-14.3 32-32l0-128c0-17.7-14.3-32-32-32s-32 14.3-32 32l0 53.4-11.3-10.7C390.5 28.6 326.5 0 256 0 127 0 20.3 95.4 2.6 219.5 .1 237 12.2 253.2 29.7 255.7s33.7-9.7 36.2-27.1zm443.5 64c2.5-17.5-9.7-33.7-27.1-36.2s-33.7 9.7-36.2 27.1c-13.3 93-93.4 164.5-190.1 164.5-53 0-101-21.5-135.8-56.2-.2-.2-.4-.4-.6-.6l-7.6-7.2 47.9 0c17.7 0 32-14.3 32-32s-14.3-32-32-32L32 320c-8.5 0-16.7 3.4-22.7 9.5S-.1 343.7 0 352.3l1 127c.1 17.7 14.6 31.9 32.3 31.7S65.2 496.4 65 478.7l-.4-51.5 10.7 10.1c46.3 46.1 110.2 74.7 180.7 74.7 129 0 235.7-95.4 253.4-219.5z"
+                  fill="currentColor"
+                />
+              </svg>
+            </button>
+          </div>
+        </div>
+        <div
+          class="buttonInputContainer buttonInputKindCallToAction"
+        >
+          <button
+            data-testid="test-join-button"
+            disabled=""
+            id="join"
+            name="join"
+            type="submit"
+          >
+            <span>
+              OK, Go!
+            </span>
+            <svg
+              aria-hidden="true"
+              class="svg-inline--fa fa-arrow-right "
+              data-icon="arrow-right"
+              data-prefix="fas"
+              role="img"
+              viewBox="0 0 512 512"
+            >
+              <path
+                d="M502.6 278.6c12.5-12.5 12.5-32.8 0-45.3l-160-160c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3L402.7 224 32 224c-17.7 0-32 14.3-32 32s14.3 32 32 32l370.7 0-105.4 105.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0l160-160z"
+                fill="currentColor"
+              />
+            </svg>
+          </button>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`GameJoinPage > prefills nickname from user default but keeps Join disabled until validated 1`] = `
+<div>
+  <div
+    class="main"
+  >
+    <div
+      class="header"
+    >
+      <button
+        class="logo"
+      >
+        <img
+          alt="Klurigo"
+          class="icon"
+          src="/src/assets/images/klurigo-icon.svg"
+        />
+        <span
+          class="text"
+        >
+          Klurigo
+        </span>
+      </button>
+      <div
+        class="side"
+      >
+        <a
+          data-discover="true"
+          href="/auth/login"
+        >
+          Login
+        </a>
+        <div
+          class="buttonInputContainer buttonInputKindCallToAction buttonInputSizeSmall"
+        >
+          <button
+            data-testid="test-back-button-button"
+            id="back-button"
+            name="back-button"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              class="svg-inline--fa fa-arrow-left "
+              data-icon="arrow-left"
+              data-prefix="fas"
+              role="img"
+              viewBox="0 0 512 512"
+            >
+              <path
+                d="M9.4 233.4c-12.5 12.5-12.5 32.8 0 45.3l160 160c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3L109.3 288 480 288c17.7 0 32-14.3 32-32s-14.3-32-32-32l-370.7 0 105.4-105.4c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0l-160 160z"
+                fill="currentColor"
+              />
+            </svg>
+            <span>
+              Back
+            </span>
+          </button>
+        </div>
+      </div>
+    </div>
+    <div
+      class="content fullWidth startAlign"
+    >
+      <div
+        class="card kindCallToAction sizeLarge center"
+      >
+        <button
+          type="button"
+        >
+          <svg
+            aria-hidden="true"
+            class="svg-inline--fa fa-xmark "
+            data-icon="xmark"
+            data-prefix="fas"
+            role="img"
+            viewBox="0 0 384 512"
+          >
+            <path
+              d="M55.1 73.4c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3L147.2 256 9.9 393.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0L192.5 301.3 329.9 438.6c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3L237.8 256 375.1 118.6c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0L192.5 210.7 55.1 73.4z"
+              fill="currentColor"
+            />
+          </svg>
+        </button>
+        <div
+          class="content"
+        >
+          <span>
+            Hey quiz champion! Did your brainy adventures happen on
+             
+            <a
+              href="https://quiz.emilhornlund.com"
+            >
+              quiz.emilhornlund.com
+            </a>
+            ? No worries— we can save all your quiz creations and epic game stats! Just pop back to
+             
+            <a
+              href="https://quiz.emilhornlund.com"
+            >
+              quiz.emilhornlund.com
+            </a>
+             one last time, and we’ll magically teleport everything over to
+             
+            <b>
+              <i>
+                klurigo.com
+              </i>
+            </b>
+            . Ready to blast off your data?
+          </span>
+        </div>
+      </div>
+      <div
+        class="main"
+      >
+        <img
+          alt="Users"
+          src="users-icon.svg"
+        />
+      </div>
+      <div
+        class="typography title medium"
+      >
+        Join the game
+      </div>
+      <div
+        class="typography text small"
+      >
+        Pick a nickname and jump in!
+      </div>
+      <form
+        data-testid="join-form"
+        name="join-game-form"
+      >
+        <div
+          class="nicknameTextFieldContainer"
+        >
+          <div
+            class="inputContainer"
+          >
+            <div
+              class="textFieldInputContainer textFieldInputKindPrimary"
+            >
+              <input
+                class="textfield"
+                data-testid="test-default-nickname-textfield-textfield"
+                id="default-nickname-textfield"
+                maxlength="20"
+                minlength="2"
+                name="default-nickname-textfield"
+                placeholder="Nickname"
+                type="text"
+                value="PreFilledNick!"
+              />
+            </div>
+          </div>
+          <div
+            class="buttonInputContainer buttonInputKindPrimary"
+          >
+            <button
+              data-testid="test-shuffle-nickname-button-button"
+              id="shuffle-nickname-button"
+              name="shuffle-nickname-button"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                class="svg-inline--fa fa-arrows-rotate "
+                data-icon="arrows-rotate"
+                data-prefix="fas"
+                role="img"
+                viewBox="0 0 512 512"
+              >
+                <path
+                  d="M65.9 228.5c13.3-93 93.4-164.5 190.1-164.5 53 0 101 21.5 135.8 56.2 .2 .2 .4 .4 .6 .6l7.6 7.2-47.9 0c-17.7 0-32 14.3-32 32s14.3 32 32 32l128 0c17.7 0 32-14.3 32-32l0-128c0-17.7-14.3-32-32-32s-32 14.3-32 32l0 53.4-11.3-10.7C390.5 28.6 326.5 0 256 0 127 0 20.3 95.4 2.6 219.5 .1 237 12.2 253.2 29.7 255.7s33.7-9.7 36.2-27.1zm443.5 64c2.5-17.5-9.7-33.7-27.1-36.2s-33.7 9.7-36.2 27.1c-13.3 93-93.4 164.5-190.1 164.5-53 0-101-21.5-135.8-56.2-.2-.2-.4-.4-.6-.6l-7.6-7.2 47.9 0c17.7 0 32-14.3 32-32s-14.3-32-32-32L32 320c-8.5 0-16.7 3.4-22.7 9.5S-.1 343.7 0 352.3l1 127c.1 17.7 14.6 31.9 32.3 31.7S65.2 496.4 65 478.7l-.4-51.5 10.7 10.1c46.3 46.1 110.2 74.7 180.7 74.7 129 0 235.7-95.4 253.4-219.5z"
+                  fill="currentColor"
+                />
+              </svg>
+            </button>
+          </div>
+        </div>
+        <div
+          class="buttonInputContainer buttonInputKindCallToAction"
+        >
+          <button
+            data-testid="test-join-button"
+            disabled=""
+            id="join"
+            name="join"
+            type="submit"
+          >
+            <span>
+              OK, Go!
+            </span>
+            <svg
+              aria-hidden="true"
+              class="svg-inline--fa fa-arrow-right "
+              data-icon="arrow-right"
+              data-prefix="fas"
+              role="img"
+              viewBox="0 0 512 512"
+            >
+              <path
+                d="M502.6 278.6c12.5-12.5 12.5-32.8 0-45.3l-160-160c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3L402.7 224 32 224c-17.7 0-32 14.3-32 32s14.3 32 32 32l370.7 0-105.4 105.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0l160-160z"
+                fill="currentColor"
+              />
+            </svg>
+          </button>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`GameJoinPage > renders title and message 1`] = `
+<div>
+  <div
+    class="main"
+  >
+    <div
+      class="header"
+    >
+      <button
+        class="logo"
+      >
+        <img
+          alt="Klurigo"
+          class="icon"
+          src="/src/assets/images/klurigo-icon.svg"
+        />
+        <span
+          class="text"
+        >
+          Klurigo
+        </span>
+      </button>
+      <div
+        class="side"
+      >
+        <a
+          data-discover="true"
+          href="/auth/login"
+        >
+          Login
+        </a>
+        <div
+          class="buttonInputContainer buttonInputKindCallToAction buttonInputSizeSmall"
+        >
+          <button
+            data-testid="test-back-button-button"
+            id="back-button"
+            name="back-button"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              class="svg-inline--fa fa-arrow-left "
+              data-icon="arrow-left"
+              data-prefix="fas"
+              role="img"
+              viewBox="0 0 512 512"
+            >
+              <path
+                d="M9.4 233.4c-12.5 12.5-12.5 32.8 0 45.3l160 160c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3L109.3 288 480 288c17.7 0 32-14.3 32-32s-14.3-32-32-32l-370.7 0 105.4-105.4c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0l-160 160z"
+                fill="currentColor"
+              />
+            </svg>
+            <span>
+              Back
+            </span>
+          </button>
+        </div>
+      </div>
+    </div>
+    <div
+      class="content fullWidth startAlign"
+    >
+      <div
+        class="card kindCallToAction sizeLarge center"
+      >
+        <button
+          type="button"
+        >
+          <svg
+            aria-hidden="true"
+            class="svg-inline--fa fa-xmark "
+            data-icon="xmark"
+            data-prefix="fas"
+            role="img"
+            viewBox="0 0 384 512"
+          >
+            <path
+              d="M55.1 73.4c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3L147.2 256 9.9 393.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0L192.5 301.3 329.9 438.6c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3L237.8 256 375.1 118.6c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0L192.5 210.7 55.1 73.4z"
+              fill="currentColor"
+            />
+          </svg>
+        </button>
+        <div
+          class="content"
+        >
+          <span>
+            Hey quiz champion! Did your brainy adventures happen on
+             
+            <a
+              href="https://quiz.emilhornlund.com"
+            >
+              quiz.emilhornlund.com
+            </a>
+            ? No worries— we can save all your quiz creations and epic game stats! Just pop back to
+             
+            <a
+              href="https://quiz.emilhornlund.com"
+            >
+              quiz.emilhornlund.com
+            </a>
+             one last time, and we’ll magically teleport everything over to
+             
+            <b>
+              <i>
+                klurigo.com
+              </i>
+            </b>
+            . Ready to blast off your data?
+          </span>
+        </div>
+      </div>
+      <div
+        class="main"
+      >
+        <img
+          alt="Users"
+          src="users-icon.svg"
+        />
+      </div>
+      <div
+        class="typography title medium"
+      >
+        Join the game
+      </div>
+      <div
+        class="typography text small"
+      >
+        Pick a nickname and jump in!
+      </div>
+      <form
+        data-testid="join-form"
+        name="join-game-form"
+      >
+        <div
+          class="nicknameTextFieldContainer"
+        >
+          <div
+            class="inputContainer"
+          >
+            <div
+              class="textFieldInputContainer textFieldInputKindPrimary"
+            >
+              <input
+                class="textfield"
+                data-testid="test-default-nickname-textfield-textfield"
+                id="default-nickname-textfield"
+                maxlength="20"
+                minlength="2"
+                name="default-nickname-textfield"
+                placeholder="Nickname"
+                type="text"
+                value=""
+              />
+            </div>
+          </div>
+          <div
+            class="buttonInputContainer buttonInputKindPrimary"
+          >
+            <button
+              data-testid="test-shuffle-nickname-button-button"
+              id="shuffle-nickname-button"
+              name="shuffle-nickname-button"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                class="svg-inline--fa fa-arrows-rotate "
+                data-icon="arrows-rotate"
+                data-prefix="fas"
+                role="img"
+                viewBox="0 0 512 512"
+              >
+                <path
+                  d="M65.9 228.5c13.3-93 93.4-164.5 190.1-164.5 53 0 101 21.5 135.8 56.2 .2 .2 .4 .4 .6 .6l7.6 7.2-47.9 0c-17.7 0-32 14.3-32 32s14.3 32 32 32l128 0c17.7 0 32-14.3 32-32l0-128c0-17.7-14.3-32-32-32s-32 14.3-32 32l0 53.4-11.3-10.7C390.5 28.6 326.5 0 256 0 127 0 20.3 95.4 2.6 219.5 .1 237 12.2 253.2 29.7 255.7s33.7-9.7 36.2-27.1zm443.5 64c2.5-17.5-9.7-33.7-27.1-36.2s-33.7 9.7-36.2 27.1c-13.3 93-93.4 164.5-190.1 164.5-53 0-101-21.5-135.8-56.2-.2-.2-.4-.4-.6-.6l-7.6-7.2 47.9 0c17.7 0 32-14.3 32-32s-14.3-32-32-32L32 320c-8.5 0-16.7 3.4-22.7 9.5S-.1 343.7 0 352.3l1 127c.1 17.7 14.6 31.9 32.3 31.7S65.2 496.4 65 478.7l-.4-51.5 10.7 10.1c46.3 46.1 110.2 74.7 180.7 74.7 129 0 235.7-95.4 253.4-219.5z"
+                  fill="currentColor"
+                />
+              </svg>
+            </button>
+          </div>
+        </div>
+        <div
+          class="buttonInputContainer buttonInputKindCallToAction"
+        >
+          <button
+            data-testid="test-join-button"
+            disabled=""
+            id="join"
+            name="join"
+            type="submit"
+          >
+            <span>
+              OK, Go!
+            </span>
+            <svg
+              aria-hidden="true"
+              class="svg-inline--fa fa-arrow-right "
+              data-icon="arrow-right"
+              data-prefix="fas"
+              role="img"
+              viewBox="0 0 512 512"
+            >
+              <path
+                d="M502.6 278.6c12.5-12.5 12.5-32.8 0-45.3l-160-160c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3L402.7 224 32 224c-17.7 0-32 14.3-32 32s14.3 32 32 32l370.7 0-105.4 105.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0l160-160z"
+                fill="currentColor"
+              />
+            </svg>
+          </button>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`GameJoinPage > starts with empty nickname when user has no default, keeping Join disabled 1`] = `
+<div>
+  <div
+    class="main"
+  >
+    <div
+      class="header"
+    >
+      <button
+        class="logo"
+      >
+        <img
+          alt="Klurigo"
+          class="icon"
+          src="/src/assets/images/klurigo-icon.svg"
+        />
+        <span
+          class="text"
+        >
+          Klurigo
+        </span>
+      </button>
+      <div
+        class="side"
+      >
+        <a
+          data-discover="true"
+          href="/auth/login"
+        >
+          Login
+        </a>
+        <div
+          class="buttonInputContainer buttonInputKindCallToAction buttonInputSizeSmall"
+        >
+          <button
+            data-testid="test-back-button-button"
+            id="back-button"
+            name="back-button"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              class="svg-inline--fa fa-arrow-left "
+              data-icon="arrow-left"
+              data-prefix="fas"
+              role="img"
+              viewBox="0 0 512 512"
+            >
+              <path
+                d="M9.4 233.4c-12.5 12.5-12.5 32.8 0 45.3l160 160c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3L109.3 288 480 288c17.7 0 32-14.3 32-32s-14.3-32-32-32l-370.7 0 105.4-105.4c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0l-160 160z"
+                fill="currentColor"
+              />
+            </svg>
+            <span>
+              Back
+            </span>
+          </button>
+        </div>
+      </div>
+    </div>
+    <div
+      class="content fullWidth startAlign"
+    >
+      <div
+        class="card kindCallToAction sizeLarge center"
+      >
+        <button
+          type="button"
+        >
+          <svg
+            aria-hidden="true"
+            class="svg-inline--fa fa-xmark "
+            data-icon="xmark"
+            data-prefix="fas"
+            role="img"
+            viewBox="0 0 384 512"
+          >
+            <path
+              d="M55.1 73.4c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3L147.2 256 9.9 393.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0L192.5 301.3 329.9 438.6c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3L237.8 256 375.1 118.6c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0L192.5 210.7 55.1 73.4z"
+              fill="currentColor"
+            />
+          </svg>
+        </button>
+        <div
+          class="content"
+        >
+          <span>
+            Hey quiz champion! Did your brainy adventures happen on
+             
+            <a
+              href="https://quiz.emilhornlund.com"
+            >
+              quiz.emilhornlund.com
+            </a>
+            ? No worries— we can save all your quiz creations and epic game stats! Just pop back to
+             
+            <a
+              href="https://quiz.emilhornlund.com"
+            >
+              quiz.emilhornlund.com
+            </a>
+             one last time, and we’ll magically teleport everything over to
+             
+            <b>
+              <i>
+                klurigo.com
+              </i>
+            </b>
+            . Ready to blast off your data?
+          </span>
+        </div>
+      </div>
+      <div
+        class="main"
+      >
+        <img
+          alt="Users"
+          src="users-icon.svg"
+        />
+      </div>
+      <div
+        class="typography title medium"
+      >
+        Join the game
+      </div>
+      <div
+        class="typography text small"
+      >
+        Pick a nickname and jump in!
+      </div>
+      <form
+        data-testid="join-form"
+        name="join-game-form"
+      >
+        <div
+          class="nicknameTextFieldContainer"
+        >
+          <div
+            class="inputContainer"
+          >
+            <div
+              class="textFieldInputContainer textFieldInputKindPrimary"
+            >
+              <input
+                class="textfield"
+                data-testid="test-default-nickname-textfield-textfield"
+                id="default-nickname-textfield"
+                maxlength="20"
+                minlength="2"
+                name="default-nickname-textfield"
+                placeholder="Nickname"
+                type="text"
+                value=""
+              />
+            </div>
+          </div>
+          <div
+            class="buttonInputContainer buttonInputKindPrimary"
+          >
+            <button
+              data-testid="test-shuffle-nickname-button-button"
+              id="shuffle-nickname-button"
+              name="shuffle-nickname-button"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                class="svg-inline--fa fa-arrows-rotate "
+                data-icon="arrows-rotate"
+                data-prefix="fas"
+                role="img"
+                viewBox="0 0 512 512"
+              >
+                <path
+                  d="M65.9 228.5c13.3-93 93.4-164.5 190.1-164.5 53 0 101 21.5 135.8 56.2 .2 .2 .4 .4 .6 .6l7.6 7.2-47.9 0c-17.7 0-32 14.3-32 32s14.3 32 32 32l128 0c17.7 0 32-14.3 32-32l0-128c0-17.7-14.3-32-32-32s-32 14.3-32 32l0 53.4-11.3-10.7C390.5 28.6 326.5 0 256 0 127 0 20.3 95.4 2.6 219.5 .1 237 12.2 253.2 29.7 255.7s33.7-9.7 36.2-27.1zm443.5 64c2.5-17.5-9.7-33.7-27.1-36.2s-33.7 9.7-36.2 27.1c-13.3 93-93.4 164.5-190.1 164.5-53 0-101-21.5-135.8-56.2-.2-.2-.4-.4-.6-.6l-7.6-7.2 47.9 0c17.7 0 32-14.3 32-32s-14.3-32-32-32L32 320c-8.5 0-16.7 3.4-22.7 9.5S-.1 343.7 0 352.3l1 127c.1 17.7 14.6 31.9 32.3 31.7S65.2 496.4 65 478.7l-.4-51.5 10.7 10.1c46.3 46.1 110.2 74.7 180.7 74.7 129 0 235.7-95.4 253.4-219.5z"
+                  fill="currentColor"
+                />
+              </svg>
+            </button>
+          </div>
+        </div>
+        <div
+          class="buttonInputContainer buttonInputKindCallToAction"
+        >
+          <button
+            data-testid="test-join-button"
+            disabled=""
+            id="join"
+            name="join"
+            type="submit"
+          >
+            <span>
+              OK, Go!
+            </span>
+            <svg
+              aria-hidden="true"
+              class="svg-inline--fa fa-arrow-right "
+              data-icon="arrow-right"
+              data-prefix="fas"
+              role="img"
+              viewBox="0 0 512 512"
+            >
+              <path
+                d="M502.6 278.6c12.5-12.5 12.5-32.8 0-45.3l-160-160c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3L402.7 224 32 224c-17.7 0-32 14.3-32 32s14.3 32 32 32l370.7 0-105.4 105.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0l160-160z"
+                fill="currentColor"
+              />
+            </svg>
+          </button>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`GameJoinPage > submits when the form is submitted (Enter key equivalent) 1`] = `
+<div>
+  <div
+    class="main"
+  >
+    <div
+      class="header"
+    >
+      <button
+        class="logo"
+      >
+        <img
+          alt="Klurigo"
+          class="icon"
+          src="/src/assets/images/klurigo-icon.svg"
+        />
+        <span
+          class="text"
+        >
+          Klurigo
+        </span>
+      </button>
+      <div
+        class="side"
+      >
+        <a
+          data-discover="true"
+          href="/auth/login"
+        >
+          Login
+        </a>
+        <div
+          class="buttonInputContainer buttonInputKindCallToAction buttonInputSizeSmall"
+        >
+          <button
+            data-testid="test-back-button-button"
+            id="back-button"
+            name="back-button"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              class="svg-inline--fa fa-arrow-left "
+              data-icon="arrow-left"
+              data-prefix="fas"
+              role="img"
+              viewBox="0 0 512 512"
+            >
+              <path
+                d="M9.4 233.4c-12.5 12.5-12.5 32.8 0 45.3l160 160c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3L109.3 288 480 288c17.7 0 32-14.3 32-32s-14.3-32-32-32l-370.7 0 105.4-105.4c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0l-160 160z"
+                fill="currentColor"
+              />
+            </svg>
+            <span>
+              Back
+            </span>
+          </button>
+        </div>
+      </div>
+    </div>
+    <div
+      class="content fullWidth startAlign"
+    >
+      <div
+        class="card kindCallToAction sizeLarge center"
+      >
+        <button
+          type="button"
+        >
+          <svg
+            aria-hidden="true"
+            class="svg-inline--fa fa-xmark "
+            data-icon="xmark"
+            data-prefix="fas"
+            role="img"
+            viewBox="0 0 384 512"
+          >
+            <path
+              d="M55.1 73.4c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3L147.2 256 9.9 393.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0L192.5 301.3 329.9 438.6c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3L237.8 256 375.1 118.6c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0L192.5 210.7 55.1 73.4z"
+              fill="currentColor"
+            />
+          </svg>
+        </button>
+        <div
+          class="content"
+        >
+          <span>
+            Hey quiz champion! Did your brainy adventures happen on
+             
+            <a
+              href="https://quiz.emilhornlund.com"
+            >
+              quiz.emilhornlund.com
+            </a>
+            ? No worries— we can save all your quiz creations and epic game stats! Just pop back to
+             
+            <a
+              href="https://quiz.emilhornlund.com"
+            >
+              quiz.emilhornlund.com
+            </a>
+             one last time, and we’ll magically teleport everything over to
+             
+            <b>
+              <i>
+                klurigo.com
+              </i>
+            </b>
+            . Ready to blast off your data?
+          </span>
+        </div>
+      </div>
+      <div
+        class="main"
+      >
+        <img
+          alt="Users"
+          src="users-icon.svg"
+        />
+      </div>
+      <div
+        class="typography title medium"
+      >
+        Join the game
+      </div>
+      <div
+        class="typography text small"
+      >
+        Pick a nickname and jump in!
+      </div>
+      <form
+        data-testid="join-form"
+        name="join-game-form"
+      >
+        <div
+          class="nicknameTextFieldContainer"
+        >
+          <div
+            class="inputContainer"
+          >
+            <div
+              class="textFieldInputContainer textFieldInputKindPrimary"
+            >
+              <input
+                class="textfield"
+                data-testid="test-default-nickname-textfield-textfield"
+                id="default-nickname-textfield"
+                maxlength="20"
+                minlength="2"
+                name="default-nickname-textfield"
+                placeholder="Nickname"
+                type="text"
+                value="KeyUser"
+              />
+            </div>
+          </div>
+          <div
+            class="buttonInputContainer buttonInputKindPrimary"
+          >
+            <button
+              data-testid="test-shuffle-nickname-button-button"
+              id="shuffle-nickname-button"
+              name="shuffle-nickname-button"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                class="svg-inline--fa fa-arrows-rotate "
+                data-icon="arrows-rotate"
+                data-prefix="fas"
+                role="img"
+                viewBox="0 0 512 512"
+              >
+                <path
+                  d="M65.9 228.5c13.3-93 93.4-164.5 190.1-164.5 53 0 101 21.5 135.8 56.2 .2 .2 .4 .4 .6 .6l7.6 7.2-47.9 0c-17.7 0-32 14.3-32 32s14.3 32 32 32l128 0c17.7 0 32-14.3 32-32l0-128c0-17.7-14.3-32-32-32s-32 14.3-32 32l0 53.4-11.3-10.7C390.5 28.6 326.5 0 256 0 127 0 20.3 95.4 2.6 219.5 .1 237 12.2 253.2 29.7 255.7s33.7-9.7 36.2-27.1zm443.5 64c2.5-17.5-9.7-33.7-27.1-36.2s-33.7 9.7-36.2 27.1c-13.3 93-93.4 164.5-190.1 164.5-53 0-101-21.5-135.8-56.2-.2-.2-.4-.4-.6-.6l-7.6-7.2 47.9 0c17.7 0 32-14.3 32-32s-14.3-32-32-32L32 320c-8.5 0-16.7 3.4-22.7 9.5S-.1 343.7 0 352.3l1 127c.1 17.7 14.6 31.9 32.3 31.7S65.2 496.4 65 478.7l-.4-51.5 10.7 10.1c46.3 46.1 110.2 74.7 180.7 74.7 129 0 235.7-95.4 253.4-219.5z"
+                  fill="currentColor"
+                />
+              </svg>
+            </button>
+          </div>
+        </div>
+        <div
+          class="buttonInputContainer buttonInputKindCallToAction"
+        >
+          <button
+            data-testid="test-join-button"
+            id="join"
+            name="join"
+            type="submit"
+          >
+            <span>
+              OK, Go!
+            </span>
+            <svg
+              aria-hidden="true"
+              class="svg-inline--fa fa-arrow-right "
+              data-icon="arrow-right"
+              data-prefix="fas"
+              role="img"
+              viewBox="0 0 512 512"
+            >
+              <path
+                d="M502.6 278.6c12.5-12.5 12.5-32.8 0-45.3l-160-160c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3L402.7 224 32 224c-17.7 0-32 14.3-32 32s14.3 32 32 32l370.7 0-105.4 105.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0l160-160z"
+                fill="currentColor"
+              />
+            </svg>
+          </button>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`GameJoinPage > submits with gameID and nickname and navigates to /game 1`] = `
+<div>
+  <div
+    class="main"
+  >
+    <div
+      class="header"
+    >
+      <button
+        class="logo"
+      >
+        <img
+          alt="Klurigo"
+          class="icon"
+          src="/src/assets/images/klurigo-icon.svg"
+        />
+        <span
+          class="text"
+        >
+          Klurigo
+        </span>
+      </button>
+      <div
+        class="side"
+      >
+        <a
+          data-discover="true"
+          href="/auth/login"
+        >
+          Login
+        </a>
+        <div
+          class="buttonInputContainer buttonInputKindCallToAction buttonInputSizeSmall"
+        >
+          <button
+            data-testid="test-back-button-button"
+            id="back-button"
+            name="back-button"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              class="svg-inline--fa fa-arrow-left "
+              data-icon="arrow-left"
+              data-prefix="fas"
+              role="img"
+              viewBox="0 0 512 512"
+            >
+              <path
+                d="M9.4 233.4c-12.5 12.5-12.5 32.8 0 45.3l160 160c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3L109.3 288 480 288c17.7 0 32-14.3 32-32s-14.3-32-32-32l-370.7 0 105.4-105.4c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0l-160 160z"
+                fill="currentColor"
+              />
+            </svg>
+            <span>
+              Back
+            </span>
+          </button>
+        </div>
+      </div>
+    </div>
+    <div
+      class="content fullWidth startAlign"
+    >
+      <div
+        class="card kindCallToAction sizeLarge center"
+      >
+        <button
+          type="button"
+        >
+          <svg
+            aria-hidden="true"
+            class="svg-inline--fa fa-xmark "
+            data-icon="xmark"
+            data-prefix="fas"
+            role="img"
+            viewBox="0 0 384 512"
+          >
+            <path
+              d="M55.1 73.4c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3L147.2 256 9.9 393.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0L192.5 301.3 329.9 438.6c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3L237.8 256 375.1 118.6c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0L192.5 210.7 55.1 73.4z"
+              fill="currentColor"
+            />
+          </svg>
+        </button>
+        <div
+          class="content"
+        >
+          <span>
+            Hey quiz champion! Did your brainy adventures happen on
+             
+            <a
+              href="https://quiz.emilhornlund.com"
+            >
+              quiz.emilhornlund.com
+            </a>
+            ? No worries— we can save all your quiz creations and epic game stats! Just pop back to
+             
+            <a
+              href="https://quiz.emilhornlund.com"
+            >
+              quiz.emilhornlund.com
+            </a>
+             one last time, and we’ll magically teleport everything over to
+             
+            <b>
+              <i>
+                klurigo.com
+              </i>
+            </b>
+            . Ready to blast off your data?
+          </span>
+        </div>
+      </div>
+      <div
+        class="main"
+      >
+        <img
+          alt="Users"
+          src="users-icon.svg"
+        />
+      </div>
+      <div
+        class="typography title medium"
+      >
+        Join the game
+      </div>
+      <div
+        class="typography text small"
+      >
+        Pick a nickname and jump in!
+      </div>
+      <form
+        data-testid="join-form"
+        name="join-game-form"
+      >
+        <div
+          class="nicknameTextFieldContainer"
+        >
+          <div
+            class="inputContainer"
+          >
+            <div
+              class="textFieldInputContainer textFieldInputKindPrimary"
+            >
+              <input
+                class="textfield"
+                data-testid="test-default-nickname-textfield-textfield"
+                id="default-nickname-textfield"
+                maxlength="20"
+                minlength="2"
+                name="default-nickname-textfield"
+                placeholder="Nickname"
+                type="text"
+                value="Emil"
+              />
+            </div>
+          </div>
+          <div
+            class="buttonInputContainer buttonInputKindPrimary"
+          >
+            <button
+              data-testid="test-shuffle-nickname-button-button"
+              id="shuffle-nickname-button"
+              name="shuffle-nickname-button"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                class="svg-inline--fa fa-arrows-rotate "
+                data-icon="arrows-rotate"
+                data-prefix="fas"
+                role="img"
+                viewBox="0 0 512 512"
+              >
+                <path
+                  d="M65.9 228.5c13.3-93 93.4-164.5 190.1-164.5 53 0 101 21.5 135.8 56.2 .2 .2 .4 .4 .6 .6l7.6 7.2-47.9 0c-17.7 0-32 14.3-32 32s14.3 32 32 32l128 0c17.7 0 32-14.3 32-32l0-128c0-17.7-14.3-32-32-32s-32 14.3-32 32l0 53.4-11.3-10.7C390.5 28.6 326.5 0 256 0 127 0 20.3 95.4 2.6 219.5 .1 237 12.2 253.2 29.7 255.7s33.7-9.7 36.2-27.1zm443.5 64c2.5-17.5-9.7-33.7-27.1-36.2s-33.7 9.7-36.2 27.1c-13.3 93-93.4 164.5-190.1 164.5-53 0-101-21.5-135.8-56.2-.2-.2-.4-.4-.6-.6l-7.6-7.2 47.9 0c17.7 0 32-14.3 32-32s-14.3-32-32-32L32 320c-8.5 0-16.7 3.4-22.7 9.5S-.1 343.7 0 352.3l1 127c.1 17.7 14.6 31.9 32.3 31.7S65.2 496.4 65 478.7l-.4-51.5 10.7 10.1c46.3 46.1 110.2 74.7 180.7 74.7 129 0 235.7-95.4 253.4-219.5z"
+                  fill="currentColor"
+                />
+              </svg>
+            </button>
+          </div>
+        </div>
+        <div
+          class="buttonInputContainer buttonInputKindCallToAction"
+        >
+          <button
+            data-testid="test-join-button"
+            id="join"
+            name="join"
+            type="submit"
+          >
+            <span>
+              OK, Go!
+            </span>
+            <svg
+              aria-hidden="true"
+              class="svg-inline--fa fa-arrow-right "
+              data-icon="arrow-right"
+              data-prefix="fas"
+              role="img"
+              viewBox="0 0 512 512"
+            >
+              <path
+                d="M502.6 278.6c12.5-12.5 12.5-32.8 0-45.3l-160-160c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3L402.7 224 32 224c-17.7 0-32 14.3-32 32s14.3 32 32 32l370.7 0-105.4 105.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0l160-160z"
+                fill="currentColor"
+              />
+            </svg>
+          </button>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>
+`;


### PR DESCRIPTION
- Initialize the nickname field with the current user's defaultNickname when available.
- Ensure form submission only occurs when nickname is valid.
- Added `data-testid` to the form element for easier testing.
- Expanded unit tests to cover initial nickname behavior, validation, and form interaction scenarios.

This improves the join game flow by reducing friction for returning players and ensuring consistent validation.