### PR TITLE
fix(answer-pin): make pin movable instead of fixed at center

### DIFF
--- a/packages/quiz/src/components/QuestionAnswerPicker/components/AnswerPin/AnswerPin.tsx
+++ b/packages/quiz/src/components/QuestionAnswerPicker/components/AnswerPin/AnswerPin.tsx
@@ -28,7 +28,7 @@ const AnswerPin: FC<AnswerPinProps> = ({ imageURL, interactive, onSubmit }) => {
       {interactive ? (
         <div className={styles.interactive}>
           <PinImage
-            value={{ x: 0.5, y: 0.5 }}
+            value={position}
             imageURL={imageURL}
             onChange={setPosition}
           />


### PR DESCRIPTION
- Replaced hardcoded default value `{ x: 0.5, y: 0.5 }` with the actual `position` state when rendering `PinImage`.
- Ensures the pin can be updated interactively instead of staying stuck at the initial center coordinates.

This fixes the bug where the pin was not movable due to a fixed position.
