### PR TITLE
ci(codecov): split coverage uploads per package and update config

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: write
 
 jobs:
   build-test:
@@ -45,23 +46,50 @@ jobs:
       - name: Test & Coverage
         run: yarn test:coverage
 
+      - name: Docker compose down
+        if: always()
+        run: docker compose down -v
+
       - name: Upload Klurigo artifacts for Sentry
+        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')
         uses: actions/upload-artifact@v4
         with:
           name: klurigo-sentry-artifacts
           path: packages/quiz/dist/assets/**/*.map
 
       - name: Upload Klurigo Service artifacts for Sentry
+        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')
         uses: actions/upload-artifact@v4
         with:
           name: klurigo-service-sentry-artifacts
           path: packages/quiz-service/dist/**/*.map
 
-      - name: Upload coverage reports to Codecov
+      - name: Upload coverage (common)
         uses: codecov/codecov-action@v5
         with:
-          files: ./packages/common/coverage/lcov.info,./packages/quiz/coverage/lcov.info,./packages/quiz-service/coverage/lcov.info
+          files: ./packages/common/coverage/lcov.info
+          flags: common
+          name: common
+          disable_search: true
+          fail_ci_if_error: true
+          verbose: true
 
-      - name: Docker compose down
-        if: always()
-        run: docker compose down -v
+      - name: Upload coverage (quiz)
+        uses: codecov/codecov-action@v5
+        with:
+          files: ./packages/quiz/coverage/lcov.info
+          flags: quiz
+          name: quiz
+          disable_search: true
+          fail_ci_if_error: true
+          verbose: true
+
+      - name: Upload coverage (quiz-service)
+        uses: codecov/codecov-action@v5
+        with:
+          files: ./packages/quiz-service/coverage/lcov.info
+          flags: quiz-service
+          name: quiz-service
+          disable_search: true
+          fail_ci_if_error: true
+          verbose: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,6 +10,7 @@ jobs:
   build:
     permissions:
       contents: read
+      pull-requests: write
     uses: ./.github/workflows/build.yml
 
   docker-build-and-push:

--- a/.github/workflows/prod-deploy.yml
+++ b/.github/workflows/prod-deploy.yml
@@ -8,6 +8,7 @@ jobs:
   build:
     permissions:
       contents: read
+      pull-requests: write
     uses: ./.github/workflows/build.yml
     secrets: inherit
 

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -9,4 +9,5 @@ jobs:
   build:
     permissions:
       contents: read
+      pull-requests: write
     uses: ./.github/workflows/build.yml

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,7 +1,8 @@
 comment:
-  layout: "reach, diff, flags, coverage"
+  layout: "reach, diff, flags, components, files, tree"
+  require_changes: false
   behavior: default
-  require_changes: true
+  hide_project_coverage: false
 
 component_management:
   default_rules:
@@ -11,6 +12,10 @@ component_management:
       - type: patch
         informational: true
   individual_components:
+    - component_id: common
+      name: common
+      paths:
+        - packages/common/**
     - component_id: quiz
       name: quiz
       paths:


### PR DESCRIPTION
- Added `pull-requests: write` permission to workflow for PR comments.
- Replaced single Codecov upload with separate uploads for `common`, `quiz`, and `quiz-service` using flags.
- Enhanced `codecov.yml` with component paths for `common` and updated comment layout.
- Changed `require_changes` to false and enabled `hide_project_coverage` display.

This improves coverage visibility across monorepo packages and ensures PR comments are properly posted.
