### PR TITLE
feat(game): hide login on game and join pages

### DIFF
--- a/packages/quiz/src/pages/GameJoinPage/GameJoinPage.tsx
+++ b/packages/quiz/src/pages/GameJoinPage/GameJoinPage.tsx
@@ -60,7 +60,8 @@ const GameJoinPage: FC = () => {
           value="Back"
           onClick={() => navigate(-1)}
         />
-      }>
+      }
+      hideLogin>
       <LegacyInfoCard />
       <PageProminentIcon src={UsersIcon} alt="Users" />
       <Typography variant="title" size="medium">

--- a/packages/quiz/src/pages/GameJoinPage/__snapshots__/GameJoinPage.test.tsx.snap
+++ b/packages/quiz/src/pages/GameJoinPage/__snapshots__/GameJoinPage.test.tsx.snap
@@ -25,12 +25,6 @@ exports[`GameJoinPage > disables the input while joining and re-enables after pr
       <div
         class="side"
       >
-        <a
-          data-discover="true"
-          href="/auth/login"
-        >
-          Login
-        </a>
         <div
           class="buttonInputContainer buttonInputKindCallToAction buttonInputSizeSmall"
         >
@@ -247,12 +241,6 @@ exports[`GameJoinPage > does not submit when nickname is blank or whitespace 1`]
       <div
         class="side"
       >
-        <a
-          data-discover="true"
-          href="/auth/login"
-        >
-          Login
-        </a>
         <div
           class="buttonInputContainer buttonInputKindCallToAction buttonInputSizeSmall"
         >
@@ -470,12 +458,6 @@ exports[`GameJoinPage > does nothing when gameID is missing 1`] = `
       <div
         class="side"
       >
-        <a
-          data-discover="true"
-          href="/auth/login"
-        >
-          Login
-        </a>
         <div
           class="buttonInputContainer buttonInputKindCallToAction buttonInputSizeSmall"
         >
@@ -692,12 +674,6 @@ exports[`GameJoinPage > ignores rapid double-submit (only calls joinGame once) 1
       <div
         class="side"
       >
-        <a
-          data-discover="true"
-          href="/auth/login"
-        >
-          Login
-        </a>
         <div
           class="buttonInputContainer buttonInputKindCallToAction buttonInputSizeSmall"
         >
@@ -914,12 +890,6 @@ exports[`GameJoinPage > join button stays disabled until nickname is valid 1`] =
       <div
         class="side"
       >
-        <a
-          data-discover="true"
-          href="/auth/login"
-        >
-          Login
-        </a>
         <div
           class="buttonInputContainer buttonInputKindCallToAction buttonInputSizeSmall"
         >
@@ -1136,12 +1106,6 @@ exports[`GameJoinPage > navigates back when clicking the back button 1`] = `
       <div
         class="side"
       >
-        <a
-          data-discover="true"
-          href="/auth/login"
-        >
-          Login
-        </a>
         <div
           class="buttonInputContainer buttonInputKindCallToAction buttonInputSizeSmall"
         >
@@ -1359,12 +1323,6 @@ exports[`GameJoinPage > prefills nickname from user default but keeps Join disab
       <div
         class="side"
       >
-        <a
-          data-discover="true"
-          href="/auth/login"
-        >
-          Login
-        </a>
         <div
           class="buttonInputContainer buttonInputKindCallToAction buttonInputSizeSmall"
         >
@@ -1582,12 +1540,6 @@ exports[`GameJoinPage > renders title and message 1`] = `
       <div
         class="side"
       >
-        <a
-          data-discover="true"
-          href="/auth/login"
-        >
-          Login
-        </a>
         <div
           class="buttonInputContainer buttonInputKindCallToAction buttonInputSizeSmall"
         >
@@ -1805,12 +1757,6 @@ exports[`GameJoinPage > starts with empty nickname when user has no default, kee
       <div
         class="side"
       >
-        <a
-          data-discover="true"
-          href="/auth/login"
-        >
-          Login
-        </a>
         <div
           class="buttonInputContainer buttonInputKindCallToAction buttonInputSizeSmall"
         >
@@ -2028,12 +1974,6 @@ exports[`GameJoinPage > submits when the form is submitted (Enter key equivalent
       <div
         class="side"
       >
-        <a
-          data-discover="true"
-          href="/auth/login"
-        >
-          Login
-        </a>
         <div
           class="buttonInputContainer buttonInputKindCallToAction buttonInputSizeSmall"
         >
@@ -2250,12 +2190,6 @@ exports[`GameJoinPage > submits with gameID and nickname and navigates to /game 
       <div
         class="side"
       >
-        <a
-          data-discover="true"
-          href="/auth/login"
-        >
-          Login
-        </a>
         <div
           class="buttonInputContainer buttonInputKindCallToAction buttonInputSizeSmall"
         >

--- a/packages/quiz/src/pages/GamePage/GamePage.tsx
+++ b/packages/quiz/src/pages/GamePage/GamePage.tsx
@@ -151,7 +151,7 @@ const GamePage = () => {
         return <PlayerPodiumState event={event} />
       default:
         return (
-          <Page>
+          <Page hideLogin>
             <LoadingSpinner />
           </Page>
         )

--- a/packages/quiz/src/pages/GamePage/__snapshots__/GamePage.test.tsx.snap
+++ b/packages/quiz/src/pages/GamePage/__snapshots__/GamePage.test.tsx.snap
@@ -24,14 +24,7 @@ exports[`GamePage > should render GamePage 1`] = `
       </button>
       <div
         class="side"
-      >
-        <a
-          data-discover="true"
-          href="/auth/login"
-        >
-          Login
-        </a>
-      </div>
+      />
     </div>
     <div
       class="content centerAlign"

--- a/packages/quiz/src/states/HostLobbyState/HostLobbyState.tsx
+++ b/packages/quiz/src/states/HostLobbyState/HostLobbyState.tsx
@@ -54,6 +54,7 @@ const HostLobbyState: FC<HostLobbyStateProps> = ({
     <>
       <GamePage
         width="medium"
+        height="full"
         header={
           <IconButtonArrowRight
             id="start-game-button"

--- a/packages/quiz/src/states/HostLobbyState/__snapshots__/HostLobbyState.test.tsx.snap
+++ b/packages/quiz/src/states/HostLobbyState/__snapshots__/HostLobbyState.test.tsx.snap
@@ -79,7 +79,7 @@ exports[`HostLobbyState > should render HostLobbyState 1`] = `
       </div>
     </div>
     <div
-      class="content centerAlign"
+      class="content fullHeight centerAlign"
     >
       <div
         class="contentWrapper mediumWidth"


### PR DESCRIPTION
- Added `hideLogin` prop to `GameJoinPage` and `GamePage` to suppress login UI during gameplay.
- Ensured consistent layout handling in loading state with `Page hideLogin`.
- Updated `HostLobbyState` to use `height="full"` for better visual balance.

Improves user experience by removing unnecessary login elements when players are already in-game.