### PR TITLE
test(auth): add full test coverage for auth flows & UI

### DIFF
--- a/packages/quiz/src/pages/AuthGamePage/AuthGamePage.test.tsx
+++ b/packages/quiz/src/pages/AuthGamePage/AuthGamePage.test.tsx
@@ -1,0 +1,139 @@
+import { render, waitFor } from '@testing-library/react'
+import React from 'react'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const h = vi.hoisted(() => ({
+  authenticateGame: vi.fn<
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    [{ gameId?: string; gamePIN?: string }],
+    Promise<void>
+  >(),
+  navigate: vi.fn(),
+  notifyError: vi.fn(),
+}))
+
+vi.mock('../../api/use-quiz-service-client.tsx', () => ({
+  useQuizServiceClient: () => ({ authenticateGame: h.authenticateGame }),
+}))
+
+vi.mock('react-router-dom', async (orig) => {
+  const actual = await orig()
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  return { ...actual, useNavigate: () => h.navigate }
+})
+
+vi.mock('../../utils/notification.ts', () => ({
+  notifyError: h.notifyError,
+}))
+
+import AuthGamePage from './AuthGamePage'
+
+describe('AuthGamePage', () => {
+  beforeEach(() => {
+    h.authenticateGame.mockReset()
+    h.navigate.mockReset()
+    h.notifyError.mockReset()
+  })
+
+  it('does nothing when no id or pin', () => {
+    const { container } = render(
+      <MemoryRouter initialEntries={['/auth/game']}>
+        <Routes>
+          <Route path="/auth/game" element={<AuthGamePage />} />
+        </Routes>
+      </MemoryRouter>,
+    )
+    expect(h.authenticateGame).not.toHaveBeenCalled()
+    expect(h.navigate).not.toHaveBeenCalled()
+    expect(container).toMatchSnapshot()
+  })
+
+  it('authenticates with gameId and navigates to /join on success', async () => {
+    h.authenticateGame.mockResolvedValueOnce({})
+    const { container } = render(
+      <MemoryRouter initialEntries={['/auth/game?id=abc-123']}>
+        <Routes>
+          <Route path="/auth/game" element={<AuthGamePage />} />
+        </Routes>
+      </MemoryRouter>,
+    )
+    await waitFor(() => {
+      expect(h.authenticateGame).toHaveBeenCalledWith({
+        gameId: 'abc-123',
+        gamePIN: undefined,
+      })
+    })
+    await waitFor(() => expect(h.navigate).toHaveBeenCalledWith('/join'))
+    expect(container).toMatchSnapshot()
+  })
+
+  it('authenticates with gamePIN and navigates to /join on success', async () => {
+    h.authenticateGame.mockResolvedValueOnce({})
+    const { container } = render(
+      <MemoryRouter initialEntries={['/auth/game?pin=777777']}>
+        <Routes>
+          <Route path="/auth/game" element={<AuthGamePage />} />
+        </Routes>
+      </MemoryRouter>,
+    )
+    await waitFor(() =>
+      expect(h.authenticateGame).toHaveBeenCalledWith({
+        gameId: undefined,
+        gamePIN: '777777',
+      }),
+    )
+    await waitFor(() => expect(h.navigate).toHaveBeenCalledWith('/join'))
+    expect(container).toMatchSnapshot()
+  })
+
+  it('authenticates with both id and pin and navigates to /join on success', async () => {
+    h.authenticateGame.mockResolvedValueOnce({})
+    const { container } = render(
+      <MemoryRouter initialEntries={['/auth/game?id=abc&pin=123']}>
+        <Routes>
+          <Route path="/auth/game" element={<AuthGamePage />} />
+        </Routes>
+      </MemoryRouter>,
+    )
+    await waitFor(() =>
+      expect(h.authenticateGame).toHaveBeenCalledWith({
+        gameId: 'abc',
+        gamePIN: '123',
+      }),
+    )
+    await waitFor(() => expect(h.navigate).toHaveBeenCalledWith('/join'))
+    expect(container).toMatchSnapshot()
+  })
+
+  it('navigates home and notifies on failure', async () => {
+    h.authenticateGame.mockRejectedValueOnce(new Error('nope'))
+    const { container } = render(
+      <MemoryRouter initialEntries={['/auth/game?id=missing']}>
+        <Routes>
+          <Route path="/auth/game" element={<AuthGamePage />} />
+        </Routes>
+      </MemoryRouter>,
+    )
+    await waitFor(() => expect(h.navigate).toHaveBeenCalledWith('/'))
+    expect(h.notifyError).toHaveBeenCalledWith(
+      'Game not found. Please try again.',
+    )
+    expect(container).toMatchSnapshot()
+  })
+
+  it('runs only once even if user clicks back/forward causing re-render with same params', async () => {
+    h.authenticateGame.mockResolvedValueOnce({})
+    const { container } = render(
+      <MemoryRouter initialEntries={['/auth/game?id=one']} initialIndex={0}>
+        <Routes>
+          <Route path="/auth/game" element={<AuthGamePage />} />
+        </Routes>
+      </MemoryRouter>,
+    )
+    await waitFor(() => expect(h.authenticateGame).toHaveBeenCalledTimes(1))
+    expect(container).toMatchSnapshot()
+  })
+})

--- a/packages/quiz/src/pages/AuthGamePage/__snapshots__/AuthGamePage.test.tsx.snap
+++ b/packages/quiz/src/pages/AuthGamePage/__snapshots__/AuthGamePage.test.tsx.snap
@@ -1,0 +1,337 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`AuthGamePage > authenticates with both id and pin and navigates to /join on success 1`] = `
+<div>
+  <div
+    class="main"
+  >
+    <div
+      class="header"
+    >
+      <button
+        class="logo"
+      >
+        <img
+          alt="Klurigo"
+          class="icon"
+          src="/src/assets/images/klurigo-icon.svg"
+        />
+        <span
+          class="text"
+        >
+          Klurigo
+        </span>
+      </button>
+      <div
+        class="side"
+      >
+        <a
+          data-discover="true"
+          href="/auth/login"
+        >
+          Login
+        </a>
+      </div>
+    </div>
+    <div
+      class="content centerAlign"
+    >
+      <div
+        class="contentWrapper fullWidth"
+      >
+        <div
+          class="contentInner"
+        >
+          <div
+            class="loadingSpinnerContainer"
+          >
+            <div />
+            <div />
+            <div />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`AuthGamePage > authenticates with gameId and navigates to /join on success 1`] = `
+<div>
+  <div
+    class="main"
+  >
+    <div
+      class="header"
+    >
+      <button
+        class="logo"
+      >
+        <img
+          alt="Klurigo"
+          class="icon"
+          src="/src/assets/images/klurigo-icon.svg"
+        />
+        <span
+          class="text"
+        >
+          Klurigo
+        </span>
+      </button>
+      <div
+        class="side"
+      >
+        <a
+          data-discover="true"
+          href="/auth/login"
+        >
+          Login
+        </a>
+      </div>
+    </div>
+    <div
+      class="content centerAlign"
+    >
+      <div
+        class="contentWrapper fullWidth"
+      >
+        <div
+          class="contentInner"
+        >
+          <div
+            class="loadingSpinnerContainer"
+          >
+            <div />
+            <div />
+            <div />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`AuthGamePage > authenticates with gamePIN and navigates to /join on success 1`] = `
+<div>
+  <div
+    class="main"
+  >
+    <div
+      class="header"
+    >
+      <button
+        class="logo"
+      >
+        <img
+          alt="Klurigo"
+          class="icon"
+          src="/src/assets/images/klurigo-icon.svg"
+        />
+        <span
+          class="text"
+        >
+          Klurigo
+        </span>
+      </button>
+      <div
+        class="side"
+      >
+        <a
+          data-discover="true"
+          href="/auth/login"
+        >
+          Login
+        </a>
+      </div>
+    </div>
+    <div
+      class="content centerAlign"
+    >
+      <div
+        class="contentWrapper fullWidth"
+      >
+        <div
+          class="contentInner"
+        >
+          <div
+            class="loadingSpinnerContainer"
+          >
+            <div />
+            <div />
+            <div />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`AuthGamePage > does nothing when no id or pin 1`] = `
+<div>
+  <div
+    class="main"
+  >
+    <div
+      class="header"
+    >
+      <button
+        class="logo"
+      >
+        <img
+          alt="Klurigo"
+          class="icon"
+          src="/src/assets/images/klurigo-icon.svg"
+        />
+        <span
+          class="text"
+        >
+          Klurigo
+        </span>
+      </button>
+      <div
+        class="side"
+      >
+        <a
+          data-discover="true"
+          href="/auth/login"
+        >
+          Login
+        </a>
+      </div>
+    </div>
+    <div
+      class="content centerAlign"
+    >
+      <div
+        class="contentWrapper fullWidth"
+      >
+        <div
+          class="contentInner"
+        >
+          <div
+            class="loadingSpinnerContainer"
+          >
+            <div />
+            <div />
+            <div />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`AuthGamePage > navigates home and notifies on failure 1`] = `
+<div>
+  <div
+    class="main"
+  >
+    <div
+      class="header"
+    >
+      <button
+        class="logo"
+      >
+        <img
+          alt="Klurigo"
+          class="icon"
+          src="/src/assets/images/klurigo-icon.svg"
+        />
+        <span
+          class="text"
+        >
+          Klurigo
+        </span>
+      </button>
+      <div
+        class="side"
+      >
+        <a
+          data-discover="true"
+          href="/auth/login"
+        >
+          Login
+        </a>
+      </div>
+    </div>
+    <div
+      class="content centerAlign"
+    >
+      <div
+        class="contentWrapper fullWidth"
+      >
+        <div
+          class="contentInner"
+        >
+          <div
+            class="loadingSpinnerContainer"
+          >
+            <div />
+            <div />
+            <div />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`AuthGamePage > runs only once even if user clicks back/forward causing re-render with same params 1`] = `
+<div>
+  <div
+    class="main"
+  >
+    <div
+      class="header"
+    >
+      <button
+        class="logo"
+      >
+        <img
+          alt="Klurigo"
+          class="icon"
+          src="/src/assets/images/klurigo-icon.svg"
+        />
+        <span
+          class="text"
+        >
+          Klurigo
+        </span>
+      </button>
+      <div
+        class="side"
+      >
+        <a
+          data-discover="true"
+          href="/auth/login"
+        >
+          Login
+        </a>
+      </div>
+    </div>
+    <div
+      class="content centerAlign"
+    >
+      <div
+        class="contentWrapper fullWidth"
+      >
+        <div
+          class="contentInner"
+        >
+          <div
+            class="loadingSpinnerContainer"
+          >
+            <div />
+            <div />
+            <div />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/packages/quiz/src/pages/AuthGoogleCallbackPage/AuthGoogleCallbackPage.test.tsx
+++ b/packages/quiz/src/pages/AuthGoogleCallbackPage/AuthGoogleCallbackPage.test.tsx
@@ -1,0 +1,232 @@
+import { render, waitFor } from '@testing-library/react'
+import React from 'react'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  GOOGLE_OAUTH_STORAGE_KEY,
+  GOOGLE_OAUTH_STORAGE_PKCE_VERIFIER_KEY,
+  GOOGLE_OAUTH_STORAGE_STATE_KEY,
+} from '../../utils/oauth.ts'
+
+const h = vi.hoisted(() => ({
+  googleExchangeCode: vi.fn<
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    [{ code: string; codeVerifier: string }],
+    Promise<void>
+  >(),
+  navigate: vi.fn(),
+  notifyError: vi.fn(),
+}))
+
+vi.mock('../../api/use-quiz-service-client.tsx', () => ({
+  useQuizServiceClient: () => ({ googleExchangeCode: h.googleExchangeCode }),
+}))
+vi.mock('react-router-dom', async (orig) => {
+  const actual = await orig()
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  return { ...actual, useNavigate: () => h.navigate }
+})
+vi.mock('../../utils/notification.ts', () => ({
+  notifyError: h.notifyError,
+}))
+
+import AuthGoogleCallbackPage from './AuthGoogleCallbackPage'
+
+describe('AuthGoogleCallbackPage', () => {
+  beforeEach(() => {
+    h.googleExchangeCode.mockReset()
+    h.navigate.mockReset()
+    h.notifyError.mockReset()
+    sessionStorage.clear()
+  })
+
+  it('shows error and redirects to /auth/login when required params are missing', async () => {
+    const { container } = render(
+      <MemoryRouter initialEntries={['/auth/google/callback']}>
+        <Routes>
+          <Route
+            path="/auth/google/callback"
+            element={<AuthGoogleCallbackPage />}
+          />
+        </Routes>
+      </MemoryRouter>,
+    )
+
+    await waitFor(() => {
+      expect(h.notifyError).toHaveBeenCalledWith(
+        'Google OAuth error. Please try again.',
+      )
+      expect(h.navigate).toHaveBeenCalledWith('/auth/login')
+    })
+    expect(h.googleExchangeCode).not.toHaveBeenCalled()
+    expect(container).toMatchSnapshot()
+  })
+
+  it('shows error and redirects when state does not match storage', async () => {
+    sessionStorage.setItem(
+      GOOGLE_OAUTH_STORAGE_KEY,
+      JSON.stringify({
+        [GOOGLE_OAUTH_STORAGE_STATE_KEY]: 'expected-state',
+        [GOOGLE_OAUTH_STORAGE_PKCE_VERIFIER_KEY]: 'verifier-123',
+      }),
+    )
+
+    render(
+      <MemoryRouter
+        initialEntries={['/auth/google/callback?code=abc&state=wrong-state']}>
+        <Routes>
+          <Route
+            path="/auth/google/callback"
+            element={<AuthGoogleCallbackPage />}
+          />
+        </Routes>
+      </MemoryRouter>,
+    )
+
+    await waitFor(() => {
+      expect(h.notifyError).toHaveBeenCalledWith(
+        'Google OAuth error. Please try again.',
+      )
+      expect(h.navigate).toHaveBeenCalledWith('/auth/login')
+    })
+    expect(h.googleExchangeCode).not.toHaveBeenCalled()
+  })
+
+  it('shows error and redirects when codeVerifier is missing', async () => {
+    sessionStorage.setItem(
+      GOOGLE_OAUTH_STORAGE_KEY,
+      JSON.stringify({
+        [GOOGLE_OAUTH_STORAGE_STATE_KEY]: 'state-123',
+        // missing PKCE verifier
+      }),
+    )
+
+    render(
+      <MemoryRouter
+        initialEntries={['/auth/google/callback?code=abc&state=state-123']}>
+        <Routes>
+          <Route
+            path="/auth/google/callback"
+            element={<AuthGoogleCallbackPage />}
+          />
+        </Routes>
+      </MemoryRouter>,
+    )
+
+    await waitFor(() => {
+      expect(h.notifyError).toHaveBeenCalledWith(
+        'Google OAuth error. Please try again.',
+      )
+      expect(h.navigate).toHaveBeenCalledWith('/auth/login')
+    })
+    expect(h.googleExchangeCode).not.toHaveBeenCalled()
+  })
+
+  it('exchanges code and navigates to / on success', async () => {
+    h.googleExchangeCode.mockResolvedValueOnce({})
+
+    sessionStorage.setItem(
+      GOOGLE_OAUTH_STORAGE_KEY,
+      JSON.stringify({
+        [GOOGLE_OAUTH_STORAGE_STATE_KEY]: 'good-state',
+        [GOOGLE_OAUTH_STORAGE_PKCE_VERIFIER_KEY]: 'verifier-xyz',
+      }),
+    )
+
+    const { container } = render(
+      <MemoryRouter
+        initialEntries={[
+          '/auth/google/callback?code=the-code&state=good-state',
+        ]}>
+        <Routes>
+          <Route
+            path="/auth/google/callback"
+            element={<AuthGoogleCallbackPage />}
+          />
+        </Routes>
+      </MemoryRouter>,
+    )
+
+    await waitFor(() =>
+      expect(h.googleExchangeCode).toHaveBeenCalledWith({
+        code: 'the-code',
+        codeVerifier: 'verifier-xyz',
+      }),
+    )
+    await waitFor(() => expect(h.navigate).toHaveBeenCalledWith('/'))
+    expect(h.notifyError).not.toHaveBeenCalled()
+    expect(container).toMatchSnapshot()
+  })
+
+  it('exchanges code and navigates to /auth/login on failure', async () => {
+    h.googleExchangeCode.mockRejectedValueOnce(new Error('boom'))
+
+    sessionStorage.setItem(
+      GOOGLE_OAUTH_STORAGE_KEY,
+      JSON.stringify({
+        [GOOGLE_OAUTH_STORAGE_STATE_KEY]: 'ok',
+        [GOOGLE_OAUTH_STORAGE_PKCE_VERIFIER_KEY]: 'pkce-123',
+      }),
+    )
+
+    render(
+      <MemoryRouter
+        initialEntries={['/auth/google/callback?code=code123&state=ok']}>
+        <Routes>
+          <Route
+            path="/auth/google/callback"
+            element={<AuthGoogleCallbackPage />}
+          />
+        </Routes>
+      </MemoryRouter>,
+    )
+
+    await waitFor(() => {
+      expect(h.googleExchangeCode).toHaveBeenCalledTimes(1)
+      expect(h.navigate).toHaveBeenCalledWith('/auth/login')
+    })
+    expect(h.notifyError).not.toHaveBeenCalled()
+  })
+
+  it('runs only once even if component re-renders with same params', async () => {
+    h.googleExchangeCode.mockResolvedValueOnce({})
+
+    sessionStorage.setItem(
+      GOOGLE_OAUTH_STORAGE_KEY,
+      JSON.stringify({
+        [GOOGLE_OAUTH_STORAGE_STATE_KEY]: 'stable',
+        [GOOGLE_OAUTH_STORAGE_PKCE_VERIFIER_KEY]: 'pkce-stable',
+      }),
+    )
+
+    const { rerender } = render(
+      <MemoryRouter
+        initialEntries={['/auth/google/callback?code=c&state=stable']}>
+        <Routes>
+          <Route
+            path="/auth/google/callback"
+            element={<AuthGoogleCallbackPage />}
+          />
+        </Routes>
+      </MemoryRouter>,
+    )
+
+    // Force a re-render without unmounting (props/route unchanged)
+    rerender(
+      <MemoryRouter
+        initialEntries={['/auth/google/callback?code=c&state=stable']}>
+        <Routes>
+          <Route
+            path="/auth/google/callback"
+            element={<AuthGoogleCallbackPage />}
+          />
+        </Routes>
+      </MemoryRouter>,
+    )
+
+    await waitFor(() => expect(h.googleExchangeCode).toHaveBeenCalledTimes(1))
+  })
+})

