### PR TITLE
fix(api): prevent infinite API request loops

### DIFF
--- a/packages/quiz/src/pages/GameResultsPage/GameResultsPage.tsx
+++ b/packages/quiz/src/pages/GameResultsPage/GameResultsPage.tsx
@@ -1,6 +1,6 @@
 import { useQuery } from '@tanstack/react-query'
-import React, { FC } from 'react'
-import { useParams } from 'react-router-dom'
+import React, { FC, useEffect } from 'react'
+import { useNavigate, useParams } from 'react-router-dom'
 
 import { useQuizServiceClient } from '../../api/use-quiz-service-client.tsx'
 import { LoadingSpinner, Page } from '../../components'
@@ -8,6 +8,8 @@ import { LoadingSpinner, Page } from '../../components'
 import { GameResultsPageUI } from './components'
 
 const GameResultsPage: FC = () => {
+  const navigate = useNavigate()
+
   const { gameID } = useParams<{ gameID: string }>()
 
   const { getGameResults } = useQuizServiceClient()
@@ -16,7 +18,14 @@ const GameResultsPage: FC = () => {
     queryKey: ['game_results', gameID],
     queryFn: () => getGameResults(gameID as string),
     enabled: !!gameID,
+    retry: false,
   })
+
+  useEffect(() => {
+    if (isError) {
+      navigate(-1)
+    }
+  }, [isError, navigate])
 
   if (!data || isLoading || isError) {
     return (

--- a/packages/quiz/src/pages/QuizDetailsPage/QuizDetailsPage.tsx
+++ b/packages/quiz/src/pages/QuizDetailsPage/QuizDetailsPage.tsx
@@ -17,25 +17,22 @@ const QuizDetailsPage: FC = () => {
   const { getQuiz, deleteQuiz, createGame, authenticateGame } =
     useQuizServiceClient()
 
-  const {
-    data: originalQuiz,
-    isLoading: isLoadingQuiz,
-    isError: hasQuizLoadingError,
-  } = useQuery({
+  const { data, isLoading, isError } = useQuery({
     queryKey: ['quiz', quizId],
     queryFn: () => getQuiz(quizId as string),
     enabled: !!quizId,
+    retry: false,
   })
 
   useEffect(() => {
-    if (hasQuizLoadingError) {
-      navigate('/profile/user')
+    if (isError) {
+      navigate(-1)
     }
-  }, [hasQuizLoadingError, navigate])
+  }, [isError, navigate])
 
   const isOwner = useMemo(
-    () => originalQuiz?.author.id === user?.ACCESS.sub,
-    [originalQuiz, user],
+    () => data?.author.id === user?.ACCESS.sub,
+    [data, user],
   )
 
   const [isHostGameLoading, setIsHostGameLoading] = useState(false)
@@ -70,9 +67,9 @@ const QuizDetailsPage: FC = () => {
 
   return (
     <QuizDetailsPageUI
-      quiz={originalQuiz}
+      quiz={data}
       isOwner={isOwner}
-      isLoadingQuiz={isLoadingQuiz}
+      isLoadingQuiz={isLoading}
       isHostGameLoading={isHostGameLoading}
       isDeleteQuizLoading={isDeleteQuizLoading}
       onHostGame={handleCreateGame}


### PR DESCRIPTION
- Added `FetchOptions` type with `refresh` flag to control token refresh behavior and stop recursive refresh calls.
- Updated API helpers (`apiGet`, `apiPost`, `apiPut`, `apiPatch`, `apiDelete`) to use unified options instead of separate scope/token params.
- Disabled auto-retry in React Query (`retry: false`) for quiz and game result queries to avoid repeated failing requests.
- Redirect users back on query errors instead of looping on failure states.

These changes fix infinite request loops by ensuring failing API calls gracefully back out instead of retrying indefinitely.
