### PR TITLE
ci(workflow): include common package coverage in Codecov upload

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v5
         with:
-          files: ./packages/quiz/coverage/lcov.info,./packages/quiz-service/coverage/lcov.info
+          files: ./packages/common/coverage/lcov.info,./packages/quiz/coverage/lcov.info,./packages/quiz-service/coverage/lcov.info
 
       - name: Docker compose down
         if: always()


### PR DESCRIPTION
- Updated `build.yml` to upload `./packages/common/coverage/lcov.info`.
- Ensures coverage from all workspaces (`common`, `quiz`, `quiz-service`) is reported.