--- a/packages/quiz/src/pages/AuthGoogleCallbackPage/__snapshots__/AuthGoogleCallbackPage.test.tsx.snap
+++ b/packages/quiz/src/pages/AuthGoogleCallbackPage/__snapshots__/AuthGoogleCallbackPage.test.tsx.snap
@@ -1,0 +1,133 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`AuthGoogleCallbackPage > exchanges code and navigates to / on success 1`] = `
+<div>
+  <div
+    class="main"
+  >
+    <div
+      class="header"
+    >
+      <button
+        class="logo"
+      >
+        <img
+          alt="Klurigo"
+          class="icon"
+          src="/src/assets/images/klurigo-icon.svg"
+        />
+        <span
+          class="text"
+        >
+          Klurigo
+        </span>
+      </button>
+      <div
+        class="side"
+      >
+        <a
+          data-discover="true"
+          href="/auth/login"
+        >
+          Login
+        </a>
+      </div>
+    </div>
+    <div
+      class="content centerAlign"
+    >
+      <div
+        class="contentWrapper fullWidth"
+      >
+        <div
+          class="contentInner"
+        >
+          <div
+            class="typography subtitle small"
+          >
+            Hold tight—calling in the Google cavalry!
+          </div>
+          <div
+            class="typography text small"
+          >
+            We’re doing the secret handshake with Google. Almost there…
+          </div>
+          <div
+            class="loadingSpinnerContainer"
+          >
+            <div />
+            <div />
+            <div />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`AuthGoogleCallbackPage > shows error and redirects to /auth/login when required params are missing 1`] = `
+<div>
+  <div
+    class="main"
+  >
+    <div
+      class="header"
+    >
+      <button
+        class="logo"
+      >
+        <img
+          alt="Klurigo"
+          class="icon"
+          src="/src/assets/images/klurigo-icon.svg"
+        />
+        <span
+          class="text"
+        >
+          Klurigo
+        </span>
+      </button>
+      <div
+        class="side"
+      >
+        <a
+          data-discover="true"
+          href="/auth/login"
+        >
+          Login
+        </a>
+      </div>
+    </div>
+    <div
+      class="content centerAlign"
+    >
+      <div
+        class="contentWrapper fullWidth"
+      >
+        <div
+          class="contentInner"
+        >
+          <div
+            class="typography subtitle small"
+          >
+            Hold tight—calling in the Google cavalry!
+          </div>
+          <div
+            class="typography text small"
+          >
+            We’re doing the secret handshake with Google. Almost there…
+          </div>
+          <div
+            class="loadingSpinnerContainer"
+          >
+            <div />
+            <div />
+            <div />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/packages/quiz/src/pages/AuthLoginPage/AuthLoginPage.test.tsx
+++ b/packages/quiz/src/pages/AuthLoginPage/AuthLoginPage.test.tsx
@@ -1,0 +1,166 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import React from 'react'
+import { MemoryRouter } from 'react-router-dom'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const h = vi.hoisted(() => ({
+  login: vi
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    .fn<[{ email: string; password: string }], Promise<void>>()
+    .mockResolvedValue({}),
+  navigate: vi.fn(),
+
+  genSeq: ['STATE_X', 'PKCE_Y'],
+  genIndex: 0,
+  generateRandomString: vi.fn((len: number) => {
+    const v = h.genSeq[h.genIndex] ?? `RND_${len}`
+    h.genIndex++
+    return v
+  }),
+  sha256: vi.fn(async () => 'CODE_CHALLENGE_HASH'),
+}))
+
+vi.mock('../../api/use-quiz-service-client.tsx', () => ({
+  useQuizServiceClient: () => ({ login: h.login }),
+}))
+
+vi.mock('react-router-dom', async (orig) => {
+  const actual = await orig()
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  return { ...actual, useNavigate: () => h.navigate }
+})
+
+vi.mock('../../config.ts', () => ({
+  default: {
+    googleClientId: 'TEST_CLIENT_ID',
+    googleRedirectUri: 'https://app.example.com/auth/google/callback',
+  },
+}))
+
+vi.mock('../../utils/oauth.ts', () => ({
+  generateRandomString: (len: number) => h.generateRandomString(len),
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  sha256: (s: string) => h.sha256(s),
+  GOOGLE_OAUTH_STORAGE_KEY: 'goog_store',
+  GOOGLE_OAUTH_STORAGE_STATE_KEY: 'goog_state',
+  GOOGLE_OAUTH_STORAGE_PKCE_VERIFIER_KEY: 'goog_pkce',
+}))
+
+import AuthLoginPage from './AuthLoginPage'
+
+describe('AuthLoginPage', () => {
+  beforeEach(() => {
+    h.login.mockClear()
+    h.navigate.mockClear()
+    h.generateRandomString.mockClear()
+    h.sha256.mockClear()
+    h.genIndex = 0
+    sessionStorage.clear()
+  })
+
+  it('renders and keeps submit disabled until fields are valid', () => {
+    const { container } = render(
+      <MemoryRouter>
+        <AuthLoginPage />
+      </MemoryRouter>,
+    )
+
+    const submit = container.querySelector('#join') as HTMLButtonElement
+    expect(submit).toBeDisabled()
+  })
+
+  it('submits with valid credentials, toggles loading, and navigates home', async () => {
+    let resolveLogin!: () => void
+    h.login.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveLogin = resolve
+        }),
+    )
+
+    const { container } = render(
+      <MemoryRouter>
+        <AuthLoginPage />
+      </MemoryRouter>,
+    )
+
+    fireEvent.change(screen.getByPlaceholderText('Email'), {
+      target: { value: 'user@example.com' },
+    })
+    fireEvent.change(screen.getByPlaceholderText('Password'), {
+      target: { value: 'PPss11!!' },
+    })
+
+    const submit = container.querySelector('#join') as HTMLButtonElement
+    expect(submit).not.toBeDisabled()
+
+    fireEvent.click(submit)
+    expect(h.login).toHaveBeenCalledWith({
+      email: 'user@example.com',
+      password: 'PPss11!!',
+    })
+
+    expect(submit).toBeDisabled()
+
+    resolveLogin()
+    await waitFor(() => {
+      expect(h.navigate).toHaveBeenCalledWith('/')
+    })
+
+    expect(submit).not.toBeDisabled()
+  })
+
+  it('starts Google OAuth, stores state & verifier, and redirects with correct params', async () => {
+    const originalLocation = window.location
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    delete (window as any).location
+    // @ts-expect-error define minimal location
+    window.location = { href: '' } as Location
+
+    try {
+      const { container } = render(
+        <MemoryRouter>
+          <AuthLoginPage />
+        </MemoryRouter>,
+      )
+
+      const googleBtn = container.querySelector(
+        '#google-login-button',
+      ) as HTMLButtonElement
+      fireEvent.click(googleBtn)
+
+      expect(h.generateRandomString).toHaveBeenCalledTimes(2)
+      expect(h.generateRandomString).toHaveBeenNthCalledWith(1, 48)
+      expect(h.generateRandomString).toHaveBeenNthCalledWith(2, 64)
+      expect(h.sha256).toHaveBeenCalledWith('PKCE_Y')
+
+      await waitFor(() =>
+        expect(window.location.href).toContain(
+          'https://accounts.google.com/o/oauth2/auth?',
+        ),
+      )
+
+      const href = window.location.href
+      expect(href).toContain('client_id=TEST_CLIENT_ID')
+      expect(href).toContain(
+        'redirect_uri=https%3A%2F%2Fapp.example.com%2Fauth%2Fgoogle%2Fcallback',
+      )
+      expect(href).toContain('response_type=code')
+      expect(href).toContain('scope=openid+profile+email')
+      expect(href).toContain('state=STATE_X')
+      expect(href).toContain('code_challenge=CODE_CHALLENGE_HASH')
+      expect(href).toContain('code_challenge_method=S256')
+
+      const stored = JSON.parse(sessionStorage.getItem('goog_store') || '{}')
+      expect(stored['goog_state']).toBe('STATE_X')
+      expect(stored['goog_pkce']).toBe('PKCE_Y')
+    } finally {
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      window.location = originalLocation
+    }
+  })
+})

--- a/packages/quiz/src/pages/AuthLoginPage/components/AuthLoginPageUI/AuthLoginPageUI.test.tsx
+++ b/packages/quiz/src/pages/AuthLoginPage/components/AuthLoginPageUI/AuthLoginPageUI.test.tsx
@@ -1,13 +1,22 @@
-import { render } from '@testing-library/react'
+import { fireEvent, render, screen } from '@testing-library/react'
 import React from 'react'
 import { MemoryRouter } from 'react-router-dom'
