### PR TITLE
feat(legacy-redirection): replace redirect link with button

### DIFF
--- a/packages/quiz/src/components/Button/Button.tsx
+++ b/packages/quiz/src/components/Button/Button.tsx
@@ -44,6 +44,7 @@ const Button: React.FC<ButtonProps> = ({
   iconPosition = 'leading',
   iconColor,
   onClick,
+  children,
 }) => {
   const deviceType = useDeviceSizeType()
 
@@ -51,8 +52,8 @@ const Button: React.FC<ButtonProps> = ({
     if (hideValue === 'mobile' && deviceType === DeviceType.Mobile) {
       return false
     }
-    return !!value
-  }, [value, deviceType, hideValue])
+    return !!value || !!children
+  }, [value, children, deviceType, hideValue])
 
   const deviceSize = useMemo(
     () => (deviceType === DeviceType.Mobile ? 'small' : size),
@@ -91,7 +92,7 @@ const Button: React.FC<ButtonProps> = ({
             {icon && iconPosition === 'leading' && (
               <FontAwesomeIcon icon={icon} color={iconColor} />
             )}
-            {showValue && <span>{value}</span>}
+            {showValue && <span>{children || value}</span>}
             {icon && iconPosition === 'trailing' && (
               <FontAwesomeIcon icon={icon} color={iconColor} />
             )}

--- a/packages/quiz/src/pages/LegacyRedirectionPage/LegacyRedirectionPage.test.tsx
+++ b/packages/quiz/src/pages/LegacyRedirectionPage/LegacyRedirectionPage.test.tsx
@@ -58,7 +58,7 @@ describe('LegacyRedirectionPage', () => {
     expect(container).toMatchSnapshot()
   })
 
-  it('shows the “saved profile” message when a migration token exists and builds the link with the token', () => {
+  it('shows the “saved profile” message when a migration token exists', () => {
     const token = 'abc123'
     window.localStorage.setItem('migrationToken', token)
 
@@ -68,26 +68,23 @@ describe('LegacyRedirectionPage', () => {
       screen.getByText(/We’ve saved your old profile/i),
     ).toBeInTheDocument()
 
-    const link = screen.getByRole('link', { name: /Take me there now/i })
-    expect(link).toHaveAttribute(
-      'href',
-      `https://example.com?migrationToken=${token}`,
-    )
-    expect(link).toHaveAttribute('target', '_blank')
-    expect(link).toHaveAttribute('rel', 'noreferrer')
+    expect(
+      screen.getByRole('button', { name: /Take Me There Now!/i }),
+    ).toBeInTheDocument()
 
     expect(container).toMatchSnapshot()
   })
 
-  it('shows the “fresh start” message when no migration token exists and builds the link without query', () => {
+  it('shows the “fresh start” message when no migration token exists', () => {
     const { container } = renderWithRouter(<LegacyRedirectionPage />)
 
     expect(
       screen.getByText(/Fresh start—no past activity found on this device./i),
     ).toBeInTheDocument()
 
-    const link = screen.getByRole('link', { name: /Take me there now/i })
-    expect(link).toHaveAttribute('href', 'https://example.com')
+    expect(
+      screen.getByRole('button', { name: /Take Me There Now!/i }),
+    ).toBeInTheDocument()
 
     expect(container).toMatchSnapshot()
   })

--- a/packages/quiz/src/pages/LegacyRedirectionPage/LegacyRedirectionPage.tsx
+++ b/packages/quiz/src/pages/LegacyRedirectionPage/LegacyRedirectionPage.tsx
@@ -1,7 +1,8 @@
-import React, { FC, useEffect, useMemo } from 'react'
+import { faPaperPlane } from '@fortawesome/free-solid-svg-icons'
+import React, { FC, useCallback, useEffect, useMemo } from 'react'
 import { useCountdown, useLocalStorage } from 'usehooks-ts'
 
-import { Page, Typography } from '../../components'
+import { Button, Page, Typography } from '../../components'
 import { REDIRECT_TARGET_HOST } from '../../utils/constants.ts'
 
 type LegacyRedirectionPageProps = {
@@ -42,14 +43,18 @@ const LegacyRedirectionPage: FC<LegacyRedirectionPageProps> = ({
     startCountdown()
   }, [startCountdown])
 
+  const handleRedirection = useCallback(() => {
+    if (!disableRedirect) {
+      console.log(`Redirecting to '${redirectionLink}'.`)
+      window.location.replace(redirectionLink)
+    }
+  }, [disableRedirect, redirectionLink])
+
   useEffect(() => {
     if (count === 0) {
-      console.log(`Redirecting to '${redirectionLink}'.`)
-      if (!disableRedirect) {
-        window.location.replace(redirectionLink)
-      }
+      handleRedirection()
     }
-  }, [count, disableRedirect, redirectionLink])
+  }, [count, handleRedirection])
 
   return (
     <Page hideLogin>
@@ -71,11 +76,15 @@ const LegacyRedirectionPage: FC<LegacyRedirectionPageProps> = ({
         Warping you over in&nbsp;<strong>{count}s</strong>…
       </Typography>
 
-      <Typography variant="link" size="medium">
-        <a href={redirectionLink} target="_blank" rel="noreferrer">
-          Take me there now
-        </a>
-      </Typography>
+      <Button
+        id="redirect-button"
+        type="button"
+        kind="call-to-action"
+        icon={faPaperPlane}
+        iconPosition="leading"
+        onClick={handleRedirection}>
+        Take Me There Now!
+      </Button>
     </Page>
   )
 }

--- a/packages/quiz/src/pages/LegacyRedirectionPage/__snapshots__/LegacyRedirectionPage.test.tsx.snap
+++ b/packages/quiz/src/pages/LegacyRedirectionPage/__snapshots__/LegacyRedirectionPage.test.tsx.snap
@@ -58,15 +58,31 @@ exports[`LegacyRedirectionPage > announces the remaining seconds in the aria-liv
         …
       </div>
       <div
-        class="typography link medium"
+        class="buttonInputContainer buttonInputKindCallToAction"
       >
-        <a
-          href="https://example.com"
-          rel="noreferrer"
-          target="_blank"
+        <button
+          data-testid="test-redirect-button-button"
+          id="redirect-button"
+          name="redirect-button"
+          type="button"
         >
-          Take me there now
-        </a>
+          <svg
+            aria-hidden="true"
+            class="svg-inline--fa fa-paper-plane "
+            data-icon="paper-plane"
+            data-prefix="fas"
+            role="img"
+            viewBox="0 0 576 512"
+          >
+            <path
+              d="M536.4-26.3c9.8-3.5 20.6-1 28 6.3s9.8 18.2 6.3 28l-178 496.9c-5 13.9-18.1 23.1-32.8 23.1-14.2 0-27-8.6-32.3-21.7l-64.2-158c-4.5-11-2.5-23.6 5.2-32.6l94.5-112.4c5.1-6.1 4.7-15-.9-20.6s-14.6-6-20.6-.9L229.2 276.1c-9.1 7.6-21.6 9.6-32.6 5.2L38.1 216.8c-13.1-5.3-21.7-18.1-21.7-32.3 0-14.7 9.2-27.8 23.1-32.8l496.9-178z"
+              fill="currentColor"
+            />
+          </svg>
+          <span>
+            Take Me There Now!
+          </span>
+        </button>
       </div>
     </div>
   </div>
@@ -131,15 +147,31 @@ exports[`LegacyRedirectionPage > redirects with window.location.replace and logs
         …
       </div>
       <div
-        class="typography link medium"
+        class="buttonInputContainer buttonInputKindCallToAction"
       >
-        <a
-          href="https://example.com?migrationToken=xyz"
-          rel="noreferrer"
-          target="_blank"
+        <button
+          data-testid="test-redirect-button-button"
+          id="redirect-button"
+          name="redirect-button"
+          type="button"
         >
-          Take me there now
-        </a>
+          <svg
+            aria-hidden="true"
+            class="svg-inline--fa fa-paper-plane "
+            data-icon="paper-plane"
+            data-prefix="fas"
+            role="img"
+            viewBox="0 0 576 512"
+          >
+            <path
+              d="M536.4-26.3c9.8-3.5 20.6-1 28 6.3s9.8 18.2 6.3 28l-178 496.9c-5 13.9-18.1 23.1-32.8 23.1-14.2 0-27-8.6-32.3-21.7l-64.2-158c-4.5-11-2.5-23.6 5.2-32.6l94.5-112.4c5.1-6.1 4.7-15-.9-20.6s-14.6-6-20.6-.9L229.2 276.1c-9.1 7.6-21.6 9.6-32.6 5.2L38.1 216.8c-13.1-5.3-21.7-18.1-21.7-32.3 0-14.7 9.2-27.8 23.1-32.8l496.9-178z"
+              fill="currentColor"
+            />
+          </svg>
+          <span>
+            Take Me There Now!
+          </span>
+        </button>
       </div>
     </div>
   </div>
@@ -204,22 +236,38 @@ exports[`LegacyRedirectionPage > renders title and shows target host in subtitle
         …
       </div>
       <div
-        class="typography link medium"
+        class="buttonInputContainer buttonInputKindCallToAction"
       >
-        <a
-          href="https://example.com"
-          rel="noreferrer"
-          target="_blank"
+        <button
+          data-testid="test-redirect-button-button"
+          id="redirect-button"
+          name="redirect-button"
+          type="button"
         >
-          Take me there now
-        </a>
+          <svg
+            aria-hidden="true"
+            class="svg-inline--fa fa-paper-plane "
+            data-icon="paper-plane"
+            data-prefix="fas"
+            role="img"
+            viewBox="0 0 576 512"
+          >
+            <path
+              d="M536.4-26.3c9.8-3.5 20.6-1 28 6.3s9.8 18.2 6.3 28l-178 496.9c-5 13.9-18.1 23.1-32.8 23.1-14.2 0-27-8.6-32.3-21.7l-64.2-158c-4.5-11-2.5-23.6 5.2-32.6l94.5-112.4c5.1-6.1 4.7-15-.9-20.6s-14.6-6-20.6-.9L229.2 276.1c-9.1 7.6-21.6 9.6-32.6 5.2L38.1 216.8c-13.1-5.3-21.7-18.1-21.7-32.3 0-14.7 9.2-27.8 23.1-32.8l496.9-178z"
+              fill="currentColor"
+            />
+          </svg>
+          <span>
+            Take Me There Now!
+          </span>
+        </button>
       </div>
     </div>
   </div>
 </div>
 `;
 
-exports[`LegacyRedirectionPage > shows the “fresh start” message when no migration token exists and builds the link without query 1`] = `
+exports[`LegacyRedirectionPage > shows the “fresh start” message when no migration token exists 1`] = `
 <div>
   <div
     class="main"
@@ -277,22 +325,38 @@ exports[`LegacyRedirectionPage > shows the “fresh start” message when no mig
         …
       </div>
       <div
-        class="typography link medium"
+        class="buttonInputContainer buttonInputKindCallToAction"
       >
-        <a
-          href="https://example.com"
-          rel="noreferrer"
-          target="_blank"
+        <button
+          data-testid="test-redirect-button-button"
+          id="redirect-button"
+          name="redirect-button"
+          type="button"
         >
-          Take me there now
-        </a>
+          <svg
+            aria-hidden="true"
+            class="svg-inline--fa fa-paper-plane "
+            data-icon="paper-plane"
+            data-prefix="fas"
+            role="img"
+            viewBox="0 0 576 512"
+          >
+            <path
+              d="M536.4-26.3c9.8-3.5 20.6-1 28 6.3s9.8 18.2 6.3 28l-178 496.9c-5 13.9-18.1 23.1-32.8 23.1-14.2 0-27-8.6-32.3-21.7l-64.2-158c-4.5-11-2.5-23.6 5.2-32.6l94.5-112.4c5.1-6.1 4.7-15-.9-20.6s-14.6-6-20.6-.9L229.2 276.1c-9.1 7.6-21.6 9.6-32.6 5.2L38.1 216.8c-13.1-5.3-21.7-18.1-21.7-32.3 0-14.7 9.2-27.8 23.1-32.8l496.9-178z"
+              fill="currentColor"
+            />
+          </svg>
+          <span>
+            Take Me There Now!
+          </span>
+        </button>
       </div>
     </div>
   </div>
 </div>
 `;
 
-exports[`LegacyRedirectionPage > shows the “saved profile” message when a migration token exists and builds the link with the token 1`] = `
+exports[`LegacyRedirectionPage > shows the “saved profile” message when a migration token exists 1`] = `
 <div>
   <div
     class="main"
@@ -350,15 +414,31 @@ exports[`LegacyRedirectionPage > shows the “saved profile” message when a mi
         …
       </div>
       <div
-        class="typography link medium"
+        class="buttonInputContainer buttonInputKindCallToAction"
       >
-        <a
-          href="https://example.com?migrationToken=abc123"
-          rel="noreferrer"
-          target="_blank"
+        <button
+          data-testid="test-redirect-button-button"
+          id="redirect-button"
+          name="redirect-button"
+          type="button"
         >
-          Take me there now
-        </a>
+          <svg
+            aria-hidden="true"
+            class="svg-inline--fa fa-paper-plane "
+            data-icon="paper-plane"
+            data-prefix="fas"
+            role="img"
+            viewBox="0 0 576 512"
+          >
+            <path
+              d="M536.4-26.3c9.8-3.5 20.6-1 28 6.3s9.8 18.2 6.3 28l-178 496.9c-5 13.9-18.1 23.1-32.8 23.1-14.2 0-27-8.6-32.3-21.7l-64.2-158c-4.5-11-2.5-23.6 5.2-32.6l94.5-112.4c5.1-6.1 4.7-15-.9-20.6s-14.6-6-20.6-.9L229.2 276.1c-9.1 7.6-21.6 9.6-32.6 5.2L38.1 216.8c-13.1-5.3-21.7-18.1-21.7-32.3 0-14.7 9.2-27.8 23.1-32.8l496.9-178z"
+              fill="currentColor"
+            />
+          </svg>
+          <span>
+            Take Me There Now!
+          </span>
+        </button>
       </div>
     </div>
   </div>
@@ -423,15 +503,31 @@ exports[`LegacyRedirectionPage > starts the countdown on mount 1`] = `
         …
       </div>
       <div
-        class="typography link medium"
+        class="buttonInputContainer buttonInputKindCallToAction"
       >
-        <a
-          href="https://example.com"
-          rel="noreferrer"
-          target="_blank"
+        <button
+          data-testid="test-redirect-button-button"
+          id="redirect-button"
+          name="redirect-button"
+          type="button"
         >
-          Take me there now
-        </a>
+          <svg
+            aria-hidden="true"
+            class="svg-inline--fa fa-paper-plane "
+            data-icon="paper-plane"
+            data-prefix="fas"
+            role="img"
+            viewBox="0 0 576 512"
+          >
+            <path
+              d="M536.4-26.3c9.8-3.5 20.6-1 28 6.3s9.8 18.2 6.3 28l-178 496.9c-5 13.9-18.1 23.1-32.8 23.1-14.2 0-27-8.6-32.3-21.7l-64.2-158c-4.5-11-2.5-23.6 5.2-32.6l94.5-112.4c5.1-6.1 4.7-15-.9-20.6s-14.6-6-20.6-.9L229.2 276.1c-9.1 7.6-21.6 9.6-32.6 5.2L38.1 216.8c-13.1-5.3-21.7-18.1-21.7-32.3 0-14.7 9.2-27.8 23.1-32.8l496.9-178z"
+              fill="currentColor"
+            />
+          </svg>
+          <span>
+            Take Me There Now!
+          </span>
+        </button>
       </div>
     </div>
   </div>


### PR DESCRIPTION
- Updated LegacyRedirectionPage to use a call-to-action Button component with an icon instead of a text link for manual redirection.
- Adjusted button rendering to support children text in Button component.
- Updated related tests to reflect button usage and renamed test cases.
- Updated snapshots to match the new button-based layout.

Improves the visual consistency and interaction design by using the standard button component for redirection.