### PR TITLE
feat(auth): add automatic user token refresh handling

### DIFF
--- a/packages/quiz/src/api/use-quiz-service-client.tsx
+++ b/packages/quiz/src/api/use-quiz-service-client.tsx
@@ -812,6 +812,7 @@ export const useQuizServiceClient = () => {
     login,
     googleExchangeCode,
     authenticateGame,
+    refresh,
     revoke,
     verifyEmail,
     resendVerificationEmail,


### PR DESCRIPTION
- Exposed `refresh` function from `useQuizServiceClient` for token renewal.
- Implemented automatic access token refresh in `AuthContextProvider` using `useEffect`.
- Added `isMounted` and `isRefreshingUserToken` guards to prevent state updates after unmount and duplicate refresh requests.

This ensures expired access tokens are seamlessly refreshed when a valid refresh token is available.
