### PR TITLE
feat(migration): add logging and change missing token response to 204

### DIFF
--- a/packages/quiz-service/src/migration/controllers/user-migration.controller.e2e-spec.ts
+++ b/packages/quiz-service/src/migration/controllers/user-migration.controller.e2e-spec.ts
@@ -47,6 +47,21 @@ describe('UserMigrationController (e2e)', () => {
         })
     })
 
+    it('should return 204 when an migration token is not found', async () => {
+      const { accessToken } = await createDefaultUserAndAuthenticate(app, {
+        unverifiedEmail: MOCK_SECONDARY_USER_EMAIL,
+      } as Partial<LocalUser>)
+
+      return supertest(app.getHttpServer())
+        .post('/api/migration/user')
+        .set({ Authorization: `Bearer ${accessToken}` })
+        .send({ migrationToken: 'jU4n2n9eC-8GEZhk8NcApcfNQF9xO0yQOeJUZQk4w-E' })
+        .expect(204)
+        .expect((res) => {
+          expect(res.body).toEqual({})
+        })
+    })
+
     it('should return 400 bad request for invalid migration token', async () => {
       const { accessToken } = await createDefaultUserAndAuthenticate(app, {
         unverifiedEmail: MOCK_SECONDARY_USER_EMAIL,
@@ -85,25 +100,6 @@ describe('UserMigrationController (e2e)', () => {
           expect(res.body).toEqual({
             message: 'Missing Authorization header',
             status: 401,
-            timestamp: expect.anything(),
-          })
-        })
-    })
-
-    it('should return 404 when an migration token is not found', async () => {
-      const { accessToken } = await createDefaultUserAndAuthenticate(app, {
-        unverifiedEmail: MOCK_SECONDARY_USER_EMAIL,
-      } as Partial<LocalUser>)
-
-      return supertest(app.getHttpServer())
-        .post('/api/migration/user')
-        .set({ Authorization: `Bearer ${accessToken}` })
-        .send({ migrationToken: 'jU4n2n9eC-8GEZhk8NcApcfNQF9xO0yQOeJUZQk4w-E' })
-        .expect(404)
-        .expect((res) => {
-          expect(res.body).toEqual({
-            message: 'User was not found by migration token',
-            status: 404,
             timestamp: expect.anything(),
           })
         })


### PR DESCRIPTION
- Introduced a logger in `UserMigrationController` for detailed debug output on migration failures.
- Updated migration flow to return 204 No Content when a migration token is not found, instead of 404.
- Adjusted E2E tests to reflect new 204 behavior and verify empty response body.

Improves observability and aligns API response with new migration handling policy.
