### PR TITLE
ci(codecov): enforce PR coverage requirements

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -29,7 +29,14 @@ coverage:
   status:
     project:
       default:
-        informational: true
+        target: auto
+        threshold: 1%
+        base: auto
+        informational: false
+        only_pulls: true
     patch:
       default:
-        informational: true
+        target: 80%
+        base: auto
+        informational: false
+        only_pulls: true


### PR DESCRIPTION
- Require at least 80% coverage on changed files for all pull requests.
- Disallow project coverage to decrease by more than 1% compared to base.
- Limit both checks to PRs only, replacing informational statuses.

Ensures stricter quality gates on pull requests while keeping main branch flexible.