### PR TITLE
fix(ui): adjust disabled cursor behavior and refine accent styling

### DIFF
--- a/packages/klurigo-web/src/pages/GameResultsPage/components/GameResultsPageUI/sections/SummarySection/SummarySection.module.scss
+++ b/packages/klurigo-web/src/pages/GameResultsPage/components/GameResultsPageUI/sections/SummarySection/SummarySection.module.scss
@@ -129,8 +129,8 @@ $contrast-opacity: 0.8;
       height: 100%;
       outline: none;
 
-      &:not(:disabled) {
-        cursor: pointer;
+      &:disabled {
+        cursor: auto;
       }
 
       @include helpers.mobile {

--- a/packages/klurigo-web/src/pages/QuizCreatorPage/components/QuizCreatorPageUI/components/GameModeSelectionModal/GameModeSelectionModal.module.scss
+++ b/packages/klurigo-web/src/pages/QuizCreatorPage/components/QuizCreatorPageUI/components/GameModeSelectionModal/GameModeSelectionModal.module.scss
@@ -29,8 +29,8 @@ $outline-offset: helpers.pxToRem(2px);
     display: flex;
     flex-direction: column;
     flex: 1;
-    background-color: colors.$color-action-tint;
-    outline: colors.$color-action-tint solid $outline-offset;
+    background-color: colors.$color-action-accent;
+    outline: colors.$color-action-accent solid $outline-offset;
     outline-offset: $outline-offset;
     border: $outline-offset solid transparent;
     border-radius: radius.$radius-surface-lg;
@@ -64,9 +64,8 @@ $outline-offset: helpers.pxToRem(2px);
     }
 
     &:hover {
-      background-color: colors.$color-action-tint;
-      outline-color: colors.$color-action-tint;
-      color: colors.$color-text-emphasis;
+      background-color: colors.$color-action-accent-hover;
+      outline-color: colors.$color-action-accent-hover;
     }
 
     .description {

--- a/packages/klurigo-web/src/styles/inputs.scss
+++ b/packages/klurigo-web/src/styles/inputs.scss
@@ -163,7 +163,6 @@
   @media (prefers-reduced-motion: no-preference) {
     &:has(> input:focus, > select:focus, > textarea:focus) {
       outline-color: colors.$color-focus-control-default;
-      box-shadow: shadows.$shadow-focus-control-default;
     }
   }
 }


### PR DESCRIPTION
- Set cursor to auto for disabled interactive elements in SummarySection.
- Replace action tint with accent tokens in GameModeSelectionModal for background and outline.
- Update hover state to use accent hover tokens for consistency.
- Remove focus box-shadow from inputs to align with updated focus styling.

This improves interaction clarity and aligns components with the semantic color system.