### PR TITLE
feat(user): extend user context with auth provider and sync to Sentry

### DIFF
--- a/packages/quiz/src/context/user/UserContext.tsx
+++ b/packages/quiz/src/context/user/UserContext.tsx
@@ -13,12 +13,12 @@ import { createContext } from 'react'
 export type UserContextType = {
   currentUser?: Pick<
     UserProfileResponseDto,
-    'id' | 'email' | 'unverifiedEmail' | 'defaultNickname'
+    'id' | 'email' | 'unverifiedEmail' | 'defaultNickname' | 'authProvider'
   >
   setCurrentUser: (
     currentUser: Pick<
       UserProfileResponseDto,
-      'id' | 'email' | 'unverifiedEmail' | 'defaultNickname'
+      'id' | 'email' | 'unverifiedEmail' | 'defaultNickname' | 'authProvider'
     >,
   ) => void
   fetchCurrentUser: (accessToken: string) => Promise<void>

--- a/packages/quiz/src/pages/ProfileUserPage/ProfileUserPage.tsx
+++ b/packages/quiz/src/pages/ProfileUserPage/ProfileUserPage.tsx
@@ -50,9 +50,17 @@ const ProfileUserPage: FC = () => {
               defaultNickname: request.defaultNickname,
             }),
       })
-        .then(({ id, email, unverifiedEmail, defaultNickname }) => {
-          setCurrentUser({ id, email, unverifiedEmail, defaultNickname })
-        })
+        .then(
+          ({ id, email, unverifiedEmail, defaultNickname, authProvider }) => {
+            setCurrentUser({
+              id,
+              email,
+              unverifiedEmail,
+              defaultNickname,
+              authProvider,
+            })
+          },
+        )
         .then(() => refetch())
         .finally(() => setIsSavingUserProfile(false))
     }


### PR DESCRIPTION
- Added `authProvider` to `UserContext` and `setCurrentUser` type.
- Updated `UserContextProvider` to include `authProvider` when setting current user.
- Implemented `useEffect` with `isMounted` guard to keep Sentry user and auth context in sync.
- Added debug logs for setting up and cleaning up Sentry context.

This ensures authentication provider details are tracked consistently and reflected in Sentry monitoring.
