### PR TITLE
fix(migration): default missing nicknames to "Unknown"

### DIFF
--- a/tools/mongodb-migrator/src/utils/collection.utils.ts
+++ b/tools/mongodb-migrator/src/utils/collection.utils.ts
@@ -213,17 +213,16 @@ export function patchUnknownNicknameInGameResults(
           {},
           'participantId',
         )
-        const foundNickname = gameParticipants.find(
-          (participant) =>
-            extractValueOrThrow<string>(participant, {}, 'participantId') ===
-            participantId,
-        )?.nickname
-        if (foundNickname) {
-          console.log(
-            `Replacing '${UNKNOWN_NICKNAME_PLACEHOLDER}' nickname with '${foundNickname}' in game result ${gameId} for player ${participantId}`,
-          )
-          return { ...player, nickname: foundNickname }
-        }
+        const foundNickname =
+          gameParticipants.find(
+            (participant) =>
+              extractValueOrThrow<string>(participant, {}, 'participantId') ===
+              participantId,
+          )?.nickname || 'Unknown'
+        console.log(
+          `Replacing '${UNKNOWN_NICKNAME_PLACEHOLDER}' nickname with '${foundNickname}' in game result ${gameId} for player ${participantId}`,
+        )
+        return { ...player, nickname: foundNickname }
       }
       return { ...player, nickname }
     })


### PR DESCRIPTION
- Updated migration tool to set nickname to "Unknown" when no match is found instead of keeping the placeholder value.
- Ensures migrated game results always display a valid, user-friendly name.

Improves clarity and avoids showing placeholder values in migrated data.