### PR TITLE
feat(migration): set computed migration token from client and player IDs

### DIFF
--- a/packages/quiz/src/context/migration/MigrationContextProvider.tsx
+++ b/packages/quiz/src/context/migration/MigrationContextProvider.tsx
@@ -90,6 +90,7 @@ const MigrationContextProvider: FC<MigrationContextProviderProps> = ({
           }
         } else if (client?.id && player?.id) {
           newMigrationToken = await sha256(`${client.id}:${player.id}`)
+          setMigrationToken(newMigrationToken)
         }
       }
 


### PR DESCRIPTION
- Compute the migration token using a SHA-256 hash of the client and player IDs.
- Persist the generated token in state via `setMigrationToken` for later use.

Ensures the migration token is properly stored once generated.