-import { describe, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('./text.utils.ts', () => ({
+  getTitle: () => 'Welcome back!',
+  getMessage: () => 'Please sign in to continue.',
+}))
 
 import AuthLoginPageUI from './AuthLoginPageUI'
 
 describe('AuthLoginPageUI', () => {
-  it('should render AuthLoginPage', async () => {
-    render(
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('renders base UI with title, message and links', () => {
+    const { container } = render(
       <MemoryRouter>
         <AuthLoginPageUI
           loading={false}
@@ -16,5 +25,132 @@ describe('AuthLoginPageUI', () => {
         />
       </MemoryRouter>,
     )
+
+    expect(screen.getByText('Welcome back!')).toBeInTheDocument()
+    expect(screen.getByText('Please sign in to continue.')).toBeInTheDocument()
+
+    // Links
+    expect(
+      screen.getByRole('link', { name: /Forgot your password\?/i }),
+    ).toHaveAttribute('href', '/auth/password/forgot')
+    expect(
+      screen.getByRole('link', {
+        name: /New here\? Join the fun and create your account!/i,
+      }),
+    ).toHaveAttribute('href', '/auth/register')
+
+    // Join button should be disabled initially (no valid fields yet)
+    const joinBtn = container.querySelector('#join') as HTMLButtonElement
+    expect(joinBtn).toBeDisabled()
+
+    expect(container).toMatchSnapshot()
+  })
+
+  it('enables submit when email and password are valid, then submits values', () => {
+    const onSubmit = vi.fn()
+    const { container } = render(
+      <MemoryRouter>
+        <AuthLoginPageUI
+          loading={false}
+          onSubmit={onSubmit}
+          onGoogleClick={() => undefined}
+        />
+      </MemoryRouter>,
+    )
+
+    const email = screen.getByPlaceholderText('Email') as HTMLInputElement
+    const password = screen.getByPlaceholderText('Password') as HTMLInputElement
+    const form = email.closest('form') as HTMLFormElement
+    const joinBtn = container.querySelector('#join') as HTMLButtonElement
+
+    // Start disabled
+    expect(joinBtn).toBeDisabled()
+
+    // Type a valid email
+    fireEvent.change(email, { target: { value: 'user@example.com' } })
+    // Still disabled because password not valid yet
+    expect(joinBtn).toBeDisabled()
+
+    // Type a strong password matching the regex (≥2 upper, ≥2 lower, ≥2 digits, ≥2 symbols)
+    fireEvent.change(password, { target: { value: 'AAaa11!!' } })
+
+    // Button should become enabled once both fields are valid
+    expect(joinBtn).not.toBeDisabled()
+
+    // Submit the form
+    fireEvent.submit(form)
+    expect(onSubmit).toHaveBeenCalledTimes(1)
+    expect(onSubmit).toHaveBeenCalledWith({
+      email: 'user@example.com',
+      password: 'AAaa11!!',
+    })
+
+    expect(container).toMatchSnapshot()
+  })
+
+  it('respects loading state: disables inputs and button, shows loading on submit', () => {
+    const { container } = render(
+      <MemoryRouter>
+        <AuthLoginPageUI
+          loading={true}
+          onSubmit={() => undefined}
+          onGoogleClick={() => undefined}
+        />
+      </MemoryRouter>,
+    )
+
+    const email = screen.getByPlaceholderText('Email') as HTMLInputElement
+    const password = screen.getByPlaceholderText('Password') as HTMLInputElement
+    const joinBtn = container.querySelector('#join') as HTMLButtonElement
+
+    expect(email).toBeDisabled()
+    expect(password).toBeDisabled()
+    expect(joinBtn).toBeDisabled()
+
+    expect(container).toMatchSnapshot()
+  })
+
+  it('fires Google button handler', () => {
+    const onGoogleClick = vi.fn()
+    const { container } = render(
+      <MemoryRouter>
+        <AuthLoginPageUI
+          loading={false}
+          onSubmit={() => undefined}
+          onGoogleClick={onGoogleClick}
+        />
+      </MemoryRouter>,
+    )
+
+    const googleBtn = container.querySelector(
+      '#google-login-button',
+    ) as HTMLButtonElement
+    fireEvent.click(googleBtn)
+    expect(onGoogleClick).toHaveBeenCalledTimes(1)
+
+    expect(container).toMatchSnapshot()
+  })
+
+  it('keeps submit disabled when fields are invalid', () => {
+    const { container } = render(
+      <MemoryRouter>
+        <AuthLoginPageUI
+          loading={false}
+          onSubmit={() => undefined}
+          onGoogleClick={() => undefined}
+        />
+      </MemoryRouter>,
+    )
+
+    const email = screen.getByPlaceholderText('Email') as HTMLInputElement
+    const password = screen.getByPlaceholderText('Password') as HTMLInputElement
+    const joinBtn = container.querySelector('#join') as HTMLButtonElement
+
+    // Invalid email and weak password
+    fireEvent.change(email, { target: { value: 'not-an-email' } })
+    fireEvent.change(password, { target: { value: 'weak' } })
+
+    expect(joinBtn).toBeDisabled()
+    expect(container).toMatchSnapshot()
   })
 })

--- a/packages/quiz/src/pages/AuthLoginPage/components/AuthLoginPageUI/AuthLoginPageUI.tsx
+++ b/packages/quiz/src/pages/AuthLoginPage/components/AuthLoginPageUI/AuthLoginPageUI.tsx
@@ -22,7 +22,7 @@ import {
 } from '../../../../components'
 
 import styles from './AuthLoginPageUI.module.scss'
-import { getMessage, getTitle } from './helpers.ts'
+import { getMessage, getTitle } from './text.utils.ts'
 
 export type LoginFormFields = AuthLoginRequestDto
 

--- a/packages/quiz/src/pages/AuthLoginPage/components/AuthLoginPageUI/__snapshots__/AuthLoginPageUI.test.tsx.snap
+++ b/packages/quiz/src/pages/AuthLoginPage/components/AuthLoginPageUI/__snapshots__/AuthLoginPageUI.test.tsx.snap
@@ -1,0 +1,2305 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`AuthLoginPageUI > enables submit when email and password are valid, then submits values (snapshot) 1`] = `
+<div>
+  <div
+    class="main"
+  >
+    <div
+      class="header"
+    >
+      <button
+        class="logo"
+      >
+        <img
+          alt="Klurigo"
+          class="icon"
+          src="/src/assets/images/klurigo-icon.svg"
+        />
+        <span
+          class="text"
+        >
+          Klurigo
+        </span>
+      </button>
+      <div
+        class="side"
+      >
+        <a
+          data-discover="true"
+          href="/auth/login"
+        >
+          Login
+        </a>
+      </div>
+    </div>
+    <div
+      class="content startAlign"
+    >
+      <div
+        class="contentWrapper fullWidth"
+      >
+        <div
+          class="contentInner"
+        >
+          <div
+            class="card kindCallToAction sizeLarge center"
+          >
+            <button
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                class="svg-inline--fa fa-xmark"
+                data-icon="xmark"
+                data-prefix="fas"
+                role="img"
+                viewBox="0 0 384 512"
+              >
+                <path
+                  d="M55.1 73.4c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3L147.2 256 9.9 393.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0L192.5 301.3 329.9 438.6c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3L237.8 256 375.1 118.6c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0L192.5 210.7 55.1 73.4z"
+                  fill="currentColor"
+                />
+              </svg>
+            </button>
+            <div
+              class="content"
+            >
+              <span>
+                Hey quiz champion! Did your brainy adventures happen on
+                 
+                <a
+                  href="https://quiz.emilhornlund.com"
+                >
+                  quiz.emilhornlund.com
+                </a>
+                ? No worries— we can save all your quiz creations and epic game stats! Just pop back to
+                 
+                <a
+                  href="https://quiz.emilhornlund.com"
+                >
+                  quiz.emilhornlund.com
+                </a>
+                 one last time, and we’ll magically teleport everything over to
+                 
+                <b>
+                  <i>
+                    klurigo.com
+                  </i>
+                </b>
+                . Ready to blast off your data?
+              </span>
+            </div>
+          </div>
+          <div
+            class="typography title medium"
+          >
+            Welcome back!
+          </div>
+          <div
+            class="typography text small"
+          >
+            Please sign in to continue.
+          </div>
+          <form
+            class="loginForm"
+          >
+            <div
+              class="inputContainer"
+            >
+              <div
+                class="textFieldInputContainer textFieldInputKindPrimary"
+              >
+                <input
+                  class="textfield"
+                  data-testid="test-email-textfield"
+                  id="email"
+                  maxlength="128"
+                  minlength="6"
+                  name="email"
+                  placeholder="Email"
+                  type="text"
+                  value="user@example.com"
+                />
+              </div>
+            </div>
+            <div
+              class="inputContainer"
+            >
+              <div
+                class="textFieldInputContainer textFieldInputKindPrimary"
+              >
+                <input
+                  class="textfield"
+                  data-testid="test-password-textfield"
+                  id="password"
+                  maxlength="128"
+                  minlength="8"
+                  name="password"
+                  placeholder="Password"
+                  type="password"
+                  value="AAaa11!!"
+                />
+              </div>
+            </div>
+            <a
+              data-discover="true"
+              href="/auth/password/forgot"
+            >
+              <div
+                class="typography link small"
+              >
+                Forgot your password?
+              </div>
+            </a>
+            <div
+              class="buttonInputContainer buttonInputKindCallToAction"
+            >
+              <button
+                data-testid="test-join-button"
+                id="join"
+                name="join"
+                type="submit"
+              >
+                <span>
+                  Let's go!
+                </span>
+                <svg
+                  aria-hidden="true"
+                  class="svg-inline--fa fa-arrow-right"
+                  data-icon="arrow-right"
+                  data-prefix="fas"
+                  role="img"
+                  viewBox="0 0 512 512"
+                >
+                  <path
+                    d="M502.6 278.6c12.5-12.5 12.5-32.8 0-45.3l-160-160c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3L402.7 224 32 224c-17.7 0-32 14.3-32 32s14.3 32 32 32l370.7 0-105.4 105.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0l160-160z"
+                    fill="currentColor"
+                  />
+                </svg>
+              </button>
+            </div>
+          </form>
+          <a
+            data-discover="true"
+            href="/auth/register"
+          >
+            <div
+              class="typography link small"
+            >
+              New here? Join the fun and create your account!
+            </div>
+          </a>
+          <div
+            class="pageDivider"
+          />
+          <div
+            class="authProviderButton"
+          >
+            <div
+              class="buttonInputContainer buttonInputKindPrimary"
+            >
+              <button
+                data-testid="test-google-login-button-button"
+                id="google-login-button"
+                name="google-login-button"
+                type="button"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="svg-inline--fa fa-google"
+                  data-icon="google"
+                  data-prefix="fab"
+                  role="img"
+                  viewBox="0 0 512 512"
+                >
+                  <path
+                    d="M500 261.8C500 403.3 403.1 504 260 504 122.8 504 12 393.2 12 256S122.8 8 260 8c66.8 0 123 24.5 166.3 64.9l-67.5 64.9c-88.3-85.2-252.5-21.2-252.5 118.2 0 86.5 69.1 156.6 153.7 156.6 98.2 0 135-70.4 140.8-106.9l-140.8 0 0-85.3 236.1 0c2.3 12.7 3.9 24.9 3.9 41.4z"
+                    fill="currentColor"
+                  />
+                </svg>
+                <span>
+                  Continue with Google
+                </span>
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`AuthLoginPageUI > enables submit when email and password are valid, then submits values 1`] = `
+<div>
+  <div
+    class="main"
+  >
+    <div
+      class="header"
+    >
+      <button
+        class="logo"
+      >
+        <img
+          alt="Klurigo"
+          class="icon"
+          src="/src/assets/images/klurigo-icon.svg"
+        />
+        <span
+          class="text"
+        >
+          Klurigo
+        </span>
+      </button>
+      <div
+        class="side"
+      >
+        <a
+          data-discover="true"
+          href="/auth/login"
+        >
+          Login
+        </a>
+      </div>
+    </div>
+    <div
+      class="content startAlign"
+    >
+      <div
+        class="contentWrapper fullWidth"
+      >
+        <div
+          class="contentInner"
+        >
+          <div
+            class="card kindCallToAction sizeLarge center"
+          >
+            <button
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                class="svg-inline--fa fa-xmark"
+                data-icon="xmark"
+                data-prefix="fas"
+                role="img"
+                viewBox="0 0 384 512"
+              >
+                <path
+                  d="M55.1 73.4c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3L147.2 256 9.9 393.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0L192.5 301.3 329.9 438.6c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3L237.8 256 375.1 118.6c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0L192.5 210.7 55.1 73.4z"
+                  fill="currentColor"
+                />
+              </svg>
+            </button>
+            <div
+              class="content"
+            >
+              <span>
+                Hey quiz champion! Did your brainy adventures happen on
+                 
+                <a
+                  href="https://quiz.emilhornlund.com"
+                >
+                  quiz.emilhornlund.com
+                </a>
+                ? No worries— we can save all your quiz creations and epic game stats! Just pop back to
+                 
+                <a
+                  href="https://quiz.emilhornlund.com"
+                >
+                  quiz.emilhornlund.com
+                </a>
+                 one last time, and we’ll magically teleport everything over to
+                 
+                <b>
+                  <i>
+                    klurigo.com
+                  </i>
+                </b>
+                . Ready to blast off your data?
+              </span>
+            </div>
+          </div>
+          <div
+            class="typography title medium"
+          >
+            Welcome back!
+          </div>
+          <div
+            class="typography text small"
+          >
+            Please sign in to continue.
+          </div>
+          <form
+            class="loginForm"
+          >
+            <div
+              class="inputContainer"
+            >
+              <div
+                class="textFieldInputContainer textFieldInputKindPrimary"
+              >
+                <input
+                  class="textfield"
+                  data-testid="test-email-textfield"
+                  id="email"
+                  maxlength="128"
+                  minlength="6"
+                  name="email"
+                  placeholder="Email"
+                  type="text"
+                  value="user@example.com"
+                />
+              </div>
+            </div>
+            <div
+              class="inputContainer"
+            >
+              <div
+                class="textFieldInputContainer textFieldInputKindPrimary"
+              >
+                <input
+                  class="textfield"
+                  data-testid="test-password-textfield"
+                  id="password"
+                  maxlength="128"
+                  minlength="8"
+                  name="password"
+                  placeholder="Password"
+                  type="password"
+                  value="AAaa11!!"
+                />
+              </div>
+            </div>
+            <a
+              data-discover="true"
+              href="/auth/password/forgot"
+            >
+              <div
+                class="typography link small"
+              >
+                Forgot your password?
+              </div>
+            </a>
+            <div
+              class="buttonInputContainer buttonInputKindCallToAction"
+            >
+              <button
+                data-testid="test-join-button"
+                id="join"
+                name="join"
+                type="submit"
+              >
+                <span>
+                  Let's go!
+                </span>
+                <svg
+                  aria-hidden="true"
+                  class="svg-inline--fa fa-arrow-right"
+                  data-icon="arrow-right"
+                  data-prefix="fas"
+                  role="img"
+                  viewBox="0 0 512 512"
+                >
+                  <path
+                    d="M502.6 278.6c12.5-12.5 12.5-32.8 0-45.3l-160-160c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3L402.7 224 32 224c-17.7 0-32 14.3-32 32s14.3 32 32 32l370.7 0-105.4 105.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0l160-160z"
+                    fill="currentColor"
+                  />
+                </svg>
+              </button>
+            </div>
+          </form>
+          <a
+            data-discover="true"
+            href="/auth/register"
+          >
+            <div
+              class="typography link small"
+            >
+              New here? Join the fun and create your account!
+            </div>
+          </a>
+          <div
+            class="pageDivider"
+          />
+          <div
+            class="authProviderButton"
+          >
+            <div
+              class="buttonInputContainer buttonInputKindPrimary"
+            >
+              <button
+                data-testid="test-google-login-button-button"
+                id="google-login-button"
+                name="google-login-button"
+                type="button"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="svg-inline--fa fa-google"
+                  data-icon="google"
+                  data-prefix="fab"
+                  role="img"
+                  viewBox="0 0 512 512"
+                >
+                  <path
+                    d="M500 261.8C500 403.3 403.1 504 260 504 122.8 504 12 393.2 12 256S122.8 8 260 8c66.8 0 123 24.5 166.3 64.9l-67.5 64.9c-88.3-85.2-252.5-21.2-252.5 118.2 0 86.5 69.1 156.6 153.7 156.6 98.2 0 135-70.4 140.8-106.9l-140.8 0 0-85.3 236.1 0c2.3 12.7 3.9 24.9 3.9 41.4z"
+                    fill="currentColor"
+                  />
+                </svg>
+                <span>
+                  Continue with Google
+                </span>
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`AuthLoginPageUI > fires Google button handler (snapshot) 1`] = `
+<div>
+  <div
+    class="main"
+  >
+    <div
+      class="header"
+    >
+      <button
+        class="logo"
+      >
+        <img
+          alt="Klurigo"
+          class="icon"
+          src="/src/assets/images/klurigo-icon.svg"
+        />
+        <span
+          class="text"
+        >
+          Klurigo
+        </span>
+      </button>
+      <div
+        class="side"
+      >
+        <a
+          data-discover="true"
+          href="/auth/login"
+        >
+          Login
+        </a>
+      </div>
+    </div>
+    <div
+      class="content startAlign"
+    >
+      <div
+        class="contentWrapper fullWidth"
+      >
+        <div
+          class="contentInner"
+        >
+          <div
+            class="card kindCallToAction sizeLarge center"
+          >
+            <button
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                class="svg-inline--fa fa-xmark"
+                data-icon="xmark"
+                data-prefix="fas"
+                role="img"
+                viewBox="0 0 384 512"
+              >
+                <path
+                  d="M55.1 73.4c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3L147.2 256 9.9 393.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0L192.5 301.3 329.9 438.6c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3L237.8 256 375.1 118.6c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0L192.5 210.7 55.1 73.4z"
+                  fill="currentColor"
+                />
+              </svg>
+            </button>
+            <div
+              class="content"
+            >
+              <span>
+                Hey quiz champion! Did your brainy adventures happen on
+                 
+                <a
+                  href="https://quiz.emilhornlund.com"
+                >
+                  quiz.emilhornlund.com
+                </a>
+                ? No worries— we can save all your quiz creations and epic game stats! Just pop back to
+                 
+                <a
+                  href="https://quiz.emilhornlund.com"
+                >
+                  quiz.emilhornlund.com
+                </a>
+                 one last time, and we’ll magically teleport everything over to
+                 
+                <b>
+                  <i>
+                    klurigo.com
+                  </i>
+                </b>
+                . Ready to blast off your data?
+              </span>
+            </div>
+          </div>
+          <div
+            class="typography title medium"
+          >
+            Welcome back!
+          </div>
+          <div
+            class="typography text small"
+          >
+            Please sign in to continue.
+          </div>
+          <form
+            class="loginForm"
+          >
+            <div
+              class="inputContainer"
+            >
+              <div
+                class="textFieldInputContainer textFieldInputKindPrimary"
+              >
+                <input
+                  class="textfield"
+                  data-testid="test-email-textfield"
+                  id="email"
+                  maxlength="128"
+                  minlength="6"
+                  name="email"
+                  placeholder="Email"
+                  type="text"
+                  value=""
+                />
+              </div>
+            </div>
+            <div
+              class="inputContainer"
+            >
+              <div
+                class="textFieldInputContainer textFieldInputKindPrimary"
+              >
+                <input
+                  class="textfield"
+                  data-testid="test-password-textfield"
+                  id="password"
+                  maxlength="128"
+                  minlength="8"
+                  name="password"
+                  placeholder="Password"
+                  type="password"
+                  value=""
+                />
+              </div>
+            </div>
+            <a
+              data-discover="true"
+              href="/auth/password/forgot"
+            >
+              <div
+                class="typography link small"
+              >
+                Forgot your password?
+              </div>
+            </a>
+            <div
+              class="buttonInputContainer buttonInputKindCallToAction"
+            >
+              <button
+                data-testid="test-join-button"
+                disabled=""
+                id="join"
+                name="join"
+                type="submit"
+              >
+                <span>
+                  Let's go!
+                </span>
+                <svg
+                  aria-hidden="true"
+                  class="svg-inline--fa fa-arrow-right"
+                  data-icon="arrow-right"
+                  data-prefix="fas"
+                  role="img"
+                  viewBox="0 0 512 512"
+                >
+                  <path
+                    d="M502.6 278.6c12.5-12.5 12.5-32.8 0-45.3l-160-160c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3L402.7 224 32 224c-17.7 0-32 14.3-32 32s14.3 32 32 32l370.7 0-105.4 105.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0l160-160z"
+                    fill="currentColor"
+                  />
+                </svg>
+              </button>
+            </div>
+          </form>
+          <a
+            data-discover="true"
+            href="/auth/register"
+          >
+            <div
+              class="typography link small"
+            >
+              New here? Join the fun and create your account!
+            </div>
+          </a>
+          <div
+            class="pageDivider"
+          />
+          <div
+            class="authProviderButton"
+          >
+            <div
+              class="buttonInputContainer buttonInputKindPrimary"
+            >
+              <button
+                data-testid="test-google-login-button-button"
+                id="google-login-button"
+                name="google-login-button"
+                type="button"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="svg-inline--fa fa-google"
+                  data-icon="google"
+                  data-prefix="fab"
+                  role="img"
+                  viewBox="0 0 512 512"
+                >
+                  <path
+                    d="M500 261.8C500 403.3 403.1 504 260 504 122.8 504 12 393.2 12 256S122.8 8 260 8c66.8 0 123 24.5 166.3 64.9l-67.5 64.9c-88.3-85.2-252.5-21.2-252.5 118.2 0 86.5 69.1 156.6 153.7 156.6 98.2 0 135-70.4 140.8-106.9l-140.8 0 0-85.3 236.1 0c2.3 12.7 3.9 24.9 3.9 41.4z"
+                    fill="currentColor"
+                  />
+                </svg>
+                <span>
+                  Continue with Google
+                </span>
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`AuthLoginPageUI > fires Google button handler 1`] = `
+<div>
+  <div
+    class="main"
+  >
+    <div
+      class="header"
+    >
+      <button
+        class="logo"
+      >
+        <img
+          alt="Klurigo"
+          class="icon"
+          src="/src/assets/images/klurigo-icon.svg"
+        />
+        <span
+          class="text"
+        >
+          Klurigo
+        </span>
+      </button>
+      <div
+        class="side"
+      >
+        <a
+          data-discover="true"
+          href="/auth/login"
+        >
+          Login
+        </a>
+      </div>
+    </div>
+    <div
+      class="content startAlign"
+    >
+      <div
+        class="contentWrapper fullWidth"
+      >
+        <div
+          class="contentInner"
+        >
+          <div
+            class="card kindCallToAction sizeLarge center"
+          >
+            <button
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                class="svg-inline--fa fa-xmark"
+                data-icon="xmark"
+                data-prefix="fas"
+                role="img"
+                viewBox="0 0 384 512"
+              >
+                <path
+                  d="M55.1 73.4c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3L147.2 256 9.9 393.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0L192.5 301.3 329.9 438.6c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3L237.8 256 375.1 118.6c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0L192.5 210.7 55.1 73.4z"
+                  fill="currentColor"
+                />
+              </svg>
+            </button>
+            <div
+              class="content"
+            >
+              <span>
+                Hey quiz champion! Did your brainy adventures happen on
+                 
+                <a
+                  href="https://quiz.emilhornlund.com"
+                >
+                  quiz.emilhornlund.com
+                </a>
+                ? No worries— we can save all your quiz creations and epic game stats! Just pop back to
+                 
+                <a
+                  href="https://quiz.emilhornlund.com"
+                >
+                  quiz.emilhornlund.com
+                </a>
+                 one last time, and we’ll magically teleport everything over to
+                 
+                <b>
+                  <i>
+                    klurigo.com
+                  </i>
+                </b>
+                . Ready to blast off your data?
+              </span>
+            </div>
+          </div>
+          <div
+            class="typography title medium"
+          >
+            Welcome back!
+          </div>
+          <div
+            class="typography text small"
+          >
+            Please sign in to continue.
+          </div>
+          <form
+            class="loginForm"
+          >
+            <div
+              class="inputContainer"
+            >
+              <div
+                class="textFieldInputContainer textFieldInputKindPrimary"
+              >
+                <input
+                  class="textfield"
+                  data-testid="test-email-textfield"
+                  id="email"
+                  maxlength="128"
+                  minlength="6"
+                  name="email"
+                  placeholder="Email"
+                  type="text"
+                  value=""
+                />
+              </div>
+            </div>
+            <div
+              class="inputContainer"
+            >
+              <div
+                class="textFieldInputContainer textFieldInputKindPrimary"
+              >
+                <input
+                  class="textfield"
+                  data-testid="test-password-textfield"
+                  id="password"
+                  maxlength="128"
+                  minlength="8"
+                  name="password"
+                  placeholder="Password"
+                  type="password"
+                  value=""
+                />
+              </div>
+            </div>
+            <a
+              data-discover="true"
+              href="/auth/password/forgot"
+            >
+              <div
+                class="typography link small"
+              >
+                Forgot your password?
+              </div>
+            </a>
+            <div
+              class="buttonInputContainer buttonInputKindCallToAction"
+            >
+              <button
+                data-testid="test-join-button"
+                disabled=""
+                id="join"
+                name="join"
+                type="submit"
+              >
+                <span>
+                  Let's go!
+                </span>
+                <svg
+                  aria-hidden="true"
+                  class="svg-inline--fa fa-arrow-right"
+                  data-icon="arrow-right"
+                  data-prefix="fas"
+                  role="img"
+                  viewBox="0 0 512 512"
+                >
+                  <path
+                    d="M502.6 278.6c12.5-12.5 12.5-32.8 0-45.3l-160-160c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3L402.7 224 32 224c-17.7 0-32 14.3-32 32s14.3 32 32 32l370.7 0-105.4 105.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0l160-160z"
+                    fill="currentColor"
+                  />
+                </svg>
+              </button>
+            </div>
+          </form>
+          <a
+            data-discover="true"
+            href="/auth/register"
+          >
+            <div
+              class="typography link small"
+            >
+              New here? Join the fun and create your account!
+            </div>
+          </a>
+          <div
+            class="pageDivider"
+          />
+          <div
+            class="authProviderButton"
+          >
+            <div
+              class="buttonInputContainer buttonInputKindPrimary"
+            >
+              <button
+                data-testid="test-google-login-button-button"
+                id="google-login-button"
+                name="google-login-button"
+                type="button"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="svg-inline--fa fa-google"
+                  data-icon="google"
+                  data-prefix="fab"
+                  role="img"
+                  viewBox="0 0 512 512"
+                >
+                  <path
+                    d="M500 261.8C500 403.3 403.1 504 260 504 122.8 504 12 393.2 12 256S122.8 8 260 8c66.8 0 123 24.5 166.3 64.9l-67.5 64.9c-88.3-85.2-252.5-21.2-252.5 118.2 0 86.5 69.1 156.6 153.7 156.6 98.2 0 135-70.4 140.8-106.9l-140.8 0 0-85.3 236.1 0c2.3 12.7 3.9 24.9 3.9 41.4z"
+                    fill="currentColor"
+                  />
+                </svg>
+                <span>
+                  Continue with Google
+                </span>
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`AuthLoginPageUI > keeps submit disabled when fields are invalid (snapshot) 1`] = `
+<div>
+  <div
+    class="main"
+  >
+    <div
+      class="header"
+    >
+      <button
+        class="logo"
+      >
+        <img
+          alt="Klurigo"
+          class="icon"
+          src="/src/assets/images/klurigo-icon.svg"
+        />
+        <span
+          class="text"
+        >
+          Klurigo
+        </span>
+      </button>
+      <div
+        class="side"
+      >
+        <a
+          data-discover="true"
+          href="/auth/login"
+        >
+          Login
+        </a>
+      </div>
+    </div>
+    <div
+      class="content startAlign"
+    >
+      <div
+        class="contentWrapper fullWidth"
+      >
+        <div
+          class="contentInner"
+        >
+          <div
+            class="card kindCallToAction sizeLarge center"
+          >
+            <button
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                class="svg-inline--fa fa-xmark"
+                data-icon="xmark"
+                data-prefix="fas"
+                role="img"
+                viewBox="0 0 384 512"
+              >
+                <path
+                  d="M55.1 73.4c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3L147.2 256 9.9 393.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0L192.5 301.3 329.9 438.6c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3L237.8 256 375.1 118.6c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0L192.5 210.7 55.1 73.4z"
+                  fill="currentColor"
+                />
+              </svg>
+            </button>
+            <div
+              class="content"
+            >
+              <span>
+                Hey quiz champion! Did your brainy adventures happen on
+                 
+                <a
+                  href="https://quiz.emilhornlund.com"
+                >
+                  quiz.emilhornlund.com
+                </a>
+                ? No worries— we can save all your quiz creations and epic game stats! Just pop back to
+                 
+                <a
+                  href="https://quiz.emilhornlund.com"
+                >
+                  quiz.emilhornlund.com
+                </a>
+                 one last time, and we’ll magically teleport everything over to
+                 
+                <b>
+                  <i>
+                    klurigo.com
+                  </i>
+                </b>
+                . Ready to blast off your data?
+              </span>
+            </div>
+          </div>
+          <div
+            class="typography title medium"
+          >
+            Welcome back!
+          </div>
+          <div
+            class="typography text small"
+          >
+            Please sign in to continue.
+          </div>
+          <form
+            class="loginForm"
+          >
+            <div
+              class="inputContainer"
+            >
+              <div
+                class="textFieldInputContainer textFieldInputKindPrimary"
+              >
+                <input
+                  class="textfield"
+                  data-testid="test-email-textfield"
+                  id="email"
+                  maxlength="128"
+                  minlength="6"
+                  name="email"
+                  placeholder="Email"
+                  type="text"
+                  value="not-an-email"
+                />
+              </div>
+            </div>
+            <div
+              class="inputContainer"
+            >
+              <div
+                class="textFieldInputContainer textFieldInputKindPrimary"
+              >
+                <input
+                  class="textfield"
+                  data-testid="test-password-textfield"
+                  id="password"
+                  maxlength="128"
+                  minlength="8"
+                  name="password"
+                  placeholder="Password"
+                  type="password"
+                  value="weak"
+                />
+              </div>
+            </div>
+            <a
+              data-discover="true"
+              href="/auth/password/forgot"
+            >
+              <div
+                class="typography link small"
+              >
+                Forgot your password?
+              </div>
+            </a>
+            <div
+              class="buttonInputContainer buttonInputKindCallToAction"
+            >
+              <button
+                data-testid="test-join-button"
+                disabled=""
+                id="join"
+                name="join"
+                type="submit"
+              >
+                <span>
+                  Let's go!
+                </span>
+                <svg
+                  aria-hidden="true"
+                  class="svg-inline--fa fa-arrow-right"
+                  data-icon="arrow-right"
+                  data-prefix="fas"
+                  role="img"
+                  viewBox="0 0 512 512"
+                >
+                  <path
+                    d="M502.6 278.6c12.5-12.5 12.5-32.8 0-45.3l-160-160c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3L402.7 224 32 224c-17.7 0-32 14.3-32 32s14.3 32 32 32l370.7 0-105.4 105.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0l160-160z"
+                    fill="currentColor"
+                  />
+                </svg>
+              </button>
+            </div>
+          </form>
+          <a
+            data-discover="true"
+            href="/auth/register"
+          >
+            <div
+              class="typography link small"
+            >
+              New here? Join the fun and create your account!
+            </div>
+          </a>
+          <div
+            class="pageDivider"
+          />
+          <div
+            class="authProviderButton"
+          >
+            <div
+              class="buttonInputContainer buttonInputKindPrimary"
+            >
+              <button
+                data-testid="test-google-login-button-button"
+                id="google-login-button"
+                name="google-login-button"
+                type="button"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="svg-inline--fa fa-google"
+                  data-icon="google"
+                  data-prefix="fab"
+                  role="img"
+                  viewBox="0 0 512 512"
+                >
+                  <path
+                    d="M500 261.8C500 403.3 403.1 504 260 504 122.8 504 12 393.2 12 256S122.8 8 260 8c66.8 0 123 24.5 166.3 64.9l-67.5 64.9c-88.3-85.2-252.5-21.2-252.5 118.2 0 86.5 69.1 156.6 153.7 156.6 98.2 0 135-70.4 140.8-106.9l-140.8 0 0-85.3 236.1 0c2.3 12.7 3.9 24.9 3.9 41.4z"
+                    fill="currentColor"
+                  />
+                </svg>
+                <span>
+                  Continue with Google
+                </span>
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`AuthLoginPageUI > keeps submit disabled when fields are invalid 1`] = `
+<div>
+  <div
+    class="main"
+  >
+    <div
+      class="header"
+    >
+      <button
+        class="logo"
+      >
+        <img
+          alt="Klurigo"
+          class="icon"
+          src="/src/assets/images/klurigo-icon.svg"
+        />
+        <span
+          class="text"
+        >
+          Klurigo
+        </span>
+      </button>
+      <div
+        class="side"
+      >
+        <a
+          data-discover="true"
+          href="/auth/login"
+        >
+          Login
+        </a>
+      </div>
+    </div>
+    <div
+      class="content startAlign"
+    >
+      <div
+        class="contentWrapper fullWidth"
+      >
+        <div
+          class="contentInner"
+        >
+          <div
+            class="card kindCallToAction sizeLarge center"
+          >
+            <button
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                class="svg-inline--fa fa-xmark"
+                data-icon="xmark"
+                data-prefix="fas"
+                role="img"
+                viewBox="0 0 384 512"
+              >
+                <path
+                  d="M55.1 73.4c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3L147.2 256 9.9 393.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0L192.5 301.3 329.9 438.6c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3L237.8 256 375.1 118.6c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0L192.5 210.7 55.1 73.4z"
+                  fill="currentColor"
+                />
+              </svg>
+            </button>
+            <div
+              class="content"
+            >
+              <span>
+                Hey quiz champion! Did your brainy adventures happen on
+                 
+                <a
+                  href="https://quiz.emilhornlund.com"
+                >
+                  quiz.emilhornlund.com
+                </a>
+                ? No worries— we can save all your quiz creations and epic game stats! Just pop back to
+                 
+                <a
+                  href="https://quiz.emilhornlund.com"
+                >
+                  quiz.emilhornlund.com
+                </a>
+                 one last time, and we’ll magically teleport everything over to
+                 
+                <b>
+                  <i>
+                    klurigo.com
+                  </i>
+                </b>
+                . Ready to blast off your data?
+              </span>
+            </div>
+          </div>
+          <div
+            class="typography title medium"
+          >
+            Welcome back!
+          </div>
+          <div
+            class="typography text small"
+          >
+            Please sign in to continue.
+          </div>
+          <form
+            class="loginForm"
+          >
+            <div
+              class="inputContainer"
+            >
+              <div
+                class="textFieldInputContainer textFieldInputKindPrimary"
+              >
+                <input
+                  class="textfield"
+                  data-testid="test-email-textfield"
+                  id="email"
+                  maxlength="128"
+                  minlength="6"
+                  name="email"
+                  placeholder="Email"
+                  type="text"
+                  value="not-an-email"
+                />
+              </div>
+            </div>
+            <div
+              class="inputContainer"
+            >
+              <div
+                class="textFieldInputContainer textFieldInputKindPrimary"
+              >
+                <input
+                  class="textfield"
+                  data-testid="test-password-textfield"
+                  id="password"
+                  maxlength="128"
+                  minlength="8"
+                  name="password"
+                  placeholder="Password"
+                  type="password"
+                  value="weak"
+                />
+              </div>
+            </div>
+            <a
+              data-discover="true"
+              href="/auth/password/forgot"
+            >
+              <div
+                class="typography link small"
+              >
+                Forgot your password?
+              </div>
+            </a>
+            <div
+              class="buttonInputContainer buttonInputKindCallToAction"
+            >
+              <button
+                data-testid="test-join-button"
+                disabled=""
+                id="join"
+                name="join"
+                type="submit"
+              >
+                <span>
+                  Let's go!
+                </span>
+                <svg
+                  aria-hidden="true"
+                  class="svg-inline--fa fa-arrow-right"
+                  data-icon="arrow-right"
+                  data-prefix="fas"
+                  role="img"
+                  viewBox="0 0 512 512"
+                >
+                  <path
+                    d="M502.6 278.6c12.5-12.5 12.5-32.8 0-45.3l-160-160c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3L402.7 224 32 224c-17.7 0-32 14.3-32 32s14.3 32 32 32l370.7 0-105.4 105.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0l160-160z"
+                    fill="currentColor"
+                  />
+                </svg>
+              </button>
+            </div>
+          </form>
+          <a
+            data-discover="true"
+            href="/auth/register"
+          >
+            <div
+              class="typography link small"
+            >
+              New here? Join the fun and create your account!
+            </div>
+          </a>
+          <div
+            class="pageDivider"
+          />
+          <div
+            class="authProviderButton"
+          >
+            <div
+              class="buttonInputContainer buttonInputKindPrimary"
+            >
+              <button
+                data-testid="test-google-login-button-button"
+                id="google-login-button"
+                name="google-login-button"
+                type="button"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="svg-inline--fa fa-google"
+                  data-icon="google"
+                  data-prefix="fab"
+                  role="img"
+                  viewBox="0 0 512 512"
+                >
+                  <path
+                    d="M500 261.8C500 403.3 403.1 504 260 504 122.8 504 12 393.2 12 256S122.8 8 260 8c66.8 0 123 24.5 166.3 64.9l-67.5 64.9c-88.3-85.2-252.5-21.2-252.5 118.2 0 86.5 69.1 156.6 153.7 156.6 98.2 0 135-70.4 140.8-106.9l-140.8 0 0-85.3 236.1 0c2.3 12.7 3.9 24.9 3.9 41.4z"
+                    fill="currentColor"
+                  />
+                </svg>
+                <span>
+                  Continue with Google
+                </span>
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`AuthLoginPageUI > renders base UI with title, message and links (snapshot) 1`] = `
+<div>
+  <div
+    class="main"
+  >
+    <div
+      class="header"
+    >
+      <button
+        class="logo"
+      >
+        <img
+          alt="Klurigo"
+          class="icon"
+          src="/src/assets/images/klurigo-icon.svg"
+        />
+        <span
+          class="text"
+        >
+          Klurigo
+        </span>
+      </button>
+      <div
+        class="side"
+      >
+        <a
+          data-discover="true"
+          href="/auth/login"
+        >
+          Login
+        </a>
+      </div>
+    </div>
+    <div
+      class="content startAlign"
+    >
+      <div
+        class="contentWrapper fullWidth"
+      >
+        <div
+          class="contentInner"
+        >
+          <div
+            class="card kindCallToAction sizeLarge center"
+          >
+            <button
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                class="svg-inline--fa fa-xmark"
+                data-icon="xmark"
+                data-prefix="fas"
+                role="img"
+                viewBox="0 0 384 512"
+              >
+                <path
+                  d="M55.1 73.4c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3L147.2 256 9.9 393.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0L192.5 301.3 329.9 438.6c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3L237.8 256 375.1 118.6c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0L192.5 210.7 55.1 73.4z"
+                  fill="currentColor"
+                />
+              </svg>
+            </button>
+            <div
+              class="content"
+            >
+              <span>
+                Hey quiz champion! Did your brainy adventures happen on
+                 
+                <a
+                  href="https://quiz.emilhornlund.com"
+                >
+                  quiz.emilhornlund.com
+                </a>
+                ? No worries— we can save all your quiz creations and epic game stats! Just pop back to
+                 
+                <a
+                  href="https://quiz.emilhornlund.com"
+                >
+                  quiz.emilhornlund.com
+                </a>
+                 one last time, and we’ll magically teleport everything over to
+                 
+                <b>
+                  <i>
+                    klurigo.com
+                  </i>
+                </b>
+                . Ready to blast off your data?
+              </span>
+            </div>
+          </div>
+          <div
+            class="typography title medium"
+          >
+            Welcome back!
+          </div>
+          <div
+            class="typography text small"
+          >
+            Please sign in to continue.
+          </div>
+          <form
+            class="loginForm"
+          >
+            <div
+              class="inputContainer"
+            >
+              <div
+                class="textFieldInputContainer textFieldInputKindPrimary"
+              >
+                <input
+                  class="textfield"
+                  data-testid="test-email-textfield"
+                  id="email"
+                  maxlength="128"
+                  minlength="6"
+                  name="email"
+                  placeholder="Email"
+                  type="text"
+                  value=""
+                />
+              </div>
+            </div>
+            <div
+              class="inputContainer"
+            >
+              <div
+                class="textFieldInputContainer textFieldInputKindPrimary"
+              >
+                <input
+                  class="textfield"
+                  data-testid="test-password-textfield"
+                  id="password"
+                  maxlength="128"
+                  minlength="8"
+                  name="password"
+                  placeholder="Password"
+                  type="password"
+                  value=""
+                />
+              </div>
+            </div>
+            <a
+              data-discover="true"
+              href="/auth/password/forgot"
+            >
+              <div
+                class="typography link small"
+              >
+                Forgot your password?
+              </div>
+            </a>
+            <div
+              class="buttonInputContainer buttonInputKindCallToAction"
+            >
+              <button
+                data-testid="test-join-button"
+                disabled=""
+                id="join"
+                name="join"
+                type="submit"
+              >
+                <span>
+                  Let's go!
+                </span>
+                <svg
+                  aria-hidden="true"
+                  class="svg-inline--fa fa-arrow-right"
+                  data-icon="arrow-right"
+                  data-prefix="fas"
+                  role="img"
+                  viewBox="0 0 512 512"
+                >
+                  <path
+                    d="M502.6 278.6c12.5-12.5 12.5-32.8 0-45.3l-160-160c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3L402.7 224 32 224c-17.7 0-32 14.3-32 32s14.3 32 32 32l370.7 0-105.4 105.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0l160-160z"
+                    fill="currentColor"
+                  />
+                </svg>
+              </button>
+            </div>
+          </form>
+          <a
+            data-discover="true"
+            href="/auth/register"
+          >
+            <div
+              class="typography link small"
+            >
+              New here? Join the fun and create your account!
+            </div>
+          </a>
+          <div
+            class="pageDivider"
+          />
+          <div
+            class="authProviderButton"
+          >
+            <div
+              class="buttonInputContainer buttonInputKindPrimary"
+            >
+              <button
+                data-testid="test-google-login-button-button"
+                id="google-login-button"
+                name="google-login-button"
+                type="button"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="svg-inline--fa fa-google"
+                  data-icon="google"
+                  data-prefix="fab"
+                  role="img"
+                  viewBox="0 0 512 512"
+                >
+                  <path
+                    d="M500 261.8C500 403.3 403.1 504 260 504 122.8 504 12 393.2 12 256S122.8 8 260 8c66.8 0 123 24.5 166.3 64.9l-67.5 64.9c-88.3-85.2-252.5-21.2-252.5 118.2 0 86.5 69.1 156.6 153.7 156.6 98.2 0 135-70.4 140.8-106.9l-140.8 0 0-85.3 236.1 0c2.3 12.7 3.9 24.9 3.9 41.4z"
+                    fill="currentColor"
+                  />
+                </svg>
+                <span>
+                  Continue with Google
+                </span>
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`AuthLoginPageUI > renders base UI with title, message and links 1`] = `
+<div>
+  <div
+    class="main"
+  >
+    <div
+      class="header"
+    >
+      <button
+        class="logo"
+      >
+        <img
+          alt="Klurigo"
+          class="icon"
+          src="/src/assets/images/klurigo-icon.svg"
+        />
+        <span
+          class="text"
+        >
+          Klurigo
+        </span>
+      </button>
+      <div
+        class="side"
+      >
+        <a
+          data-discover="true"
+          href="/auth/login"
+        >
+          Login
+        </a>
+      </div>
+    </div>
+    <div
+      class="content startAlign"
+    >
+      <div
+        class="contentWrapper fullWidth"
+      >
+        <div
+          class="contentInner"
+        >
+          <div
+            class="card kindCallToAction sizeLarge center"
+          >
+            <button
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                class="svg-inline--fa fa-xmark"
+                data-icon="xmark"
+                data-prefix="fas"
+                role="img"
+                viewBox="0 0 384 512"
+              >
+                <path
+                  d="M55.1 73.4c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3L147.2 256 9.9 393.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0L192.5 301.3 329.9 438.6c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3L237.8 256 375.1 118.6c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0L192.5 210.7 55.1 73.4z"
+                  fill="currentColor"
+                />
+              </svg>
+            </button>
+            <div
+              class="content"
+            >
+              <span>
+                Hey quiz champion! Did your brainy adventures happen on
+                 
+                <a
+                  href="https://quiz.emilhornlund.com"
+                >
+                  quiz.emilhornlund.com
+                </a>
+                ? No worries— we can save all your quiz creations and epic game stats! Just pop back to
+                 
+                <a
+                  href="https://quiz.emilhornlund.com"
+                >
+                  quiz.emilhornlund.com
+                </a>
+                 one last time, and we’ll magically teleport everything over to
+                 
+                <b>
+                  <i>
+                    klurigo.com
+                  </i>
+                </b>
+                . Ready to blast off your data?
+              </span>
+            </div>
+          </div>
+          <div
+            class="typography title medium"
+          >
+            Welcome back!
+          </div>
+          <div
+            class="typography text small"
+          >
+            Please sign in to continue.
+          </div>
+          <form
+            class="loginForm"
+          >
+            <div
+              class="inputContainer"
+            >
+              <div
+                class="textFieldInputContainer textFieldInputKindPrimary"
+              >
+                <input
+                  class="textfield"
+                  data-testid="test-email-textfield"
+                  id="email"
+                  maxlength="128"
+                  minlength="6"
+                  name="email"
+                  placeholder="Email"
+                  type="text"
+                  value=""
+                />
+              </div>
+            </div>
+            <div
+              class="inputContainer"
+            >
+              <div
+                class="textFieldInputContainer textFieldInputKindPrimary"
+              >
+                <input
+                  class="textfield"
+                  data-testid="test-password-textfield"
+                  id="password"
+                  maxlength="128"
+                  minlength="8"
+                  name="password"
+                  placeholder="Password"
+                  type="password"
+                  value=""
+                />
+              </div>
+            </div>
+            <a
+              data-discover="true"
+              href="/auth/password/forgot"
+            >
+              <div
+                class="typography link small"
+              >
+                Forgot your password?
+              </div>
+            </a>
+            <div
+              class="buttonInputContainer buttonInputKindCallToAction"
+            >
+              <button
+                data-testid="test-join-button"
+                disabled=""
+                id="join"
+                name="join"
+                type="submit"
+              >
+                <span>
+                  Let's go!
+                </span>
+                <svg
+                  aria-hidden="true"
+                  class="svg-inline--fa fa-arrow-right"
+                  data-icon="arrow-right"
+                  data-prefix="fas"
+                  role="img"
+                  viewBox="0 0 512 512"
+                >
+                  <path
+                    d="M502.6 278.6c12.5-12.5 12.5-32.8 0-45.3l-160-160c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3L402.7 224 32 224c-17.7 0-32 14.3-32 32s14.3 32 32 32l370.7 0-105.4 105.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0l160-160z"
+                    fill="currentColor"
+                  />
+                </svg>
+              </button>
+            </div>
+          </form>
+          <a
+            data-discover="true"
+            href="/auth/register"
+          >
+            <div
+              class="typography link small"
+            >
+              New here? Join the fun and create your account!
+            </div>
+          </a>
+          <div
+            class="pageDivider"
+          />
+          <div
+            class="authProviderButton"
+          >
+            <div
+              class="buttonInputContainer buttonInputKindPrimary"
+            >
+              <button
+                data-testid="test-google-login-button-button"
+                id="google-login-button"
+                name="google-login-button"
+                type="button"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="svg-inline--fa fa-google"
+                  data-icon="google"
+                  data-prefix="fab"
+                  role="img"
+                  viewBox="0 0 512 512"
+                >
+                  <path
+                    d="M500 261.8C500 403.3 403.1 504 260 504 122.8 504 12 393.2 12 256S122.8 8 260 8c66.8 0 123 24.5 166.3 64.9l-67.5 64.9c-88.3-85.2-252.5-21.2-252.5 118.2 0 86.5 69.1 156.6 153.7 156.6 98.2 0 135-70.4 140.8-106.9l-140.8 0 0-85.3 236.1 0c2.3 12.7 3.9 24.9 3.9 41.4z"
+                    fill="currentColor"
+                  />
+                </svg>
+                <span>
+                  Continue with Google
+                </span>
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`AuthLoginPageUI > respects loading state: disables inputs and button, shows loading on submit (snapshot) 1`] = `
+<div>
+  <div
+    class="main"
+  >
+    <div
+      class="header"
+    >
+      <button
+        class="logo"
+      >
+        <img
+          alt="Klurigo"
+          class="icon"
+          src="/src/assets/images/klurigo-icon.svg"
+        />
+        <span
+          class="text"
+        >
+          Klurigo
+        </span>
+      </button>
+      <div
+        class="side"
+      >
+        <a
+          data-discover="true"
+          href="/auth/login"
+        >
+          Login
+        </a>
+      </div>
+    </div>
+    <div
+      class="content startAlign"
+    >
+      <div
+        class="contentWrapper fullWidth"
+      >
+        <div
+          class="contentInner"
+        >
+          <div
+            class="card kindCallToAction sizeLarge center"
+          >
+            <button
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                class="svg-inline--fa fa-xmark"
+                data-icon="xmark"
+                data-prefix="fas"
+                role="img"
+                viewBox="0 0 384 512"
+              >
+                <path
+                  d="M55.1 73.4c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3L147.2 256 9.9 393.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0L192.5 301.3 329.9 438.6c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3L237.8 256 375.1 118.6c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0L192.5 210.7 55.1 73.4z"
+                  fill="currentColor"
+                />
+              </svg>
+            </button>
+            <div
+              class="content"
+            >
+              <span>
+                Hey quiz champion! Did your brainy adventures happen on
+                 
+                <a
+                  href="https://quiz.emilhornlund.com"
+                >
+                  quiz.emilhornlund.com
+                </a>
+                ? No worries— we can save all your quiz creations and epic game stats! Just pop back to
+                 
+                <a
+                  href="https://quiz.emilhornlund.com"
+                >
+                  quiz.emilhornlund.com
+                </a>
+                 one last time, and we’ll magically teleport everything over to
+                 
+                <b>
+                  <i>
+                    klurigo.com
+                  </i>
+                </b>
+                . Ready to blast off your data?
+              </span>
+            </div>
+          </div>
+          <div
+            class="typography title medium"
+          >
+            Welcome back!
+          </div>
+          <div
+            class="typography text small"
+          >
+            Please sign in to continue.
+          </div>
+          <form
+            class="loginForm"
+          >
+            <div
+              class="inputContainer"
+            >
+              <div
+                class="textFieldInputContainer textFieldInputKindPrimary disabled"
+              >
+                <input
+                  class="textfield"
+                  data-testid="test-email-textfield"
+                  disabled=""
+                  id="email"
+                  maxlength="128"
+                  minlength="6"
+                  name="email"
+                  placeholder="Email"
+                  type="text"
+                  value=""
+                />
+              </div>
+            </div>
+            <div
+              class="inputContainer"
+            >
+              <div
+                class="textFieldInputContainer textFieldInputKindPrimary disabled"
+              >
+                <input
+                  class="textfield"
+                  data-testid="test-password-textfield"
+                  disabled=""
+                  id="password"
+                  maxlength="128"
+                  minlength="8"
+                  name="password"
+                  placeholder="Password"
+                  type="password"
+                  value=""
+                />
+              </div>
+            </div>
+            <a
+              data-discover="true"
+              href="/auth/password/forgot"
+            >
+              <div
+                class="typography link small"
+              >
+                Forgot your password?
+              </div>
+            </a>
+            <div
+              class="buttonInputContainer buttonInputKindCallToAction"
+            >
+              <button
+                data-testid="test-join-button"
+                disabled=""
+                id="join"
+                name="join"
+                type="submit"
+              >
+                <div
+                  class="loadingSpinner"
+                >
+                  <div />
+                  <div />
+                  <div />
+                </div>
+              </button>
+            </div>
+          </form>
+          <a
+            data-discover="true"
+            href="/auth/register"
+          >
+            <div
+              class="typography link small"
+            >
+              New here? Join the fun and create your account!
+            </div>
+          </a>
+          <div
+            class="pageDivider"
+          />
+          <div
+            class="authProviderButton"
+          >
+            <div
+              class="buttonInputContainer buttonInputKindPrimary"
+            >
+              <button
+                data-testid="test-google-login-button-button"
+                id="google-login-button"
+                name="google-login-button"
+                type="button"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="svg-inline--fa fa-google"
+                  data-icon="google"
+                  data-prefix="fab"
+                  role="img"
+                  viewBox="0 0 512 512"
+                >
+                  <path
+                    d="M500 261.8C500 403.3 403.1 504 260 504 122.8 504 12 393.2 12 256S122.8 8 260 8c66.8 0 123 24.5 166.3 64.9l-67.5 64.9c-88.3-85.2-252.5-21.2-252.5 118.2 0 86.5 69.1 156.6 153.7 156.6 98.2 0 135-70.4 140.8-106.9l-140.8 0 0-85.3 236.1 0c2.3 12.7 3.9 24.9 3.9 41.4z"
+                    fill="currentColor"
+                  />
+                </svg>
+                <span>
+                  Continue with Google
+                </span>
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`AuthLoginPageUI > respects loading state: disables inputs and button, shows loading on submit 1`] = `
+<div>
+  <div
+    class="main"
+  >
+    <div
+      class="header"
+    >
+      <button
+        class="logo"
+      >
+        <img
+          alt="Klurigo"
+          class="icon"
+          src="/src/assets/images/klurigo-icon.svg"
+        />
+        <span
+          class="text"
+        >
+          Klurigo
+        </span>
+      </button>
+      <div
+        class="side"
+      >
+        <a
+          data-discover="true"
+          href="/auth/login"
+        >
+          Login
+        </a>
+      </div>
+    </div>
+    <div
+      class="content startAlign"
+    >
+      <div
+        class="contentWrapper fullWidth"
+      >
+        <div
+          class="contentInner"
+        >
+          <div
+            class="card kindCallToAction sizeLarge center"
+          >
+            <button
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                class="svg-inline--fa fa-xmark"
+                data-icon="xmark"
+                data-prefix="fas"
+                role="img"
+                viewBox="0 0 384 512"
+              >
+                <path
+                  d="M55.1 73.4c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3L147.2 256 9.9 393.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0L192.5 301.3 329.9 438.6c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3L237.8 256 375.1 118.6c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0L192.5 210.7 55.1 73.4z"
+                  fill="currentColor"
+                />
+              </svg>
+            </button>
+            <div
+              class="content"
+            >
+              <span>
+                Hey quiz champion! Did your brainy adventures happen on
+                 
+                <a
+                  href="https://quiz.emilhornlund.com"
+                >
+                  quiz.emilhornlund.com
+                </a>
+                ? No worries— we can save all your quiz creations and epic game stats! Just pop back to
+                 
+                <a
+                  href="https://quiz.emilhornlund.com"
+                >
+                  quiz.emilhornlund.com
+                </a>
+                 one last time, and we’ll magically teleport everything over to
+                 
+                <b>
+                  <i>
+                    klurigo.com
+                  </i>
+                </b>
+                . Ready to blast off your data?
+              </span>
+            </div>
+          </div>
+          <div
+            class="typography title medium"
+          >
+            Welcome back!
+          </div>
+          <div
+            class="typography text small"
+          >
+            Please sign in to continue.
+          </div>
+          <form
+            class="loginForm"
+          >
+            <div
+              class="inputContainer"
+            >
+              <div
+                class="textFieldInputContainer textFieldInputKindPrimary disabled"
+              >
+                <input
+                  class="textfield"
+                  data-testid="test-email-textfield"
+                  disabled=""
+                  id="email"
+                  maxlength="128"
+                  minlength="6"
+                  name="email"
+                  placeholder="Email"
+                  type="text"
+                  value=""
+                />
+              </div>
+            </div>
+            <div
+              class="inputContainer"
+            >
+              <div
+                class="textFieldInputContainer textFieldInputKindPrimary disabled"
+              >
+                <input
+                  class="textfield"
+                  data-testid="test-password-textfield"
+                  disabled=""
+                  id="password"
+                  maxlength="128"
+                  minlength="8"
+                  name="password"
+                  placeholder="Password"
+                  type="password"
+                  value=""
+                />
+              </div>
+            </div>
+            <a
+              data-discover="true"
+              href="/auth/password/forgot"
+            >
+              <div
+                class="typography link small"
+              >
+                Forgot your password?
+              </div>
+            </a>
+            <div
+              class="buttonInputContainer buttonInputKindCallToAction"
+            >
+              <button
+                data-testid="test-join-button"
+                disabled=""
+                id="join"
+                name="join"
+                type="submit"
+              >
+                <div
+                  class="loadingSpinner"
+                >
+                  <div />
+                  <div />
+                  <div />
+                </div>
+              </button>
+            </div>
+          </form>
+          <a
+            data-discover="true"
+            href="/auth/register"
+          >
+            <div
+              class="typography link small"
+            >
+              New here? Join the fun and create your account!
+            </div>
+          </a>
+          <div
+            class="pageDivider"
+          />
+          <div
+            class="authProviderButton"
+          >
+            <div
+              class="buttonInputContainer buttonInputKindPrimary"
+            >
+              <button
+                data-testid="test-google-login-button-button"
+                id="google-login-button"
+                name="google-login-button"
+                type="button"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="svg-inline--fa fa-google"
+                  data-icon="google"
+                  data-prefix="fab"
+                  role="img"
+                  viewBox="0 0 512 512"
+                >
+                  <path
+                    d="M500 261.8C500 403.3 403.1 504 260 504 122.8 504 12 393.2 12 256S122.8 8 260 8c66.8 0 123 24.5 166.3 64.9l-67.5 64.9c-88.3-85.2-252.5-21.2-252.5 118.2 0 86.5 69.1 156.6 153.7 156.6 98.2 0 135-70.4 140.8-106.9l-140.8 0 0-85.3 236.1 0c2.3 12.7 3.9 24.9 3.9 41.4z"
+                    fill="currentColor"
+                  />
+                </svg>
+                <span>
+                  Continue with Google
+                </span>
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/packages/quiz/src/pages/AuthLoginPage/components/AuthLoginPageUI/text.utils.test.ts
+++ b/packages/quiz/src/pages/AuthLoginPage/components/AuthLoginPageUI/text.utils.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { getMessage, getTitle, MESSAGES, TITLES } from './text.utils'
+
+describe('getTitle', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('returns first title when Math.random is 0', () => {
+    vi.spyOn(Math, 'random').mockReturnValue(0)
+    expect(getTitle()).toBe(TITLES[0])
+  })
+
+  it('returns middle title when Math.random is 0.5', () => {
+    vi.spyOn(Math, 'random').mockReturnValue(0.5) // floor(0.5 * 5) = 2
+    expect(getTitle()).toBe(TITLES[2])
+  })
+
+  it('returns last title when Math.random is close to 1', () => {
+    vi.spyOn(Math, 'random').mockReturnValue(0.999999) // last index
+    expect(getTitle()).toBe(TITLES[TITLES.length - 1])
+  })
+
+  it('returns one of the predefined titles', () => {
+    vi.spyOn(Math, 'random').mockReturnValue(0.12)
+    expect(TITLES).toContain(getTitle())
+  })
+})
+
+describe('getMessage', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('returns first message when Math.random is 0', () => {
+    vi.spyOn(Math, 'random').mockReturnValue(0)
+    expect(getMessage()).toBe(MESSAGES[0])
+  })
+
+  it('returns middle message when Math.random is 0.5', () => {
+    vi.spyOn(Math, 'random').mockReturnValue(0.5) // floor(0.5 * 9) = 4
+    expect(getMessage()).toBe(MESSAGES[4])
+  })
+
+  it('returns last message when Math.random is close to 1', () => {
+    vi.spyOn(Math, 'random').mockReturnValue(0.999999) // last index
+    expect(getMessage()).toBe(MESSAGES[MESSAGES.length - 1])
+  })
+
+  it('returns one of the predefined messages', () => {
+    vi.spyOn(Math, 'random').mockReturnValue(0.23)
+    expect(MESSAGES).toContain(getMessage())
+  })
+})

