### PR TITLE
feat(quiz): enhance PinImage and ConfirmDialog components

### DIFF
--- a/packages/quiz/src/components/ConfirmDialog/ConfirmDialog.tsx
+++ b/packages/quiz/src/components/ConfirmDialog/ConfirmDialog.tsx
@@ -11,6 +11,7 @@ export interface ConfirmDialogProps {
   open?: boolean
   destructive?: boolean
   confirmTitle?: string
+  closeTitle?: string
   loading?: boolean
   onConfirm?: () => void
   onClose?: () => void
@@ -22,6 +23,7 @@ const ConfirmDialog: FC<ConfirmDialogProps> = ({
   open = false,
   destructive = false,
   confirmTitle = 'Confirm',
+  closeTitle = 'Close',
   loading = false,
   onConfirm,
   onClose,
@@ -43,7 +45,7 @@ const ConfirmDialog: FC<ConfirmDialogProps> = ({
         type="button"
         kind="secondary"
         size="small"
-        value="Close"
+        value={closeTitle}
         onClick={() => onClose?.()}
       />
     </div>

--- a/packages/quiz/src/components/PinImage/PinImage.module.scss
+++ b/packages/quiz/src/components/PinImage/PinImage.module.scss
@@ -18,6 +18,7 @@
   height: 100%;
   pointer-events: auto;
   touch-action: none;
+  z-index: variables.$pin-image-z-index;
 
   &:active .pin {
     cursor: grabbing;
@@ -66,5 +67,16 @@
         height: 100%;
       }
     }
+  }
+
+  .children {
+    position: relative;
+    z-index: 1;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
   }
 }

--- a/packages/quiz/src/components/ResponsiveImage/ResponsiveImage.module.scss
+++ b/packages/quiz/src/components/ResponsiveImage/ResponsiveImage.module.scss
@@ -26,7 +26,7 @@
       width: 100%;
       height: 100%;
       transition: none !important;
-      border: helpers.pxToRem(4px) solid colors.$white-1-50;
+      border: variables.$control-outside-border-width solid colors.$white;
       background-color: colors.$white-1-50;
 
       @include helpers.mobile {

--- a/packages/quiz/src/pages/QuizCreatorPage/components/QuizCreatorPageUI/components/QuestionEditor/components/QuestionField/PinQuestionField/PinQuestionField.module.scss
+++ b/packages/quiz/src/pages/QuizCreatorPage/components/QuizCreatorPageUI/components/QuestionEditor/components/QuestionField/PinQuestionField/PinQuestionField.module.scss
@@ -1,3 +1,7 @@
+@use '../../../../../../../../../styles/colors';
+@use '../../../../../../../../../styles/helpers';
+@use '../../../../../../../../../styles/variables';
+
 .pinQuestionField {
   display: flex;
   flex-direction: column;
@@ -5,4 +9,49 @@
   align-items: center;
   align-self: center;
   width: 100%;
+
+  .overlay {
+    display: flex;
+    flex-direction: row;
+    align-items: flex-end;
+    justify-content: flex-end;
+    width: 100%;
+    height: 100%;
+
+    @include helpers.mobile {
+      padding: variables.$mobile-narrow-layout-gutter * 0.5;
+    }
+
+    @include helpers.tablet {
+      padding: variables.$tablet-narrow-layout-gutter * 0.5;
+    }
+
+    @include helpers.desktop {
+      padding: variables.$desktop-narrow-layout-gutter * 0.5;
+    }
+
+    .actions {
+      display: flex;
+      flex-direction: row;
+      background-color: colors.$white-1-80;
+
+      @include helpers.mobile {
+        padding: variables.$mobile-narrow-layout-gutter * 0.5;
+        column-gap: variables.$mobile-narrow-layout-gutter * 0.5;
+        border-radius: variables.$mobile-narrow-layout-gutter;
+      }
+
+      @include helpers.tablet {
+        padding: variables.$tablet-narrow-layout-gutter * 0.5;
+        column-gap: variables.$tablet-narrow-layout-gutter * 0.5;
+        border-radius: variables.$tablet-narrow-layout-gutter;
+      }
+
+      @include helpers.desktop {
+        padding: variables.$desktop-narrow-layout-gutter * 0.5;
+        column-gap: variables.$desktop-narrow-layout-gutter * 0.5;
+        border-radius: variables.$desktop-control-normal-border-radius;
+      }
+    }
+  }
 }

--- a/packages/quiz/src/pages/QuizCreatorPage/components/QuizCreatorPageUI/components/QuestionEditor/components/QuestionField/PinQuestionField/PinQuestionField.tsx
+++ b/packages/quiz/src/pages/QuizCreatorPage/components/QuizCreatorPageUI/components/QuestionEditor/components/QuestionField/PinQuestionField/PinQuestionField.tsx
@@ -1,9 +1,10 @@
-import { faPlus } from '@fortawesome/free-solid-svg-icons'
+import { faPlus, faRetweet, faTrash } from '@fortawesome/free-solid-svg-icons'
 import { MediaType, QuestionPinDto, QuestionPinTolerance } from '@quiz/common'
-import React, { FC, useState } from 'react'
+import React, { FC, useEffect, useState } from 'react'
 
 import {
   Button,
+  ConfirmDialog,
   MediaModal,
   PinImage,
 } from '../../../../../../../../../components'
@@ -35,6 +36,11 @@ const PinQuestionField: FC<PinQuestionFieldProps> = ({
   onPositionValid,
 }) => {
   const [showMediaModal, setShowMediaModal] = useState(false)
+  const [showConfirmDeleteImage, setShowConfirmDeleteImage] = useState(false)
+
+  useEffect(() => {
+    console.log('showMediaModal', showMediaModal)
+  }, [showMediaModal])
 
   return (
     <>
@@ -45,8 +51,31 @@ const PinQuestionField: FC<PinQuestionFieldProps> = ({
             value={{ x: position?.x ?? 0.5, y: position?.y ?? 0.5, tolerance }}
             alt={imageURL}
             onChange={onPositionChange}
-            onValid={onPositionValid}
-          />
+            onValid={onPositionValid}>
+            <div className={styles.overlay}>
+              <div className={styles.actions}>
+                <Button
+                  id="replace-image-button"
+                  type="button"
+                  kind="call-to-action"
+                  size="small"
+                  icon={faRetweet}
+                  onClick={() => {
+                    console.log('FOOO')
+                    setShowMediaModal(true)
+                  }}
+                />
+                <Button
+                  id="delete-image-button"
+                  type="button"
+                  kind="destructive"
+                  size="small"
+                  icon={faTrash}
+                  onClick={() => setShowConfirmDeleteImage(true)}
+                />
+              </div>
+            </div>
+          </PinImage>
         ) : (
           <Button
             id="add-image-button"
@@ -70,6 +99,21 @@ const PinQuestionField: FC<PinQuestionFieldProps> = ({
           imageOnly
         />
       )}
+
+      <ConfirmDialog
+        title="Confirm Remove Image"
+        message="Are you sure you want to remove this image?"
+        open={showConfirmDeleteImage}
+        confirmTitle="Yes"
+        closeTitle="No"
+        onConfirm={() => {
+          onImageUrlChange(undefined)
+          onImageUrlValid(false)
+          setShowConfirmDeleteImage(false)
+        }}
+        onClose={() => setShowConfirmDeleteImage(false)}
+        destructive
+      />
     </>
   )
 }

--- a/packages/quiz/src/styles/variables.scss
+++ b/packages/quiz/src/styles/variables.scss
@@ -77,4 +77,5 @@ $desktop-control-small-font-size: 16px;
 $tooltip-z-index: 999;
 $modal-z-index: 998;
 $menu-z-index: 997;
+$pin-image-z-index: 996;
 $podium-z-index: 1;


### PR DESCRIPTION
- Added `closeTitle` prop to ConfirmDialog for customizable close button text.
- Introduced `children` support in PinImage for overlay actions.
- Updated PinImage to handle pointer events with z-index layering.
- Adjusted SCSS styles for PinImage and PinQuestionField with overlay/action bar.
- Added confirm dialog for image deletion in PinQuestionField.

These changes improve user interaction with Pin questions, providing better image management and clearer UI feedback.