### PR TITLE
fix(question-picker): correct error indicator handling in QuestionPicker

### DIFF
--- a/packages/klurigo-web/src/pages/QuizCreatorPage/components/QuizCreatorPageUI/QuizCreatorPageUI.tsx
+++ b/packages/klurigo-web/src/pages/QuizCreatorPage/components/QuizCreatorPageUI/QuizCreatorPageUI.tsx
@@ -159,7 +159,7 @@ const QuizCreatorPageUI: FC<QuizCreatorPageUIProps> = ({
               questions={questions.map((question, index) => ({
                 type: question.type as QuestionType,
                 text: question.question,
-                error: !questionValidations[index].valid,
+                valid: questionValidations[index].valid,
               }))}
               selectedQuestionIndex={selectedQuestionIndex}
               onAddQuestion={onAddQuestion}

--- a/packages/klurigo-web/src/pages/QuizCreatorPage/components/QuizCreatorPageUI/components/QuestionPicker/QuestionPicker.tsx
+++ b/packages/klurigo-web/src/pages/QuizCreatorPage/components/QuizCreatorPageUI/components/QuestionPicker/QuestionPicker.tsx
@@ -12,7 +12,7 @@ import styles from './QuestionPicker.module.scss'
 export type QuestionPickerItem = {
   type: QuestionType
   text?: string
-  errorMessage?: string
+  valid: boolean
 }
 
 export interface QuestionPickerProps {
@@ -75,14 +75,14 @@ const QuestionPicker: FC<QuestionPickerProps> = ({
       <div
         ref={questionPickerItemContainerRef}
         className={styles.questionPickerItemContainer}>
-        {questions.map(({ type, text, errorMessage }, index) => (
+        {questions.map(({ type, text, valid }, index) => (
           <QuestionPickerItem
             key={`question-picker-item-${index}`}
             index={index}
             text={text || 'Question'}
             type={type}
             active={isActive(index)}
-            errorMessage={errorMessage}
+            valid={valid}
             onClick={() => onSelectQuestion(index)}
             onDrop={onDropQuestion}
             onDuplicate={() => onDuplicateQuestion(index)}

--- a/packages/klurigo-web/src/pages/QuizCreatorPage/components/QuizCreatorPageUI/components/QuestionPicker/components/QuestionPickerItem/QuestionPickerItem.module.scss
+++ b/packages/klurigo-web/src/pages/QuizCreatorPage/components/QuizCreatorPageUI/components/QuestionPicker/components/QuestionPickerItem/QuestionPickerItem.module.scss
@@ -248,7 +248,7 @@ $normal-question-picker-item-indicator-size: helpers.pxToRem(22px);
       .questionPickerItemOverlayError {
         color: colors.$color-status-warning;
         background-color: colors.$color-surface-default;
-        pointer-events: auto;
+        pointer-events: none;
 
         @include helpers.mobile {
           @include helpers.fontSize(16px);

--- a/packages/klurigo-web/src/pages/QuizCreatorPage/components/QuizCreatorPageUI/components/QuestionPicker/components/QuestionPickerItem/QuestionPickerItem.tsx
+++ b/packages/klurigo-web/src/pages/QuizCreatorPage/components/QuizCreatorPageUI/components/QuestionPicker/components/QuestionPickerItem/QuestionPickerItem.tsx
@@ -4,11 +4,6 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { QuestionType } from '@klurigo/common'
 import type { DragEvent, FC, MouseEvent } from 'react'
 
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from '../../../../../../../../components'
 import { QuestionTypeLabels } from '../../../../../../../../models'
 import { classNames } from '../../../../../../../../utils/helpers'
 
@@ -19,7 +14,7 @@ export interface QuestionPickerItemProps {
   text: string
   type: QuestionType
   active?: boolean
-  errorMessage?: string
+  valid: boolean
   onClick?: () => void
   onDrop?: (id: number) => void
   onDuplicate?: () => void
@@ -31,7 +26,7 @@ const QuestionPickerItem: FC<QuestionPickerItemProps> = ({
   text,
   type,
   active,
-  errorMessage,
+  valid,
   onClick,
   onDrop,
   onDuplicate,
@@ -102,18 +97,9 @@ const QuestionPickerItem: FC<QuestionPickerItemProps> = ({
               <FontAwesomeIcon icon={faCopy} />
             </button>
           )}
-          {!!errorMessage && (
+          {!valid && (
             <div className={styles.questionPickerItemOverlayError}>
-              <Tooltip placement="bottom">
-                <TooltipTrigger>
-                  <FontAwesomeIcon icon={faCircleExclamation} />
-                </TooltipTrigger>
-                <TooltipContent>
-                  <div className={styles.tooltipErrorContent}>
-                    {errorMessage}
-                  </div>
-                </TooltipContent>
-              </Tooltip>
+              <FontAwesomeIcon icon={faCircleExclamation} />
             </div>
           )}
           {active && (


### PR DESCRIPTION
- Replace errorMessage with valid flag across QuestionPicker components
- Show error indicator based on invalid state instead of message presence
- Remove tooltip-based error display in favor of simple indicator
- Prevent overlay from blocking interactions with pointer-events: none

Ensures consistent validation state handling and fixes interaction issues.