--- a/packages/quiz/src/pages/AuthLoginPage/components/AuthLoginPageUI/text.utils.ts
+++ b/packages/quiz/src/pages/AuthLoginPage/components/AuthLoginPageUI/text.utils.ts
@@ -1,4 +1,4 @@
-const TITLES = [
+export const TITLES = [
   'Welcome back, Quizmaster!',
   'Hello again, genius!',
   'Your quiz hub awaits!',
@@ -6,7 +6,7 @@ const TITLES = [
   'Back to the quiz zone!',
 ]
 
-const MESSAGES = [
+export const MESSAGES = [
   'Sign in to access your quizzes, stats, and the brilliant chaos you left behind.',
   'Rejoin your quiz universe — your profile, history, and leaderboard spot are all waiting.',
   'Time to log in and reconnect with your inner trivia titan.',

--- a/packages/quiz/src/pages/AuthPasswordForgotPage/AuthPasswordForgotPage.test.tsx
+++ b/packages/quiz/src/pages/AuthPasswordForgotPage/AuthPasswordForgotPage.test.tsx
@@ -1,0 +1,117 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import React from 'react'
+import { MemoryRouter } from 'react-router-dom'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const h = vi.hoisted(() => ({
+  sendPasswordResetEmail: vi
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    .fn<[{ email: string }], Promise<void>>()
+    .mockResolvedValue({}),
+  navigate: vi.fn(),
+}))
+
+vi.mock('../../api/use-quiz-service-client.tsx', () => ({
+  useQuizServiceClient: () => ({
+    sendPasswordResetEmail: h.sendPasswordResetEmail,
+  }),
+}))
+
+vi.mock('react-router-dom', async (orig) => {
+  const actual = await orig()
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  return { ...actual, useNavigate: () => h.navigate }
+})
+
+import AuthPasswordForgotPage from './AuthPasswordForgotPage'
+
+describe('AuthPasswordForgotPage', () => {
+  beforeEach(() => {
+    h.sendPasswordResetEmail.mockClear()
+    h.navigate.mockClear()
+  })
+
+  it('renders and has disabled submit initially', () => {
+    const { container } = render(
+      <MemoryRouter>
+        <AuthPasswordForgotPage />
+      </MemoryRouter>,
+    )
+
+    const submit = container.querySelector(
+      '#continue-button',
+    ) as HTMLButtonElement
+    expect(submit).toBeDisabled()
+    expect(container).toMatchSnapshot()
+  })
+
+  it('submits valid email, disables during request, then navigates home on success', async () => {
+    let resolve!: () => void
+    h.sendPasswordResetEmail.mockImplementation(
+      () =>
+        new Promise<void>((r) => {
+          resolve = r
+        }),
+    )
+
+    const { container } = render(
+      <MemoryRouter>
+        <AuthPasswordForgotPage />
+      </MemoryRouter>,
+    )
+
+    fireEvent.change(screen.getByPlaceholderText('Email'), {
+      target: { value: 'user@example.com' },
+    })
+
+    const submit = container.querySelector(
+      '#continue-button',
+    ) as HTMLButtonElement
+    expect(submit).not.toBeDisabled()
+
+    fireEvent.click(submit)
+    expect(h.sendPasswordResetEmail).toHaveBeenCalledWith({
+      email: 'user@example.com',
+    })
+    expect(submit).toBeDisabled()
+
+    resolve()
+    await waitFor(() => expect(h.navigate).toHaveBeenCalledWith('/'))
+    expect(submit).not.toBeDisabled()
+  })
+
+  it('re-enables submit and does not navigate on failure', async () => {
+    // async finally so loading=true is rendered before we flip it back to false
+    const thenable = {
+      then: () => thenable,
+      catch: () => thenable,
+      finally: (cb: () => void) => {
+        setTimeout(cb, 0)
+        return thenable
+      },
+    } as unknown as Promise<void>
+
+    h.sendPasswordResetEmail.mockReturnValue(thenable)
+
+    const { container } = render(
+      <MemoryRouter>
+        <AuthPasswordForgotPage />
+      </MemoryRouter>,
+    )
+
+    fireEvent.change(screen.getByPlaceholderText('Email'), {
+      target: { value: 'user@example.com' },
+    })
+
+    const submit = container.querySelector(
+      '#continue-button',
+    ) as HTMLButtonElement
+    fireEvent.click(submit)
+
+    await waitFor(() => expect(submit).toBeDisabled())
+    await waitFor(() => expect(submit).not.toBeDisabled())
+    expect(h.navigate).not.toHaveBeenCalled()
+  })
+})

--- a/packages/quiz/src/pages/AuthPasswordForgotPage/__snapshots__/AuthPasswordForgotPage.test.tsx.snap
+++ b/packages/quiz/src/pages/AuthPasswordForgotPage/__snapshots__/AuthPasswordForgotPage.test.tsx.snap
@@ -1,0 +1,111 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`AuthPasswordForgotPage > renders and has disabled submit initially 1`] = `
+<div>
+  <div
+    class="main"
+  >
+    <div
+      class="header"
+    >
+      <button
+        class="logo"
+      >
+        <img
+          alt="Klurigo"
+          class="icon"
+          src="/src/assets/images/klurigo-icon.svg"
+        />
+        <span
+          class="text"
+        >
+          Klurigo
+        </span>
+      </button>
+      <div
+        class="side"
+      >
+        <a
+          data-discover="true"
+          href="/auth/login"
+        >
+          Login
+        </a>
+      </div>
+    </div>
+    <div
+      class="content centerAlign"
+    >
+      <div
+        class="contentWrapper fullWidth"
+      >
+        <div
+          class="contentInner"
+        >
+          <div
+            class="typography subtitle full"
+          >
+            Uh-oh, Lost Your Key?
+          </div>
+          <div
+            class="typography text medium"
+          >
+            Don’t panic – it happens! Drop your email below and we’ll beam you a shiny new password link.
+          </div>
+          <form
+            class="form"
+          >
+            <div
+              class="inputContainer"
+            >
+              <div
+                class="textFieldInputContainer textFieldInputKindPrimary"
+              >
+                <input
+                  class="textfield"
+                  data-testid="test-email-textfield"
+                  id="email"
+                  maxlength="128"
+                  minlength="6"
+                  name="email"
+                  placeholder="Email"
+                  type="text"
+                  value=""
+                />
+              </div>
+            </div>
+            <div
+              class="buttonInputContainer buttonInputKindCallToAction"
+            >
+              <button
+                data-testid="test-continue-button-button"
+                disabled=""
+                id="continue-button"
+                name="continue-button"
+                type="submit"
+              >
+                <span>
+                  Send Reset Link
+                </span>
+                <svg
+                  aria-hidden="true"
+                  class="svg-inline--fa fa-arrow-right"
+                  data-icon="arrow-right"
+                  data-prefix="fas"
+                  role="img"
+                  viewBox="0 0 512 512"
+                >
+                  <path
+                    d="M502.6 278.6c12.5-12.5 12.5-32.8 0-45.3l-160-160c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3L402.7 224 32 224c-17.7 0-32 14.3-32 32s14.3 32 32 32l370.7 0-105.4 105.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0l160-160z"
+                    fill="currentColor"
+                  />
+                </svg>
+              </button>
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/packages/quiz/src/pages/AuthPasswordResetPage/AuthPasswordResetPage.test.tsx
+++ b/packages/quiz/src/pages/AuthPasswordResetPage/AuthPasswordResetPage.test.tsx
@@ -1,0 +1,140 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import React from 'react'
+import { MemoryRouter } from 'react-router-dom'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const h = vi.hoisted(() => ({
+  expired: false,
+  resetPassword: vi
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    .fn<[{ password: string }, string], Promise<void>>()
+    .mockResolvedValue({}),
+  navigate: vi.fn(),
+}))
+
+vi.mock('../../api/api.utils', () => ({
+  isTokenExpired: () => h.expired,
+}))
+
+vi.mock('../../api/use-quiz-service-client.tsx', () => ({
+  useQuizServiceClient: () => ({ resetPassword: h.resetPassword }),
+}))
+
+vi.mock('react-router-dom', async (orig) => {
+  const actual = await orig()
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  return { ...actual, useNavigate: () => h.navigate }
+})
+
+import AuthPasswordResetPage from './AuthPasswordResetPage'
+
+describe('AuthPasswordResetPage', () => {
+  beforeEach(() => {
+    h.expired = false
+    h.resetPassword.mockClear()
+    h.navigate.mockClear()
+  })
+
+  it('shows error when token is missing', () => {
+    const { container } = render(
+      <MemoryRouter initialEntries={['/auth/password/reset']}>
+        <AuthPasswordResetPage />
+      </MemoryRouter>,
+    )
+    expect(screen.getByText('Oops! Something went wrong.')).toBeInTheDocument()
+    expect(
+      screen.getByText('The supplied link is invalid or has expired.'),
+    ).toBeInTheDocument()
+    expect(container).toMatchSnapshot()
+  })
+
+  it('shows error when token is expired', () => {
+    h.expired = true
+    const { container } = render(
+      <MemoryRouter initialEntries={['/auth/password/reset?token=T1']}>
+        <AuthPasswordResetPage />
+      </MemoryRouter>,
+    )
+    expect(screen.getByText('Oops! Something went wrong.')).toBeInTheDocument()
+    expect(container).toMatchSnapshot()
+  })
+
+  it('submits valid password, disables button while pending, then navigates on success', async () => {
+    let resolve!: () => void
+    h.resetPassword.mockImplementation(
+      () =>
+        new Promise<void>((r) => {
+          resolve = r
+        }),
+    )
+
+    const { container } = render(
+      <MemoryRouter initialEntries={['/auth/password/reset?token=T1']}>
+        <AuthPasswordResetPage />
+      </MemoryRouter>,
+    )
+
+    fireEvent.change(screen.getByPlaceholderText('New Password'), {
+      target: { value: 'PPss11!!' },
+    })
+    fireEvent.change(screen.getByPlaceholderText('Confirm Password'), {
+      target: { value: 'PPss11!!' },
+    })
+
+    const submit = container.querySelector(
+      '#reset-password-button',
+    ) as HTMLButtonElement
+    expect(submit).not.toBeDisabled()
+
+    fireEvent.click(submit)
+    expect(h.resetPassword).toHaveBeenCalledWith({ password: 'PPss11!!' }, 'T1')
+    expect(submit).toBeDisabled()
+
+    resolve()
+    await waitFor(() => expect(h.navigate).toHaveBeenCalledWith('/auth/login'))
+    expect(submit).not.toBeDisabled()
+  })
+
+  it('shows error view on failure and does not navigate', async () => {
+    let reject!: (e?: unknown) => void
+    h.resetPassword.mockImplementation(
+      () =>
+        new Promise<void>((_, r) => {
+          reject = r
+        }),
+    )
+
+    const { container } = render(
+      <MemoryRouter initialEntries={['/auth/password/reset?token=T1']}>
+        <AuthPasswordResetPage />
+      </MemoryRouter>,
+    )
+
+    fireEvent.change(screen.getByPlaceholderText('New Password'), {
+      target: { value: 'PPss11!!' },
+    })
+    fireEvent.change(screen.getByPlaceholderText('Confirm Password'), {
+      target: { value: 'PPss11!!' },
+    })
+
+    const submit = container.querySelector(
+      '#reset-password-button',
+    ) as HTMLButtonElement
+    fireEvent.click(submit)
+    expect(submit).toBeDisabled()
+
+    reject(new Error('nope'))
+
+    await waitFor(() =>
+      expect(
+        screen.getByText('Oops! Something went wrong.'),
+      ).toBeInTheDocument(),
+    )
+
+    expect(h.navigate).not.toHaveBeenCalled()
+    expect(document.querySelector('#reset-password-button')).toBeNull()
+    expect(container).toMatchSnapshot()
+  })
+})

--- a/packages/quiz/src/pages/AuthPasswordResetPage/__snapshots__/AuthPasswordResetPage.test.tsx.snap
+++ b/packages/quiz/src/pages/AuthPasswordResetPage/__snapshots__/AuthPasswordResetPage.test.tsx.snap
@@ -1,0 +1,229 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`AuthPasswordResetPage > shows error view on failure and does not navigate 1`] = `
+<div>
+  <div
+    class="main"
+  >
+    <div
+      class="header"
+    >
+      <button
+        class="logo"
+      >
+        <img
+          alt="Klurigo"
+          class="icon"
+          src="/src/assets/images/klurigo-icon.svg"
+        />
+        <span
+          class="text"
+        >
+          Klurigo
+        </span>
+      </button>
+      <div
+        class="side"
+      >
+        <a
+          data-discover="true"
+          href="/auth/login"
+        >
+          Login
+        </a>
+      </div>
+    </div>
+    <div
+      class="content centerAlign"
+    >
+      <div
+        class="contentWrapper fullWidth"
+      >
+        <div
+          class="contentInner"
+        >
+          <div
+            class="badge large red"
+          >
+            <svg
+              aria-hidden="true"
+              class="svg-inline--fa fa-xmark"
+              data-icon="xmark"
+              data-prefix="fas"
+              role="img"
+              viewBox="0 0 384 512"
+            >
+              <path
+                d="M55.1 73.4c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3L147.2 256 9.9 393.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0L192.5 301.3 329.9 438.6c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3L237.8 256 375.1 118.6c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0L192.5 210.7 55.1 73.4z"
+                fill="currentColor"
+              />
+            </svg>
+          </div>
+          <div
+            class="typography subtitle small"
+          >
+            Oops! Something went wrong.
+          </div>
+          <div
+            class="typography text medium"
+          >
+            The supplied link is invalid or has expired.
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`AuthPasswordResetPage > shows error when token is expired 1`] = `
+<div>
+  <div
+    class="main"
+  >
+    <div
+      class="header"
+    >
+      <button
+        class="logo"
+      >
+        <img
+          alt="Klurigo"
+          class="icon"
+          src="/src/assets/images/klurigo-icon.svg"
+        />
+        <span
+          class="text"
+        >
+          Klurigo
+        </span>
+      </button>
+      <div
+        class="side"
+      >
+        <a
+          data-discover="true"
+          href="/auth/login"
+        >
+          Login
+        </a>
+      </div>
+    </div>
+    <div
+      class="content centerAlign"
+    >
+      <div
+        class="contentWrapper fullWidth"
+      >
+        <div
+          class="contentInner"
+        >
+          <div
+            class="badge large red"
+          >
+            <svg
+              aria-hidden="true"
+              class="svg-inline--fa fa-xmark"
+              data-icon="xmark"
+              data-prefix="fas"
+              role="img"
+              viewBox="0 0 384 512"
+            >
+              <path
+                d="M55.1 73.4c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3L147.2 256 9.9 393.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0L192.5 301.3 329.9 438.6c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3L237.8 256 375.1 118.6c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0L192.5 210.7 55.1 73.4z"
+                fill="currentColor"
+              />
+            </svg>
+          </div>
+          <div
+            class="typography subtitle small"
+          >
+            Oops! Something went wrong.
+          </div>
+          <div
+            class="typography text medium"
+          >
+            The supplied link is invalid or has expired.
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`AuthPasswordResetPage > shows error when token is missing 1`] = `
+<div>
+  <div
+    class="main"
+  >
+    <div
+      class="header"
+    >
+      <button
+        class="logo"
+      >
+        <img
+          alt="Klurigo"
+          class="icon"
+          src="/src/assets/images/klurigo-icon.svg"
+        />
+        <span
+          class="text"
+        >
+          Klurigo
+        </span>
+      </button>
+      <div
+        class="side"
+      >
+        <a
+          data-discover="true"
+          href="/auth/login"
+        >
+          Login
+        </a>
+      </div>
+    </div>
+    <div
+      class="content centerAlign"
+    >
+      <div
+        class="contentWrapper fullWidth"
+      >
+        <div
+          class="contentInner"
+        >
+          <div
+            class="badge large red"
+          >
+            <svg
+              aria-hidden="true"
+              class="svg-inline--fa fa-xmark"
+              data-icon="xmark"
+              data-prefix="fas"
+              role="img"
+              viewBox="0 0 384 512"
+            >
+              <path
+                d="M55.1 73.4c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3L147.2 256 9.9 393.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0L192.5 301.3 329.9 438.6c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3L237.8 256 375.1 118.6c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0L192.5 210.7 55.1 73.4z"
+                fill="currentColor"
+              />
+            </svg>
+          </div>
+          <div
+            class="typography subtitle small"
+          >
+            Oops! Something went wrong.
+          </div>
+          <div
+            class="typography text medium"
+          >
+            The supplied link is invalid or has expired.
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/packages/quiz/src/pages/AuthPasswordResetPage/components/AuthPasswordResetPageUI/AuthPasswordResetPageUI.test.tsx
+++ b/packages/quiz/src/pages/AuthPasswordResetPage/components/AuthPasswordResetPageUI/AuthPasswordResetPageUI.test.tsx
@@ -1,50 +1,203 @@
-import { render } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import React from 'react'
 import { MemoryRouter } from 'react-router-dom'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
-import AuthPasswordResetPage from './AuthPasswordResetPageUI'
+import AuthPasswordResetPageUI from './AuthPasswordResetPageUI'
 
-describe('AuthPasswordResetPage', () => {
-  it('should render AuthPasswordResetPage', async () => {
+describe('AuthPasswordResetPageUI', () => {
+  it('renders default view', () => {
     const { container } = render(
       <MemoryRouter>
-        <AuthPasswordResetPage
+        <AuthPasswordResetPageUI
           loading={false}
           error={false}
           onSubmit={() => undefined}
         />
       </MemoryRouter>,
     )
-
     expect(container).toMatchSnapshot()
   })
 
-  it('should render AuthPasswordResetPage when loading', async () => {
+  it('renders loading view', () => {
     const { container } = render(
       <MemoryRouter>
-        <AuthPasswordResetPage
+        <AuthPasswordResetPageUI
           loading={true}
           error={false}
           onSubmit={() => undefined}
         />
       </MemoryRouter>,
     )
-
     expect(container).toMatchSnapshot()
   })
 
-  it('should render AuthPasswordResetPage when error', async () => {
+  it('renders error view', () => {
     const { container } = render(
       <MemoryRouter>
-        <AuthPasswordResetPage
+        <AuthPasswordResetPageUI
           loading={false}
           error={true}
           onSubmit={() => undefined}
         />
       </MemoryRouter>,
     )
-
     expect(container).toMatchSnapshot()
+  })
+
+  it('keeps submit disabled until both fields are valid and match', async () => {
+    const { container } = render(
+      <MemoryRouter>
+        <AuthPasswordResetPageUI
+          loading={false}
+          error={false}
+          onSubmit={() => undefined}
+        />
+      </MemoryRouter>,
+    )
+
+    const submit = container.querySelector(
+      '#reset-password-button',
+    ) as HTMLButtonElement
+    expect(submit).toBeDisabled()
+
+    fireEvent.change(screen.getByPlaceholderText('New Password'), {
+      target: { value: 'PPss11!!' }, // meets regex
+    })
+    // still disabled because confirm is empty/invalid
+    expect(submit).toBeDisabled()
+
+    fireEvent.change(screen.getByPlaceholderText('Confirm Password'), {
+      target: { value: 'PPss11!!' },
+    })
+    await waitFor(() => expect(submit).not.toBeDisabled())
+  })
+
+  it('stays disabled if password fails regex', () => {
+    const { container } = render(
+      <MemoryRouter>
+        <AuthPasswordResetPageUI
+          loading={false}
+          error={false}
+          onSubmit={() => undefined}
+        />
+      </MemoryRouter>,
+    )
+
+    const submit = container.querySelector(
+      '#reset-password-button',
+    ) as HTMLButtonElement
+
+    fireEvent.change(screen.getByPlaceholderText('New Password'), {
+      target: { value: 'Pp1!' }, // too short / not enough classes
+    })
+    fireEvent.change(screen.getByPlaceholderText('Confirm Password'), {
+      target: { value: 'Pp1!' },
+    })
+    expect(submit).toBeDisabled()
+  })
+
+  it('stays disabled when confirm does not match, then enables after fixing', async () => {
+    const { container } = render(
+      <MemoryRouter>
+        <AuthPasswordResetPageUI
+          loading={false}
+          error={false}
+          onSubmit={() => undefined}
+        />
+      </MemoryRouter>,
+    )
+
+    const submit = container.querySelector(
+      '#reset-password-button',
+    ) as HTMLButtonElement
+
+    fireEvent.change(screen.getByPlaceholderText('New Password'), {
+      target: { value: 'PPss11!!' },
+    })
+    fireEvent.change(screen.getByPlaceholderText('Confirm Password'), {
+      target: { value: 'PPss11??' }, // mismatch
+    })
+    expect(submit).toBeDisabled()
+
+    fireEvent.change(screen.getByPlaceholderText('Confirm Password'), {
+      target: { value: 'PPss11!!' }, // match now
+    })
+    await waitFor(() => expect(submit).not.toBeDisabled())
+  })
+
+  it('submits valid password', () => {
+    const onSubmit = vi.fn()
+    const { container } = render(
+      <MemoryRouter>
+        <AuthPasswordResetPageUI
+          loading={false}
+          error={false}
+          onSubmit={onSubmit}
+        />
+      </MemoryRouter>,
+    )
+
+    fireEvent.change(screen.getByPlaceholderText('New Password'), {
+      target: { value: 'PPss11!!' },
+    })
+    fireEvent.change(screen.getByPlaceholderText('Confirm Password'), {
+      target: { value: 'PPss11!!' },
+    })
+
+    const submit = container.querySelector(
+      '#reset-password-button',
+    ) as HTMLButtonElement
+    fireEvent.click(submit)
+
+    expect(onSubmit).toHaveBeenCalledTimes(1)
+    expect(onSubmit).toHaveBeenCalledWith({ password: 'PPss11!!' })
+  })
+
+  it('disables submit when loading even with valid fields, and re-enables when loading prop changes', async () => {
+    const onSubmit = vi.fn()
+    const { container, rerender } = render(
+      <MemoryRouter>
+        <AuthPasswordResetPageUI
+          loading={false}
+          error={false}
+          onSubmit={onSubmit}
+        />
+      </MemoryRouter>,
+    )
+
+    fireEvent.change(screen.getByPlaceholderText('New Password'), {
+      target: { value: 'PPss11!!' },
+    })
+    fireEvent.change(screen.getByPlaceholderText('Confirm Password'), {
+      target: { value: 'PPss11!!' },
+    })
+
+    const submit = container.querySelector(
+      '#reset-password-button',
+    ) as HTMLButtonElement
+    expect(submit).not.toBeDisabled()
+
+    rerender(
+      <MemoryRouter>
+        <AuthPasswordResetPageUI
+          loading={true}
+          error={false}
+          onSubmit={onSubmit}
+        />
+      </MemoryRouter>,
+    )
+    expect(submit).toBeDisabled()
+
+    rerender(
+      <MemoryRouter>
+        <AuthPasswordResetPageUI
+          loading={false}
+          error={false}
+          onSubmit={onSubmit}
+        />
+      </MemoryRouter>,
+    )
+    await waitFor(() => expect(submit).not.toBeDisabled())
   })
 })

--- a/packages/quiz/src/pages/AuthPasswordResetPage/components/AuthPasswordResetPageUI/__snapshots__/AuthPasswordResetPageUI.test.tsx.snap
+++ b/packages/quiz/src/pages/AuthPasswordResetPage/components/AuthPasswordResetPageUI/__snapshots__/AuthPasswordResetPageUI.test.tsx.snap
@@ -326,3 +326,330 @@ exports[`AuthPasswordResetPage > should render AuthPasswordResetPage when loadin
   </div>
 </div>
 `;
+
+exports[`AuthPasswordResetPageUI > renders default view 1`] = `
+<div>
+  <div
+    class="main"
+  >
+    <div
+      class="header"
+    >
+      <button
+        class="logo"
+      >
+        <img
+          alt="Klurigo"
+          class="icon"
+          src="/src/assets/images/klurigo-icon.svg"
+        />
+        <span
+          class="text"
+        >
+          Klurigo
+        </span>
+      </button>
+      <div
+        class="side"
+      >
+        <a
+          data-discover="true"
+          href="/auth/login"
+        >
+          Login
+        </a>
+      </div>
+    </div>
+    <div
+      class="content centerAlign"
+    >
+      <div
+        class="contentWrapper fullWidth"
+      >
+        <div
+          class="contentInner"
+        >
+          <div
+            class="typography subtitle full"
+          >
+            Lock It Down!
+          </div>
+          <div
+            class="typography text medium"
+          >
+            Choose your dazzling new password and confirm it below. Let’s keep those sneaky hackers out!
+          </div>
+          <form
+            class="form"
+          >
+            <div
+              class="inputContainer"
+            >
+              <div
+                class="textFieldInputContainer textFieldInputKindPrimary"
+              >
+                <input
+                  class="textfield"
+                  data-testid="test-password-textfield"
+                  id="password"
+                  maxlength="128"
+                  minlength="8"
+                  name="password"
+                  placeholder="New Password"
+                  type="password"
+                  value=""
+                />
+              </div>
+            </div>
+            <div
+              class="inputContainer"
+            >
+              <div
+                class="textFieldInputContainer textFieldInputKindPrimary"
+              >
+                <input
+                  class="textfield"
+                  data-testid="test-confirmPassword-textfield"
+                  id="confirmPassword"
+                  maxlength="128"
+                  minlength="8"
+                  name="confirmPassword"
+                  placeholder="Confirm Password"
+                  type="password"
+                  value=""
+                />
+              </div>
+            </div>
+            <div
+              class="buttonInputContainer buttonInputKindCallToAction"
+            >
+              <button
+                data-testid="test-reset-password-button-button"
+                disabled=""
+                id="reset-password-button"
+                name="reset-password-button"
+                type="submit"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="svg-inline--fa fa-lock"
+                  data-icon="lock"
+                  data-prefix="fas"
+                  role="img"
+                  viewBox="0 0 384 512"
+                >
+                  <path
+                    d="M128 96l0 64 128 0 0-64c0-35.3-28.7-64-64-64s-64 28.7-64 64zM64 160l0-64C64 25.3 121.3-32 192-32S320 25.3 320 96l0 64c35.3 0 64 28.7 64 64l0 224c0 35.3-28.7 64-64 64L64 512c-35.3 0-64-28.7-64-64L0 224c0-35.3 28.7-64 64-64z"
+                    fill="currentColor"
+                  />
+                </svg>
+                <span>
+                  Lock It Down!
+                </span>
+              </button>
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`AuthPasswordResetPageUI > renders error view 1`] = `
+<div>
+  <div
+    class="main"
+  >
+    <div
+      class="header"
+    >
+      <button
+        class="logo"
+      >
+        <img
+          alt="Klurigo"
+          class="icon"
+          src="/src/assets/images/klurigo-icon.svg"
+        />
+        <span
+          class="text"
+        >
+          Klurigo
+        </span>
+      </button>
+      <div
+        class="side"
+      >
+        <a
+          data-discover="true"
+          href="/auth/login"
+        >
+          Login
+        </a>
+      </div>
+    </div>
+    <div
+      class="content centerAlign"
+    >
+      <div
+        class="contentWrapper fullWidth"
+      >
+        <div
+          class="contentInner"
+        >
+          <div
+            class="badge large red"
+          >
+            <svg
+              aria-hidden="true"
+              class="svg-inline--fa fa-xmark"
+              data-icon="xmark"
+              data-prefix="fas"
+              role="img"
+              viewBox="0 0 384 512"
+            >
+              <path
+                d="M55.1 73.4c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3L147.2 256 9.9 393.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0L192.5 301.3 329.9 438.6c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3L237.8 256 375.1 118.6c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0L192.5 210.7 55.1 73.4z"
+                fill="currentColor"
+              />
+            </svg>
+          </div>
+          <div
+            class="typography subtitle small"
+          >
+            Oops! Something went wrong.
+          </div>
+          <div
+            class="typography text medium"
+          >
+            The supplied link is invalid or has expired.
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`AuthPasswordResetPageUI > renders loading view 1`] = `
+<div>
+  <div
+    class="main"
+  >
+    <div
+      class="header"
+    >
+      <button
+        class="logo"
+      >
+        <img
+          alt="Klurigo"
+          class="icon"
+          src="/src/assets/images/klurigo-icon.svg"
+        />
+        <span
+          class="text"
+        >
+          Klurigo
+        </span>
+      </button>
+      <div
+        class="side"
+      >
+        <a
+          data-discover="true"
+          href="/auth/login"
+        >
+          Login
+        </a>
+      </div>
+    </div>
+    <div
+      class="content centerAlign"
+    >
+      <div
+        class="contentWrapper fullWidth"
+      >
+        <div
+          class="contentInner"
+        >
+          <div
+            class="typography subtitle full"
+          >
+            Lock It Down!
+          </div>
+          <div
+            class="typography text medium"
+          >
+            Choose your dazzling new password and confirm it below. Let’s keep those sneaky hackers out!
+          </div>
+          <form
+            class="form"
+          >
+            <div
+              class="inputContainer"
+            >
+              <div
+                class="textFieldInputContainer textFieldInputKindPrimary disabled"
+              >
+                <input
+                  class="textfield"
+                  data-testid="test-password-textfield"
+                  disabled=""
+                  id="password"
+                  maxlength="128"
+                  minlength="8"
+                  name="password"
+                  placeholder="New Password"
+                  type="password"
+                  value=""
+                />
+              </div>
+            </div>
+            <div
+              class="inputContainer"
+            >
+              <div
+                class="textFieldInputContainer textFieldInputKindPrimary disabled"
+              >
+                <input
+                  class="textfield"
+                  data-testid="test-confirmPassword-textfield"
+                  disabled=""
+                  id="confirmPassword"
+                  maxlength="128"
+                  minlength="8"
+                  name="confirmPassword"
+                  placeholder="Confirm Password"
+                  type="password"
+                  value=""
+                />
+              </div>
+            </div>
+            <div
+              class="buttonInputContainer buttonInputKindCallToAction"
+            >
+              <button
+                data-testid="test-reset-password-button-button"
+                disabled=""
+                id="reset-password-button"
+                name="reset-password-button"
+                type="submit"
+              >
+                <div
+                  class="loadingSpinner"
+                >
+                  <div />
+                  <div />
+                  <div />
+                </div>
+              </button>
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/packages/quiz/src/pages/AuthRegisterPage/AuthRegisterPage.test.tsx
+++ b/packages/quiz/src/pages/AuthRegisterPage/AuthRegisterPage.test.tsx
@@ -1,0 +1,144 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import React from 'react'
+import { MemoryRouter } from 'react-router-dom'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const h = vi.hoisted(() => ({
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  register: vi.fn<[], Promise<void>>().mockResolvedValue(),
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  login: vi.fn<[], Promise<void>>().mockResolvedValue(),
+  navigate: vi.fn(),
+}))
+
+vi.mock('../../api/use-quiz-service-client.tsx', () => ({
+  useQuizServiceClient: () => ({ register: h.register, login: h.login }),
+}))
+
+vi.mock('react-router-dom', async (orig) => {
+  const actual = await orig()
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  return { ...actual, useNavigate: () => h.navigate }
+})
+
+import AuthRegisterPage from './AuthRegisterPage'
+
+function fillAllFields() {
+  fireEvent.change(screen.getByPlaceholderText('Email'), {
+    target: { value: 'user@example.com' },
+  })
+  fireEvent.change(screen.getByPlaceholderText('Password'), {
+    target: { value: 'PPss11!!' },
+  })
+  fireEvent.change(screen.getByPlaceholderText('Given Name'), {
+    target: { value: 'John' },
+  })
+  fireEvent.change(screen.getByPlaceholderText('Family Name'), {
+    target: { value: 'Doe' },
+  })
+
+  const textboxes = screen.getAllByRole('textbox')
+  const known = new Set([
+    screen.getByPlaceholderText('Email'),
+    screen.getByPlaceholderText('Given Name'),
+    screen.getByPlaceholderText('Family Name'),
+  ])
+  const nicknameInput = textboxes.find(
+    (el) => !known.has(el as HTMLInputElement),
+  )
+  if (!nicknameInput) throw new Error('Nickname input not found')
+  fireEvent.change(nicknameInput, { target: { value: 'ShadowCyborg' } })
+}
+
+describe('AuthRegisterPage', () => {
+  beforeEach(() => {
+    h.register.mockClear()
+    h.login.mockClear()
+    h.navigate.mockClear()
+  })
+
+  it('renders and keeps submit disabled until all fields valid', () => {
+    const { container } = render(
+      <MemoryRouter>
+        <AuthRegisterPage />
+      </MemoryRouter>,
+    )
+
+    const submit = container.querySelector('#join') as HTMLButtonElement
+    expect(submit).toBeDisabled()
+
+    fillAllFields()
+
+    expect(submit).not.toBeDisabled()
+  })
+
+  it('registers, then logs in, then navigates home; submit disabled during pending', async () => {
+    let resolveRegister!: () => void
+    let resolveLogin!: () => void
+
+    h.register.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveRegister = resolve
+        }),
+    )
+    h.login.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveLogin = resolve
+        }),
+    )
+
+    const { container } = render(
+      <MemoryRouter>
+        <AuthRegisterPage />
+      </MemoryRouter>,
+    )
+
+    fillAllFields()
+    const submit = container.querySelector('#join') as HTMLButtonElement
+    fireEvent.click(submit)
+
+    expect(h.register).toHaveBeenCalledTimes(1)
+    expect(submit).toBeDisabled()
+
+    resolveRegister!()
+    await waitFor(() => expect(h.login).toHaveBeenCalledTimes(1))
+
+    resolveLogin!()
+    await waitFor(() => expect(h.navigate).toHaveBeenCalledWith('/'))
+
+    expect(submit).not.toBeDisabled()
+  })
+
+  it('disables during successful register+login and re-enables after', async () => {
+    let resolveLogin!: () => void
+    h.register.mockResolvedValue({})
+    h.login.mockImplementation(
+      () => new Promise<void>((r) => (resolveLogin = r)),
+    )
+
+    const { container } = render(
+      <MemoryRouter>
+        <AuthRegisterPage />
+      </MemoryRouter>,
+    )
+
+    fillAllFields()
+
+    const submit = container.querySelector('#join') as HTMLButtonElement
+    fireEvent.click(submit)
+
+    await waitFor(() => expect(h.register).toHaveBeenCalledTimes(1))
+    await waitFor(() => expect(h.login).toHaveBeenCalledTimes(1))
+
+    await waitFor(() => expect(submit).toBeDisabled())
+
+    resolveLogin()
+    await waitFor(() => expect(h.navigate).toHaveBeenCalledWith('/'))
+    await waitFor(() => expect(submit).not.toBeDisabled())
+  })
+})

--- a/packages/quiz/src/pages/AuthRegisterPage/components/AuthRegisterPageUI/AuthRegisterPageUI.test.tsx
+++ b/packages/quiz/src/pages/AuthRegisterPage/components/AuthRegisterPageUI/AuthRegisterPageUI.test.tsx
@@ -1,16 +1,87 @@
-import { render } from '@testing-library/react'
+import { fireEvent, render, screen } from '@testing-library/react'
 import React from 'react'
 import { MemoryRouter } from 'react-router-dom'
-import { describe, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import AuthRegisterPageUI from './AuthRegisterPageUI'
 
+vi.mock('./text.utils.ts', () => ({
+  getTitle: () => 'Create your account',
+  getMessage: () => 'Join the party — make an account in seconds.',
+}))
+
 describe('AuthRegisterPageUI', () => {
-  it('should render AuthRegisterPageUI', async () => {
-    render(
+  it('renders default state', () => {
+    const { container } = render(
       <MemoryRouter>
         <AuthRegisterPageUI loading={false} onSubmit={() => undefined} />
       </MemoryRouter>,
     )
+    expect(screen.getByText('Create your account')).toBeInTheDocument()
+    expect(
+      screen.getByText('Join the party — make an account in seconds.'),
+    ).toBeInTheDocument()
+    expect(container).toMatchSnapshot()
+  })
+
+  it('renders loading state', () => {
+    const { container } = render(
+      <MemoryRouter>
+        <AuthRegisterPageUI loading={true} onSubmit={() => undefined} />
+      </MemoryRouter>,
+    )
+    // Submit should be disabled while loading
+    const submit = container.querySelector('#join') as HTMLButtonElement
+    expect(submit).toBeDisabled()
+    expect(container).toMatchSnapshot()
+  })
+
+  it('keeps submit disabled until all fields are valid, then submits values', () => {
+    const onSubmit = vi.fn()
+    const { container } = render(
+      <MemoryRouter>
+        <AuthRegisterPageUI loading={false} onSubmit={onSubmit} />
+      </MemoryRouter>,
+    )
+
+    const submit = container.querySelector('#join') as HTMLButtonElement
+    expect(submit).toBeDisabled()
+
+    // Fill required/validated fields with values that satisfy regex/lengths
+    fireEvent.change(screen.getByPlaceholderText('Email'), {
+      target: { value: 'user@example.com' },
+    })
+    fireEvent.change(screen.getByPlaceholderText('Password'), {
+      target: { value: 'PPss11!!' }, // ≥2 upper, ≥2 lower, ≥2 digits, ≥2 symbols
+    })
+    fireEvent.change(screen.getByPlaceholderText('Given Name'), {
+      target: { value: 'Alice' },
+    })
+    fireEvent.change(screen.getByPlaceholderText('Family Name'), {
+      target: { value: 'Smith' },
+    })
+
+    // NicknameTextField doesn't expose a placeholder; select the remaining text input
+    const textInputs = Array.from(
+      container.querySelectorAll('input[type="text"]'),
+    ) as HTMLInputElement[]
+    const nicknameInput = textInputs.find(
+      (el) =>
+        el.id !== 'email' && el.id !== 'givenName' && el.id !== 'familyName',
+    ) as HTMLInputElement
+    fireEvent.change(nicknameInput, { target: { value: 'FrostyBear' } })
+
+    expect(submit).not.toBeDisabled()
+
+    fireEvent.click(submit)
+
+    expect(onSubmit).toHaveBeenCalledTimes(1)
+    expect(onSubmit).toHaveBeenCalledWith({
+      email: 'user@example.com',
+      password: 'PPss11!!',
+      givenName: 'Alice',
+      familyName: 'Smith',
+      defaultNickname: 'FrostyBear',
+    })
   })
 })

--- a/packages/quiz/src/pages/AuthRegisterPage/components/AuthRegisterPageUI/AuthRegisterPageUI.tsx
+++ b/packages/quiz/src/pages/AuthRegisterPage/components/AuthRegisterPageUI/AuthRegisterPageUI.tsx
@@ -26,7 +26,7 @@ import {
 import NicknameTextField from '../../../../components/NicknameTextField'
 
 import styles from './AuthRegisterPageUI.module.scss'
-import { getMessage, getTitle } from './helpers.ts'
+import { getMessage, getTitle } from './text.utils.ts'
 
 export type CreateUserFormFields = CreateUserRequestDto
 

--- a/packages/quiz/src/pages/AuthRegisterPage/components/AuthRegisterPageUI/__snapshots__/AuthRegisterPageUI.test.tsx.snap
+++ b/packages/quiz/src/pages/AuthRegisterPage/components/AuthRegisterPageUI/__snapshots__/AuthRegisterPageUI.test.tsx.snap
@@ -1,0 +1,544 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`AuthRegisterPageUI > renders default state 1`] = `
+<div>
+  <div
+    class="main"
+  >
+    <div
+      class="header"
+    >
+      <button
+        class="logo"
+      >
+        <img
+          alt="Klurigo"
+          class="icon"
+          src="/src/assets/images/klurigo-icon.svg"
+        />
+        <span
+          class="text"
+        >
+          Klurigo
+        </span>
+      </button>
+      <div
+        class="side"
+      >
+        <a
+          data-discover="true"
+          href="/auth/login"
+        >
+          Login
+        </a>
+      </div>
+    </div>
+    <div
+      class="content startAlign"
+    >
+      <div
+        class="contentWrapper fullWidth"
+      >
+        <div
+          class="contentInner"
+        >
+          <div
+            class="card kindCallToAction sizeLarge center"
+          >
+            <button
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                class="svg-inline--fa fa-xmark"
+                data-icon="xmark"
+                data-prefix="fas"
+                role="img"
+                viewBox="0 0 384 512"
+              >
+                <path
+                  d="M55.1 73.4c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3L147.2 256 9.9 393.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0L192.5 301.3 329.9 438.6c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3L237.8 256 375.1 118.6c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0L192.5 210.7 55.1 73.4z"
+                  fill="currentColor"
+                />
+              </svg>
+            </button>
+            <div
+              class="content"
+            >
+              <span>
+                Hey quiz champion! Did your brainy adventures happen on
+                 
+                <a
+                  href="https://quiz.emilhornlund.com"
+                >
+                  quiz.emilhornlund.com
+                </a>
+                ? No worries— we can save all your quiz creations and epic game stats! Just pop back to
+                 
+                <a
+                  href="https://quiz.emilhornlund.com"
+                >
+                  quiz.emilhornlund.com
+                </a>
+                 one last time, and we’ll magically teleport everything over to
+                 
+                <b>
+                  <i>
+                    klurigo.com
+                  </i>
+                </b>
+                . Ready to blast off your data?
+              </span>
+            </div>
+          </div>
+          <div
+            class="typography title medium"
+          >
+            Create your account
+          </div>
+          <div
+            class="typography text small"
+          >
+            Join the party — make an account in seconds.
+          </div>
+          <form
+            class="createUserForm"
+          >
+            <div
+              class="inputContainer"
+            >
+              <div
+                class="textFieldInputContainer textFieldInputKindPrimary"
+              >
+                <input
+                  class="textfield"
+                  data-testid="test-email-textfield"
+                  id="email"
+                  maxlength="128"
+                  minlength="6"
+                  name="email"
+                  placeholder="Email"
+                  type="text"
+                  value=""
+                />
+              </div>
+            </div>
+            <div
+              class="inputContainer"
+            >
+              <div
+                class="textFieldInputContainer textFieldInputKindPrimary"
+              >
+                <input
+                  class="textfield"
+                  data-testid="test-password-textfield"
+                  id="password"
+                  maxlength="128"
+                  minlength="8"
+                  name="password"
+                  placeholder="Password"
+                  type="password"
+                  value=""
+                />
+              </div>
+            </div>
+            <div
+              class="inputContainer"
+            >
+              <div
+                class="textFieldInputContainer textFieldInputKindPrimary"
+              >
+                <input
+                  class="textfield"
+                  data-testid="test-givenName-textfield"
+                  id="givenName"
+                  maxlength="64"
+                  minlength="1"
+                  name="givenName"
+                  placeholder="Given Name"
+                  type="text"
+                  value=""
+                />
+              </div>
+            </div>
+            <div
+              class="inputContainer"
+            >
+              <div
+                class="textFieldInputContainer textFieldInputKindPrimary"
+              >
+                <input
+                  class="textfield"
+                  data-testid="test-familyName-textfield"
+                  id="familyName"
+                  maxlength="64"
+                  minlength="1"
+                  name="familyName"
+                  placeholder="Family Name"
+                  type="text"
+                  value=""
+                />
+              </div>
+            </div>
+            <div
+              class="nicknameTextFieldContainer"
+            >
+              <div
+                class="inputContainer"
+              >
+                <div
+                  class="textFieldInputContainer textFieldInputKindPrimary"
+                >
+                  <input
+                    class="textfield"
+                    data-testid="test-default-nickname-textfield-textfield"
+                    id="default-nickname-textfield"
+                    maxlength="20"
+                    minlength="2"
+                    name="default-nickname-textfield"
+                    placeholder="Default Nickname"
+                    type="text"
+                    value=""
+                  />
+                </div>
+              </div>
+              <div
+                class="buttonInputContainer buttonInputKindPrimary"
+              >
+                <button
+                  data-testid="test-shuffle-nickname-button-button"
+                  id="shuffle-nickname-button"
+                  name="shuffle-nickname-button"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="svg-inline--fa fa-arrows-rotate"
+                    data-icon="arrows-rotate"
+                    data-prefix="fas"
+                    role="img"
+                    viewBox="0 0 512 512"
+                  >
+                    <path
+                      d="M65.9 228.5c13.3-93 93.4-164.5 190.1-164.5 53 0 101 21.5 135.8 56.2 .2 .2 .4 .4 .6 .6l7.6 7.2-47.9 0c-17.7 0-32 14.3-32 32s14.3 32 32 32l128 0c17.7 0 32-14.3 32-32l0-128c0-17.7-14.3-32-32-32s-32 14.3-32 32l0 53.4-11.3-10.7C390.5 28.6 326.5 0 256 0 127 0 20.3 95.4 2.6 219.5 .1 237 12.2 253.2 29.7 255.7s33.7-9.7 36.2-27.1zm443.5 64c2.5-17.5-9.7-33.7-27.1-36.2s-33.7 9.7-36.2 27.1c-13.3 93-93.4 164.5-190.1 164.5-53 0-101-21.5-135.8-56.2-.2-.2-.4-.4-.6-.6l-7.6-7.2 47.9 0c17.7 0 32-14.3 32-32s-14.3-32-32-32L32 320c-8.5 0-16.7 3.4-22.7 9.5S-.1 343.7 0 352.3l1 127c.1 17.7 14.6 31.9 32.3 31.7S65.2 496.4 65 478.7l-.4-51.5 10.7 10.1c46.3 46.1 110.2 74.7 180.7 74.7 129 0 235.7-95.4 253.4-219.5z"
+                      fill="currentColor"
+                    />
+                  </svg>
+                </button>
+              </div>
+            </div>
+            <div
+              class="buttonInputContainer buttonInputKindCallToAction"
+            >
+              <button
+                data-testid="test-join-button"
+                disabled=""
+                id="join"
+                name="join"
+                type="submit"
+              >
+                <span>
+                  Let's go!
+                </span>
+                <svg
+                  aria-hidden="true"
+                  class="svg-inline--fa fa-arrow-right"
+                  data-icon="arrow-right"
+                  data-prefix="fas"
+                  role="img"
+                  viewBox="0 0 512 512"
+                >
+                  <path
+                    d="M502.6 278.6c12.5-12.5 12.5-32.8 0-45.3l-160-160c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3L402.7 224 32 224c-17.7 0-32 14.3-32 32s14.3 32 32 32l370.7 0-105.4 105.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0l160-160z"
+                    fill="currentColor"
+                  />
+                </svg>
+              </button>
+            </div>
+          </form>
+          <a
+            data-discover="true"
+            href="/auth/login"
+          >
+            <div
+              class="typography link small"
+            >
+              Got an account? Flash your credentials and come on in!
+            </div>
+          </a>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`AuthRegisterPageUI > renders loading state 1`] = `
+<div>
+  <div
+    class="main"
+  >
+    <div
+      class="header"
+    >
+      <button
+        class="logo"
+      >
+        <img
+          alt="Klurigo"
+          class="icon"
+          src="/src/assets/images/klurigo-icon.svg"
+        />
+        <span
+          class="text"
+        >
+          Klurigo
+        </span>
+      </button>
+      <div
+        class="side"
+      >
+        <a
+          data-discover="true"
+          href="/auth/login"
+        >
+          Login
+        </a>
+      </div>
+    </div>
+    <div
+      class="content startAlign"
+    >
+      <div
+        class="contentWrapper fullWidth"
+      >
+        <div
+          class="contentInner"
+        >
+          <div
+            class="card kindCallToAction sizeLarge center"
+          >
+            <button
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                class="svg-inline--fa fa-xmark"
+                data-icon="xmark"
+                data-prefix="fas"
+                role="img"
+                viewBox="0 0 384 512"
+              >
+                <path
+                  d="M55.1 73.4c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3L147.2 256 9.9 393.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0L192.5 301.3 329.9 438.6c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3L237.8 256 375.1 118.6c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0L192.5 210.7 55.1 73.4z"
+                  fill="currentColor"
+                />
+              </svg>
+            </button>
+            <div
+              class="content"
+            >
+              <span>
+                Hey quiz champion! Did your brainy adventures happen on
+                 
+                <a
+                  href="https://quiz.emilhornlund.com"
+                >
+                  quiz.emilhornlund.com
+                </a>
+                ? No worries— we can save all your quiz creations and epic game stats! Just pop back to
+                 
+                <a
+                  href="https://quiz.emilhornlund.com"
+                >
+                  quiz.emilhornlund.com
+                </a>
+                 one last time, and we’ll magically teleport everything over to
+                 
+                <b>
+                  <i>
+                    klurigo.com
+                  </i>
+                </b>
+                . Ready to blast off your data?
+              </span>
+            </div>
+          </div>
+          <div
+            class="typography title medium"
+          >
+            Create your account
+          </div>
+          <div
+            class="typography text small"
+          >
+            Join the party — make an account in seconds.
+          </div>
+          <form
+            class="createUserForm"
+          >
+            <div
+              class="inputContainer"
+            >
+              <div
+                class="textFieldInputContainer textFieldInputKindPrimary disabled"
+              >
+                <input
+                  class="textfield"
+                  data-testid="test-email-textfield"
+                  disabled=""
+                  id="email"
+                  maxlength="128"
+                  minlength="6"
+                  name="email"
+                  placeholder="Email"
+                  type="text"
+                  value=""
+                />
+              </div>
+            </div>
+            <div
+              class="inputContainer"
+            >
+              <div
+                class="textFieldInputContainer textFieldInputKindPrimary disabled"
+              >
+                <input
+                  class="textfield"
+                  data-testid="test-password-textfield"
+                  disabled=""
+                  id="password"
+                  maxlength="128"
+                  minlength="8"
+                  name="password"
+                  placeholder="Password"
+                  type="password"
+                  value=""
+                />
+              </div>
+            </div>
+            <div
+              class="inputContainer"
+            >
+              <div
+                class="textFieldInputContainer textFieldInputKindPrimary disabled"
+              >
+                <input
+                  class="textfield"
+                  data-testid="test-givenName-textfield"
+                  disabled=""
+                  id="givenName"
+                  maxlength="64"
+                  minlength="1"
+                  name="givenName"
+                  placeholder="Given Name"
+                  type="text"
+                  value=""
+                />
+              </div>
+            </div>
+            <div
+              class="inputContainer"
+            >
+              <div
+                class="textFieldInputContainer textFieldInputKindPrimary disabled"
+              >
+                <input
+                  class="textfield"
+                  data-testid="test-familyName-textfield"
+                  disabled=""
+                  id="familyName"
+                  maxlength="64"
+                  minlength="1"
+                  name="familyName"
+                  placeholder="Family Name"
+                  type="text"
+                  value=""
+                />
+              </div>
+            </div>
+            <div
+              class="nicknameTextFieldContainer"
+            >
+              <div
+                class="inputContainer"
+              >
+                <div
+                  class="textFieldInputContainer textFieldInputKindPrimary disabled"
+                >
+                  <input
+                    class="textfield"
+                    data-testid="test-default-nickname-textfield-textfield"
+                    disabled=""
+                    id="default-nickname-textfield"
+                    maxlength="20"
+                    minlength="2"
+                    name="default-nickname-textfield"
+                    placeholder="Default Nickname"
+                    type="text"
+                    value=""
+                  />
+                </div>
+              </div>
+              <div
+                class="buttonInputContainer buttonInputKindPrimary"
+              >
+                <button
+                  data-testid="test-shuffle-nickname-button-button"
+                  disabled=""
+                  id="shuffle-nickname-button"
+                  name="shuffle-nickname-button"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="svg-inline--fa fa-arrows-rotate"
+                    data-icon="arrows-rotate"
+                    data-prefix="fas"
+                    role="img"
+                    viewBox="0 0 512 512"
+                  >
+                    <path
+                      d="M65.9 228.5c13.3-93 93.4-164.5 190.1-164.5 53 0 101 21.5 135.8 56.2 .2 .2 .4 .4 .6 .6l7.6 7.2-47.9 0c-17.7 0-32 14.3-32 32s14.3 32 32 32l128 0c17.7 0 32-14.3 32-32l0-128c0-17.7-14.3-32-32-32s-32 14.3-32 32l0 53.4-11.3-10.7C390.5 28.6 326.5 0 256 0 127 0 20.3 95.4 2.6 219.5 .1 237 12.2 253.2 29.7 255.7s33.7-9.7 36.2-27.1zm443.5 64c2.5-17.5-9.7-33.7-27.1-36.2s-33.7 9.7-36.2 27.1c-13.3 93-93.4 164.5-190.1 164.5-53 0-101-21.5-135.8-56.2-.2-.2-.4-.4-.6-.6l-7.6-7.2 47.9 0c17.7 0 32-14.3 32-32s-14.3-32-32-32L32 320c-8.5 0-16.7 3.4-22.7 9.5S-.1 343.7 0 352.3l1 127c.1 17.7 14.6 31.9 32.3 31.7S65.2 496.4 65 478.7l-.4-51.5 10.7 10.1c46.3 46.1 110.2 74.7 180.7 74.7 129 0 235.7-95.4 253.4-219.5z"
+                      fill="currentColor"
+                    />
+                  </svg>
+                </button>
+              </div>
+            </div>
+            <div
+              class="buttonInputContainer buttonInputKindCallToAction"
+            >
+              <button
+                data-testid="test-join-button"
+                disabled=""
+                id="join"
+                name="join"
+                type="submit"
+              >
+                <div
+                  class="loadingSpinner"
+                >
+                  <div />
+                  <div />
+                  <div />
+                </div>
+              </button>
+            </div>
+          </form>
+          <a
+            data-discover="true"
+            href="/auth/login"
+          >
+            <div
+              class="typography link small"
+            >
+              Got an account? Flash your credentials and come on in!
+            </div>
+          </a>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/packages/quiz/src/pages/AuthRegisterPage/components/AuthRegisterPageUI/text.utils.test.ts
+++ b/packages/quiz/src/pages/AuthRegisterPage/components/AuthRegisterPageUI/text.utils.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { getMessage, getTitle, MESSAGES, TITLES } from './text.utils.ts'
+
+describe('AuthRegister helpers', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe('getTitle', () => {
+    it('returns first title when Math.random is 0', () => {
+      vi.spyOn(Math, 'random').mockReturnValue(0)
+      expect(getTitle()).toBe(TITLES[0])
+    })
+
+    it('returns middle title when Math.random is 0.5', () => {
+      vi.spyOn(Math, 'random').mockReturnValue(0.5)
+      // TITLES length is 10 -> floor(0.5 * 10) = 5
+      expect(getTitle()).toBe(TITLES[5])
+    })
+
+    it('returns last title when Math.random is close to 1', () => {
+      vi.spyOn(Math, 'random').mockReturnValue(0.999999)
+      expect(getTitle()).toBe(TITLES[TITLES.length - 1])
+    })
+
+    it('returns one of the predefined titles', () => {
+      vi.spyOn(Math, 'random').mockReturnValue(0.12)
+      expect(TITLES).toContain(getTitle())
+    })
+  })
+
+  describe('getMessage', () => {
+    it('returns first message when Math.random is 0', () => {
+      vi.spyOn(Math, 'random').mockReturnValue(0)
+      expect(getMessage()).toBe(MESSAGES[0])
+    })
+
+    it('returns middle message when Math.random is 0.5', () => {
+      vi.spyOn(Math, 'random').mockReturnValue(0.5)
+      // MESSAGES length is 9 -> floor(0.5 * 9) = 4
+      expect(getMessage()).toBe(MESSAGES[4])
+    })
+
+    it('returns last message when Math.random is close to 1', () => {
+      vi.spyOn(Math, 'random').mockReturnValue(0.999999)
+      expect(getMessage()).toBe(MESSAGES[MESSAGES.length - 1])
+    })
+
+    it('returns one of the predefined messages', () => {
+      vi.spyOn(Math, 'random').mockReturnValue(0.23)
+      expect(MESSAGES).toContain(getMessage())
+    })
+  })
+})

--- a/packages/quiz/src/pages/AuthRegisterPage/components/AuthRegisterPageUI/text.utils.ts
+++ b/packages/quiz/src/pages/AuthRegisterPage/components/AuthRegisterPageUI/text.utils.ts
@@ -1,4 +1,4 @@
-const TITLES = [
+export const TITLES = [
   'Join the quiz zone!',
   'Welcome, newcomer!',
   'Create your quiz identity',
@@ -11,7 +11,7 @@ const TITLES = [
   'New here? Let’s fix that!',
 ]
 
-const MESSAGES = [
+export const MESSAGES = [
   'Create an account to start building quizzes, tracking your progress, and challenging others to brainy showdowns.',
   'Join a growing world of trivia lovers and unlock access to all the quizzes, stats, and features you never knew you needed.',
   'Sign up and claim your spot on the leaderboard — your quiz legacy starts here.',

--- a/packages/quiz/src/pages/AuthVerifyPage/AuthVerifyPage.test.tsx
+++ b/packages/quiz/src/pages/AuthVerifyPage/AuthVerifyPage.test.tsx
@@ -1,0 +1,147 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import React from 'react'
+import { MemoryRouter } from 'react-router-dom'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// hoisted shared state
+const h = vi.hoisted(() => ({
+  verifyEmail: vi.fn<(token: string) => Promise<void>>().mockResolvedValue(),
+  isUserAuthenticated: false,
+  navigate: vi.fn(),
+}))
+
+vi.mock('../../api/use-quiz-service-client.tsx', () => ({
+  useQuizServiceClient: () => ({ verifyEmail: h.verifyEmail }),
+}))
+
+vi.mock('../../context/auth', () => ({
+  useAuthContext: () => ({ isUserAuthenticated: h.isUserAuthenticated }),
+}))
+
+vi.mock('react-router-dom', async (orig) => {
+  const actual = await orig()
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  return { ...actual, useNavigate: () => h.navigate }
+})
+
+import AuthVerifyPage from './AuthVerifyPage'
+
+describe('AuthVerifyPage', () => {
+  beforeEach(() => {
+    h.verifyEmail.mockClear()
+    h.isUserAuthenticated = false
+    h.navigate.mockClear()
+  })
+
+  it('navigates home when token is missing', () => {
+    const { container } = render(
+      <MemoryRouter initialEntries={['/auth/verify']}>
+        <AuthVerifyPage />
+      </MemoryRouter>,
+    )
+
+    expect(h.navigate).toHaveBeenCalledWith('/')
+    expect(container).toMatchSnapshot()
+  })
+
+  it('shows loading while verifying with token present', () => {
+    h.verifyEmail.mockReturnValue(new Promise(() => {})) // stay pending
+
+    const { container } = render(
+      <MemoryRouter initialEntries={['/auth/verify?token=ABC']}>
+        <AuthVerifyPage />
+      </MemoryRouter>,
+    )
+
+    expect(h.verifyEmail).toHaveBeenCalledWith('ABC')
+    expect(
+      screen.getByText('One moment… verifying your magic link!'),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText('Good things come to those who wait!'),
+    ).toBeInTheDocument()
+    expect(container).toMatchSnapshot()
+  })
+
+  it('renders verified state (logged out) with login link', async () => {
+    let resolve!: () => void
+    h.verifyEmail.mockImplementation(
+      () =>
+        new Promise<void>((r) => {
+          resolve = r
+        }),
+    )
+
+    const { container } = render(
+      <MemoryRouter initialEntries={['/auth/verify?token=TOK']}>
+        <AuthVerifyPage />
+      </MemoryRouter>,
+    )
+
+    resolve()
+    await waitFor(() =>
+      expect(
+        screen.getByText('Hooray! Your email’s all set!'),
+      ).toBeInTheDocument(),
+    )
+
+    const loginLink = screen.getByRole('link', {
+      name: 'Log in to get started!',
+    })
+    expect(loginLink).toHaveAttribute('href', '/auth/login')
+    expect(container).toMatchSnapshot()
+  })
+
+  it('renders verified state (logged in) with home link', async () => {
+    h.isUserAuthenticated = true
+    let resolve!: () => void
+    h.verifyEmail.mockImplementation(
+      () =>
+        new Promise<void>((r) => {
+          resolve = r
+        }),
+    )
+
+    const { container } = render(
+      <MemoryRouter initialEntries={['/auth/verify?token=ZZZ']}>
+        <AuthVerifyPage />
+      </MemoryRouter>,
+    )
+
+    resolve()
+    await waitFor(() =>
+      expect(
+        screen.getByText('Hooray! Your email’s all set!'),
+      ).toBeInTheDocument(),
+    )
+
+    const homeLink = screen.getByRole('link', { name: 'Take me home' })
+    expect(homeLink).toHaveAttribute('href', '/')
+    expect(container).toMatchSnapshot()
+  })
+
+  it('shows error state when verification fails', async () => {
+    let reject!: (e?: unknown) => void
+    h.verifyEmail.mockImplementation(
+      () =>
+        new Promise<void>((_, r) => {
+          reject = r
+        }),
+    )
+
+    const { container } = render(
+      <MemoryRouter initialEntries={['/auth/verify?token=BAD']}>
+        <AuthVerifyPage />
+      </MemoryRouter>,
+    )
+
+    reject(new Error('nope'))
+    await waitFor(() =>
+      expect(
+        screen.getByText('Oops! Something went wrong.'),
+      ).toBeInTheDocument(),
+    )
+    expect(container).toMatchSnapshot()
+  })
+})

--- a/packages/quiz/src/pages/AuthVerifyPage/__snapshots__/AuthVerifyPage.test.tsx.snap
+++ b/packages/quiz/src/pages/AuthVerifyPage/__snapshots__/AuthVerifyPage.test.tsx.snap
@@ -1,0 +1,374 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`AuthVerifyPage > navigates home when token is missing 1`] = `
+<div>
+  <div
+    class="main"
+  >
+    <div
+      class="header"
+    >
+      <button
+        class="logo"
+      >
+        <img
+          alt="Klurigo"
+          class="icon"
+          src="/src/assets/images/klurigo-icon.svg"
+        />
+        <span
+          class="text"
+        >
+          Klurigo
+        </span>
+      </button>
+      <div
+        class="side"
+      >
+        <a
+          data-discover="true"
+          href="/auth/login"
+        >
+          Login
+        </a>
+      </div>
+    </div>
+    <div
+      class="content centerAlign"
+    >
+      <div
+        class="contentWrapper fullWidth"
+      >
+        <div
+          class="contentInner"
+        >
+          <div
+            class="typography subtitle small"
+          >
+            One moment… verifying your magic link!
+          </div>
+          <div
+            class="loadingSpinnerContainer"
+          >
+            <div />
+            <div />
+            <div />
+          </div>
+          <div
+            class="typography text small"
+          >
+            Good things come to those who wait!
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`AuthVerifyPage > renders verified state (logged in) with home link 1`] = `
+<div>
+  <div
+    class="main"
+  >
+    <div
+      class="header"
+    >
+      <button
+        class="logo"
+      >
+        <img
+          alt="Klurigo"
+          class="icon"
+          src="/src/assets/images/klurigo-icon.svg"
+        />
+        <span
+          class="text"
+        >
+          Klurigo
+        </span>
+      </button>
+      <div
+        class="side"
+      />
+    </div>
+    <div
+      class="content centerAlign"
+    >
+      <div
+        class="contentWrapper fullWidth"
+      >
+        <div
+          class="contentInner"
+        >
+          <div
+            class="badge large green"
+          >
+            <svg
+              aria-hidden="true"
+              class="svg-inline--fa fa-check"
+              data-icon="check"
+              data-prefix="fas"
+              role="img"
+              viewBox="0 0 448 512"
+            >
+              <path
+                d="M434.8 70.1c14.3 10.4 17.5 30.4 7.1 44.7l-256 352c-5.5 7.6-14 12.3-23.4 13.1s-18.5-2.7-25.1-9.3l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0l101.5 101.5 234-321.7c10.4-14.3 30.4-17.5 44.7-7.1z"
+                fill="currentColor"
+              />
+            </svg>
+          </div>
+          <div
+            class="typography subtitle medium"
+          >
+            Hooray! Your email’s all set!
+          </div>
+          <div
+            class="typography text medium"
+          >
+            Welcome aboard the fun train. Let’s roll!
+          </div>
+          <a
+            data-discover="true"
+            href="/"
+          >
+            <div
+              class="typography link small"
+            >
+              Take me home
+            </div>
+          </a>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`AuthVerifyPage > renders verified state (logged out) with login link 1`] = `
+<div>
+  <div
+    class="main"
+  >
+    <div
+      class="header"
+    >
+      <button
+        class="logo"
+      >
+        <img
+          alt="Klurigo"
+          class="icon"
+          src="/src/assets/images/klurigo-icon.svg"
+        />
+        <span
+          class="text"
+        >
+          Klurigo
+        </span>
+      </button>
+      <div
+        class="side"
+      >
+        <a
+          data-discover="true"
+          href="/auth/login"
+        >
+          Login
+        </a>
+      </div>
+    </div>
+    <div
+      class="content centerAlign"
+    >
+      <div
+        class="contentWrapper fullWidth"
+      >
+        <div
+          class="contentInner"
+        >
+          <div
+            class="badge large green"
+          >
+            <svg
+              aria-hidden="true"
+              class="svg-inline--fa fa-check"
+              data-icon="check"
+              data-prefix="fas"
+              role="img"
+              viewBox="0 0 448 512"
+            >
+              <path
+                d="M434.8 70.1c14.3 10.4 17.5 30.4 7.1 44.7l-256 352c-5.5 7.6-14 12.3-23.4 13.1s-18.5-2.7-25.1-9.3l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0l101.5 101.5 234-321.7c10.4-14.3 30.4-17.5 44.7-7.1z"
+                fill="currentColor"
+              />
+            </svg>
+          </div>
+          <div
+            class="typography subtitle medium"
+          >
+            Hooray! Your email’s all set!
+          </div>
+          <div
+            class="typography text medium"
+          >
+            Welcome aboard the fun train. Let’s roll!
+          </div>
+          <a
+            data-discover="true"
+            href="/auth/login"
+          >
+            <div
+              class="typography link small"
+            >
+              Log in to get started!
+            </div>
+          </a>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`AuthVerifyPage > shows error state when verification fails 1`] = `
+<div>
+  <div
+    class="main"
+  >
+    <div
+      class="header"
+    >
+      <button
+        class="logo"
+      >
+        <img
+          alt="Klurigo"
+          class="icon"
+          src="/src/assets/images/klurigo-icon.svg"
+        />
+        <span
+          class="text"
+        >
+          Klurigo
+        </span>
+      </button>
+      <div
+        class="side"
+      >
+        <a
+          data-discover="true"
+          href="/auth/login"
+        >
+          Login
+        </a>
+      </div>
+    </div>
+    <div
+      class="content centerAlign"
+    >
+      <div
+        class="contentWrapper fullWidth"
+      >
+        <div
+          class="contentInner"
+        >
+          <div
+            class="badge large red"
+          >
+            <svg
+              aria-hidden="true"
+              class="svg-inline--fa fa-xmark"
+              data-icon="xmark"
+              data-prefix="fas"
+              role="img"
+              viewBox="0 0 384 512"
+            >
+              <path
+                d="M55.1 73.4c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3L147.2 256 9.9 393.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0L192.5 301.3 329.9 438.6c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3L237.8 256 375.1 118.6c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0L192.5 210.7 55.1 73.4z"
+                fill="currentColor"
+              />
+            </svg>
+          </div>
+          <div
+            class="typography subtitle small"
+          >
+            Oops! Something went wrong.
+          </div>
+          <div
+            class="typography text medium"
+          >
+            The supplied link is invalid or has expired.
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`AuthVerifyPage > shows loading while verifying with token present 1`] = `
+<div>
+  <div
+    class="main"
+  >
+    <div
+      class="header"
+    >
+      <button
+        class="logo"
+      >
+        <img
+          alt="Klurigo"
+          class="icon"
+          src="/src/assets/images/klurigo-icon.svg"
+        />
+        <span
+          class="text"
+        >
+          Klurigo
+        </span>
+      </button>
+      <div
+        class="side"
+      >
+        <a
+          data-discover="true"
+          href="/auth/login"
+        >
+          Login
+        </a>
+      </div>
+    </div>
+    <div
+      class="content centerAlign"
+    >
+      <div
+        class="contentWrapper fullWidth"
+      >
+        <div
+          class="contentInner"
+        >
+          <div
+            class="typography subtitle small"
+          >
+            One moment… verifying your magic link!
+          </div>
+          <div
+            class="loadingSpinnerContainer"
+          >
+            <div />
+            <div />
+            <div />
+          </div>
+          <div
+            class="typography text small"
+          >
+            Good things come to those who wait!
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/packages/quiz/src/pages/AuthVerifyPage/components/AuthVerifyPageUI/AuthVerifyPageUI.test.tsx
+++ b/packages/quiz/src/pages/AuthVerifyPage/components/AuthVerifyPageUI/AuthVerifyPageUI.test.tsx
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import React from 'react'
 import { MemoryRouter } from 'react-router-dom'
 import { describe, expect, it } from 'vitest'
@@ -6,42 +6,91 @@ import { describe, expect, it } from 'vitest'
 import AuthVerifyPageUI from './AuthVerifyPageUI'
 
 describe('AuthVerifyPageUI', () => {
-  it('should render AuthVerifyPageUI as loading', async () => {
+  it('renders verifying state', () => {
     const { container } = render(
       <MemoryRouter>
         <AuthVerifyPageUI verified={false} loggedIn={false} />
       </MemoryRouter>,
     )
 
+    expect(
+      screen.getByText('One moment… verifying your magic link!'),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText('Good things come to those who wait!'),
+    ).toBeInTheDocument()
+    expect(screen.queryByText('Hooray! Your email’s all set!')).toBeNull()
+    expect(screen.queryByText('Oops! Something went wrong.')).toBeNull()
+
     expect(container).toMatchSnapshot()
   })
 
-  it('should render AuthVerifyPageUI as verified', async () => {
+  it('renders verified state (not logged in) with login link', () => {
     const { container } = render(
       <MemoryRouter>
         <AuthVerifyPageUI verified={true} loggedIn={false} />
       </MemoryRouter>,
     )
 
+    expect(
+      screen.getByText('Hooray! Your email’s all set!'),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText('Welcome aboard the fun train. Let’s roll!'),
+    ).toBeInTheDocument()
+
+    const loginLink = container.querySelector('a[href="/auth/login"]')
+    expect(loginLink).toBeTruthy()
+    expect(screen.getByText('Log in to get started!')).toBeInTheDocument()
+
+    // no home link in this branch
+    expect(container.querySelector('a[href="/"]')).toBeNull()
+
     expect(container).toMatchSnapshot()
   })
 
-  it('should render AuthVerifyPageUI as verified and logged in', async () => {
+  it('renders verified state (logged in) with home link', () => {
     const { container } = render(
       <MemoryRouter>
         <AuthVerifyPageUI verified={true} loggedIn={true} />
       </MemoryRouter>,
     )
 
+    expect(
+      screen.getByText('Hooray! Your email’s all set!'),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText('Welcome aboard the fun train. Let’s roll!'),
+    ).toBeInTheDocument()
+
+    const home = screen.getByRole('link', { name: 'Take me home' })
+    expect(home).toHaveAttribute('href', '/')
+
+    // ensure the *component’s* login link isn’t present
+    expect(
+      screen.queryByRole('link', { name: 'Log in to get started!' }),
+    ).toBeNull()
+
     expect(container).toMatchSnapshot()
   })
 
-  it('should render AuthVerifyPageUI with error', async () => {
+  it('renders error state', () => {
     const { container } = render(
       <MemoryRouter>
         <AuthVerifyPageUI verified={false} loggedIn={false} error={true} />
       </MemoryRouter>,
     )
+
+    expect(screen.getByText('Oops! Something went wrong.')).toBeInTheDocument()
+    expect(
+      screen.getByText('The supplied link is invalid or has expired.'),
+    ).toBeInTheDocument()
+
+    // no verifying or success texts in error branch
+    expect(
+      screen.queryByText('One moment… verifying your magic link!'),
+    ).toBeNull()
+    expect(screen.queryByText('Hooray! Your email’s all set!')).toBeNull()
 
     expect(container).toMatchSnapshot()
   })

--- a/packages/quiz/src/pages/AuthVerifyPage/components/AuthVerifyPageUI/__snapshots__/AuthVerifyPageUI.test.tsx.snap
+++ b/packages/quiz/src/pages/AuthVerifyPage/components/AuthVerifyPageUI/__snapshots__/AuthVerifyPageUI.test.tsx.snap
@@ -1,5 +1,319 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`AuthVerifyPageUI > renders error state 1`] = `
+<div>
+  <div
+    class="main"
+  >
+    <div
+      class="header"
+    >
+      <button
+        class="logo"
+      >
+        <img
+          alt="Klurigo"
+          class="icon"
+          src="/src/assets/images/klurigo-icon.svg"
+        />
+        <span
+          class="text"
+        >
+          Klurigo
+        </span>
+      </button>
+      <div
+        class="side"
+      >
+        <a
+          data-discover="true"
+          href="/auth/login"
+        >
+          Login
+        </a>
+      </div>
+    </div>
+    <div
+      class="content centerAlign"
+    >
+      <div
+        class="contentWrapper fullWidth"
+      >
+        <div
+          class="contentInner"
+        >
+          <div
+            class="badge large red"
+          >
+            <svg
+              aria-hidden="true"
+              class="svg-inline--fa fa-xmark"
+              data-icon="xmark"
+              data-prefix="fas"
+              role="img"
+              viewBox="0 0 384 512"
+            >
+              <path
+                d="M55.1 73.4c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3L147.2 256 9.9 393.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0L192.5 301.3 329.9 438.6c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3L237.8 256 375.1 118.6c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0L192.5 210.7 55.1 73.4z"
+                fill="currentColor"
+              />
+            </svg>
+          </div>
+          <div
+            class="typography subtitle small"
+          >
+            Oops! Something went wrong.
+          </div>
+          <div
+            class="typography text medium"
+          >
+            The supplied link is invalid or has expired.
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`AuthVerifyPageUI > renders verified state (logged in) with home link 1`] = `
+<div>
+  <div
+    class="main"
+  >
+    <div
+      class="header"
+    >
+      <button
+        class="logo"
+      >
+        <img
+          alt="Klurigo"
+          class="icon"
+          src="/src/assets/images/klurigo-icon.svg"
+        />
+        <span
+          class="text"
+        >
+          Klurigo
+        </span>
+      </button>
+      <div
+        class="side"
+      >
+        <a
+          data-discover="true"
+          href="/auth/login"
+        >
+          Login
+        </a>
+      </div>
+    </div>
+    <div
+      class="content centerAlign"
+    >
+      <div
+        class="contentWrapper fullWidth"
+      >
+        <div
+          class="contentInner"
+        >
+          <div
+            class="badge large green"
+          >
+            <svg
+              aria-hidden="true"
+              class="svg-inline--fa fa-check"
+              data-icon="check"
+              data-prefix="fas"
+              role="img"
+              viewBox="0 0 448 512"
+            >
+              <path
+                d="M434.8 70.1c14.3 10.4 17.5 30.4 7.1 44.7l-256 352c-5.5 7.6-14 12.3-23.4 13.1s-18.5-2.7-25.1-9.3l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0l101.5 101.5 234-321.7c10.4-14.3 30.4-17.5 44.7-7.1z"
+                fill="currentColor"
+              />
+            </svg>
+          </div>
+          <div
+            class="typography subtitle medium"
+          >
+            Hooray! Your email’s all set!
+          </div>
+          <div
+            class="typography text medium"
+          >
+            Welcome aboard the fun train. Let’s roll!
+          </div>
+          <a
+            data-discover="true"
+            href="/"
+          >
+            <div
+              class="typography link small"
+            >
+              Take me home
+            </div>
+          </a>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`AuthVerifyPageUI > renders verified state (not logged in) with login link 1`] = `
+<div>
+  <div
+    class="main"
+  >
+    <div
+      class="header"
+    >
+      <button
+        class="logo"
+      >
+        <img
+          alt="Klurigo"
+          class="icon"
+          src="/src/assets/images/klurigo-icon.svg"
+        />
+        <span
+          class="text"
+        >
+          Klurigo
+        </span>
+      </button>
+      <div
+        class="side"
+      >
+        <a
+          data-discover="true"
+          href="/auth/login"
+        >
+          Login
+        </a>
+      </div>
+    </div>
+    <div
+      class="content centerAlign"
+    >
+      <div
+        class="contentWrapper fullWidth"
+      >
+        <div
+          class="contentInner"
+        >
+          <div
+            class="badge large green"
+          >
+            <svg
+              aria-hidden="true"
+              class="svg-inline--fa fa-check"
+              data-icon="check"
+              data-prefix="fas"
+              role="img"
+              viewBox="0 0 448 512"
+            >
+              <path
+                d="M434.8 70.1c14.3 10.4 17.5 30.4 7.1 44.7l-256 352c-5.5 7.6-14 12.3-23.4 13.1s-18.5-2.7-25.1-9.3l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0l101.5 101.5 234-321.7c10.4-14.3 30.4-17.5 44.7-7.1z"
+                fill="currentColor"
+              />
+            </svg>
+          </div>
+          <div
+            class="typography subtitle medium"
+          >
+            Hooray! Your email’s all set!
+          </div>
+          <div
+            class="typography text medium"
+          >
+            Welcome aboard the fun train. Let’s roll!
+          </div>
+          <a
+            data-discover="true"
+            href="/auth/login"
+          >
+            <div
+              class="typography link small"
+            >
+              Log in to get started!
+            </div>
+          </a>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`AuthVerifyPageUI > renders verifying state 1`] = `
+<div>
+  <div
+    class="main"
+  >
+    <div
+      class="header"
+    >
+      <button
+        class="logo"
+      >
+        <img
+          alt="Klurigo"
+          class="icon"
+          src="/src/assets/images/klurigo-icon.svg"
+        />
+        <span
+          class="text"
+        >
+          Klurigo
+        </span>
+      </button>
+      <div
+        class="side"
+      >
+        <a
+          data-discover="true"
+          href="/auth/login"
+        >
+          Login
+        </a>
+      </div>
+    </div>
+    <div
+      class="content centerAlign"
+    >
+      <div
+        class="contentWrapper fullWidth"
+      >
+        <div
+          class="contentInner"
+        >
+          <div
+            class="typography subtitle small"
+          >
+            One moment… verifying your magic link!
+          </div>
+          <div
+            class="loadingSpinnerContainer"
+          >
+            <div />
+            <div />
+            <div />
+          </div>
+          <div
+            class="typography text small"
+          >
+            Good things come to those who wait!
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`AuthVerifyPageUI > should render AuthVerifyPageUI as loading 1`] = `
 <div>
   <div


### PR DESCRIPTION
- Add tests for `AuthGamePage` (id/pin, success/error, single-run guard).
- Add tests for `AuthGoogleCallbackPage` (param/state checks, success → `/`, failure → `/auth/login`, rerender-safe).
- Add tests for `AuthLoginPage` (form submit, loading, Google OAuth redirect + session storage).
- Expand `AuthLoginPageUI` tests (validation, loading, links, Google button) and snapshot them.
- Rename `helpers.ts` → `text.utils.ts` in login/register UIs; update imports.
- Add unit tests for `text.utils` (deterministic `Math.random`) for both login & register.
- Add tests for `AuthPasswordForgotPage` and its UI (validation, loading, success nav, re-enable on failure).
- Add tests for `AuthPasswordResetPage` and its UI (token missing/expired, validation, success nav, error view).
- Add tests for `AuthVerifyPage` and its UI (loading, verified logged in/out, missing token redirect, error).
