### PR TITLE
chore(github-actions): replace deprecated set-output with GITHUB_OUTPUT

### DIFF
--- a/.github/workflows/docker-build-and-push.yml
+++ b/.github/workflows/docker-build-and-push.yml
@@ -26,8 +26,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - id: get_sha
-        run: |
-          echo "::set-output name=short_sha::$(git rev-parse --short HEAD)"
+        run: echo "short_sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
 
   docker_build_and_push:
     needs: prepare


### PR DESCRIPTION
- Updated docker-build-and-push workflow to use the recommended syntax.
- Replaced ::set-output with writing to $GITHUB_OUTPUT for short_sha.
- Removes deprecation warnings and ensures compatibility with future runners.

This modernizes the workflow according to GitHub Actions best practices.