### PR TITLE
feat(auth): fetch current user after successful token refresh

### DIFF
--- a/packages/quiz/src/api/use-quiz-service-client.tsx
+++ b/packages/quiz/src/api/use-quiz-service-client.tsx
@@ -312,8 +312,11 @@ export const useQuizServiceClient = () => {
     scope: TokenScope,
     request: AuthRefreshRequestDto,
   ): Promise<AuthResponseDto> =>
-    apiPost<AuthResponseDto>('/auth/refresh', request).then((res) => {
+    apiPost<AuthResponseDto>('/auth/refresh', request).then(async (res) => {
       setTokenPair(scope, res.accessToken, res.refreshToken)
+      if (scope === TokenScope.User) {
+        await fetchCurrentUser(res.accessToken)
+      }
       return res
     })
 


### PR DESCRIPTION
- Updated `refresh` method in `useQuizServiceClient` to call `fetchCurrentUser` when refreshing a user token.
- Ensures user context is reloaded immediately after obtaining a new access token.
- Improves consistency between refreshed tokens and current user state.

This guarantees the app always has an up-to-date user profile following token refresh.
