### PR TITLE
fix(game-results): prevent metric values from breaking row layout

### DIFF
--- a/packages/quiz/src/pages/GameResultsPage/components/GameResultsPageUI/GameResultsPageUI.module.scss
+++ b/packages/quiz/src/pages/GameResultsPage/components/GameResultsPageUI/GameResultsPageUI.module.scss
@@ -326,6 +326,9 @@
           .value {
             flex: 1;
             flex-wrap: wrap;
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
           }
         }
 


### PR DESCRIPTION
- Added `white-space: nowrap`, `overflow: hidden`, and `text-overflow: ellipsis` to metric value cells in the results table.
- Ensures long metric values do not disrupt the alignment or wrapping of row content.

Improves table readability and preserves consistent row formatting.
