### PR TITLE
feat(user-service): add nickname generation for new Google users

### DIFF
--- a/packages/quiz-service/src/user/services/user.service.ts
+++ b/packages/quiz-service/src/user/services/user.service.ts
@@ -12,6 +12,7 @@ import {
   AuthProvider,
   CreateUserRequestDto,
   CreateUserResponseDto,
+  generateNickname,
   UpdateGoogleUserProfileRequestDto,
   UserProfileResponseDto,
 } from '@quiz/common'
@@ -220,7 +221,7 @@ export class UserService {
       unverifiedEmail: profile.verified_email ? undefined : profile.email,
       givenName: profile.given_name,
       familyName: profile.family_name,
-      defaultNickname: undefined,
+      defaultNickname: generateNickname(),
     }
 
     let createdUser: GoogleUser


### PR DESCRIPTION
- Integrated `generateNickname()` when creating a new Google user.
- Ensures that each Google account is initialized with a default nickname.

This improves user onboarding by providing an automatic nickname if none is supplied.
