### PR TITLE
fix(sortable-table): prevent iOS page scroll during drag

### DIFF
--- a/packages/quiz/src/components/SortableTable/SortableTable.module.scss
+++ b/packages/quiz/src/components/SortableTable/SortableTable.module.scss
@@ -58,6 +58,8 @@
     }
 
     &.draggable {
+      touch-action: none;
+
       &:hover {
         cursor: grab;
       }

--- a/packages/quiz/src/components/SortableTable/SortableTable.tsx
+++ b/packages/quiz/src/components/SortableTable/SortableTable.tsx
@@ -101,10 +101,14 @@ const SortableTable: FC<SortableTableProps> = ({
   }, [values])
 
   const sensors = useSensors(
-    useSensor(TouchSensor),
-    useSensor(PointerSensor),
+    useSensor(PointerSensor, {
+      activationConstraint: { distance: 5 },
+    }),
     useSensor(KeyboardSensor, {
       coordinateGetter: sortableKeyboardCoordinates,
+    }),
+    useSensor(TouchSensor, {
+      activationConstraint: { distance: 5 },
     }),
   )
 


### PR DESCRIPTION
- Added `touch-action: none` to `.draggable` class to disable native scrolling on draggable elements.
- Updated sensors to prioritize `PointerSensor` with activation constraint for smoother drag start on iOS.
- Added `TouchSensor` with activation constraint as fallback.

Ensures sortable table works correctly on iOS Safari/Firefox without page scroll interfering with drag operations.
