### PR TITLE
feat(quiz): add unsaved changes exit flow and refresh quiz lists

### DIFF
--- a/packages/klurigo-web/src/components/Page/Page.module.scss
+++ b/packages/klurigo-web/src/components/Page/Page.module.scss
@@ -91,10 +91,12 @@
 
       .text {
         position: relative;
-        @include helpers.fontSize(20px);
-        font-weight: bolder;
+        font-weight: 900;
         color: colors.$color-text-inverse;
+        letter-spacing: 1px;
         top: helpers.pxToRem(-1px);
+
+        @include helpers.fontSize(20px);
       }
 
       @include helpers.mobile {

--- a/packages/klurigo-web/src/components/Page/Page.tsx
+++ b/packages/klurigo-web/src/components/Page/Page.tsx
@@ -82,7 +82,7 @@ const Page: FC<PageProps> = ({
     return (
       <>
         <MenuItem icon={faIdCard} link={`/users/${user?.ACCESS.sub}/profile`}>
-          My Profile
+          Profile
         </MenuItem>
         <MenuItem icon={faLightbulb} link="/profile/quizzes">
           Quizzes

--- a/packages/klurigo-web/src/pages/ProfileQuizzesPage/components/ProfileQuizzesPageUI/__snapshots__/ProfileQuizzesPageUI.test.tsx.snap
+++ b/packages/klurigo-web/src/pages/ProfileQuizzesPage/components/ProfileQuizzesPageUI/__snapshots__/ProfileQuizzesPageUI.test.tsx.snap
@@ -240,7 +240,7 @@ exports[`ProfileQuizzesPageUI > should render ProfileQuizzesPageUI with card gri
                         fill="currentColor"
                       />
                     </svg>
-                    9 months ago
+                    10 months ago
                   </span>
                 </div>
               </div>
@@ -321,7 +321,7 @@ exports[`ProfileQuizzesPageUI > should render ProfileQuizzesPageUI with card gri
                         fill="currentColor"
                       />
                     </svg>
-                    9 months ago
+                    10 months ago
                   </span>
                 </div>
               </div>
@@ -402,7 +402,7 @@ exports[`ProfileQuizzesPageUI > should render ProfileQuizzesPageUI with card gri
                         fill="currentColor"
                       />
                     </svg>
-                    9 months ago
+                    10 months ago
                   </span>
                 </div>
               </div>
@@ -483,7 +483,7 @@ exports[`ProfileQuizzesPageUI > should render ProfileQuizzesPageUI with card gri
                         fill="currentColor"
                       />
                     </svg>
-                    9 months ago
+                    10 months ago
                   </span>
                 </div>
               </div>
@@ -564,7 +564,7 @@ exports[`ProfileQuizzesPageUI > should render ProfileQuizzesPageUI with card gri
                         fill="currentColor"
                       />
                     </svg>
-                    9 months ago
+                    10 months ago
                   </span>
                 </div>
               </div>

--- a/packages/klurigo-web/src/pages/QuizCreatorPage/QuizCreatorPage.test.tsx
+++ b/packages/klurigo-web/src/pages/QuizCreatorPage/QuizCreatorPage.test.tsx
@@ -6,25 +6,21 @@ import {
   QuizCategory,
   QuizVisibility,
 } from '@klurigo/common'
-import { act, render } from '@testing-library/react'
+import { act, fireEvent, render, screen } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import type { BlockerFunction } from 'react-router-dom'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import QuizCreatorPage from './QuizCreatorPage'
-
-/**
- * ---------------------------------------------------------------------------
- * Mocks
- * ---------------------------------------------------------------------------
- */
 
 type QuizSummary = {
   mode: GameMode
   title: string
   description?: string
   imageCoverURL?: string
-  visibility?: QuizVisibility
-  category?: QuizCategory
-  languageCode?: LanguageCode
+  visibility: QuizVisibility
+  category: QuizCategory
+  languageCode: LanguageCode
 }
 
 type UseQueryResult<T> = {
@@ -45,41 +41,48 @@ type QuizSettings = {
 
 type QuizCreatorPageUIProps = {
   gameMode?: GameMode
-  onSelectGameMode: (mode: GameMode) => void
   quizSettings: QuizSettings
-  quizSettingsValidation: Record<string, boolean | undefined>
-  allQuizSettingsValid: boolean
-  onQuizSettingsValueChange: <K extends keyof QuizSettings>(
-    key: K,
-    value?: QuizSettings[K],
-  ) => void
   questions: unknown[]
-  questionValidations: Record<string, unknown>[]
-  allQuestionsValid: boolean
-  selectedQuestion: unknown
   selectedQuestionIndex: number
-  onSetQuestions: (next: unknown[]) => void
-  onSelectedQuestionIndex: (index: number) => void
+  canSaveQuiz: boolean
+  isSavingQuiz?: boolean
+  onSelectGameMode: (mode: GameMode) => void
+  onQuizSettingsValueChange: (
+    key: keyof QuizSettings,
+    value?: QuizSettings[keyof QuizSettings],
+  ) => void
+  onSetQuestions: (questions: unknown[]) => void
   onAddQuestion: () => void
-  onQuestionValueChange: (key: string, value?: unknown) => void
-  onDropQuestionIndex: () => void
-  onDuplicateQuestionIndex: (index: number) => void
-  onDeleteQuestionIndex: (index: number) => void
-  onReplaceQuestion: (index: number) => void
-  isSavingQuiz: boolean
   onSaveQuiz: () => void
+  onExit: () => void
+}
+
+type UnsavedChangesExitModalProps = {
+  onReset: () => void
+  onConfirm: () => void
+}
+
+type MockBlocker = {
+  state: 'blocked' | 'proceeding' | 'unblocked'
+  proceed: () => void
+  reset: () => void
 }
 
 let latestUIProps: QuizCreatorPageUIProps | undefined
+let latestShouldBlock: BlockerFunction | undefined
 
 let mockQuizId: string | undefined
+let mockBlocker: MockBlocker
 
-const navigateMock = vi.fn<(path: string) => void>()
-const notifyErrorMock = vi.fn<(msg: string) => void>()
+const navigateMock = vi.fn<(path: string | number) => void>()
+const notifyErrorMock = vi.fn<(message: string) => void>()
+const invalidateQueriesMock = vi.fn<
+  (args: { queryKey: readonly string[] }) => Promise<void>
+>(() => Promise.resolve())
 
-const createQuizMock = vi.fn<(request: QuizRequestDto) => Promise<void>>(() =>
-  Promise.resolve(),
-)
+const createQuizMock = vi.fn<
+  (request: QuizRequestDto) => Promise<{ id: string }>
+>(() => Promise.resolve({ id: 'new-quiz-id' }))
 const updateQuizMock = vi.fn<
   (quizId: string, request: QuizRequestDto) => Promise<void>
 >(() => Promise.resolve())
@@ -87,65 +90,71 @@ const getQuizMock = vi.fn<(quizId: string) => Promise<QuizSummary>>()
 const getQuizQuestionsMock = vi.fn<(quizId: string) => Promise<unknown[]>>()
 
 const setGameModeMock = vi.fn<(mode: GameMode) => void>()
-const setQuestionsMock = vi.fn<(qs: unknown[]) => void>()
-const selectQuestionMock = vi.fn<(index: number) => void>()
+const moveSelectedQuestionToMock = vi.fn<(index: number) => void>()
 const addQuestionMock = vi.fn<(type: QuestionType) => void>()
-const updateSelectedQuestionFieldMock =
-  vi.fn<(key: string, value?: unknown) => void>()
 const duplicateQuestionMock = vi.fn<(index: number) => void>()
 const deleteQuestionMock = vi.fn<(index: number) => void>()
-const replaceQuestionMock = vi.fn<(index: number) => void>()
+const replaceQuestionMock = vi.fn<(type: QuestionType) => void>()
 
 const setQuizSettingsMock = vi.fn<(next: QuizSettings) => void>()
 const updateSettingsFieldMock =
   vi.fn<
-    <K extends keyof QuizSettings>(key: K, value?: QuizSettings[K]) => void
+    (key: keyof QuizSettings, value?: QuizSettings[keyof QuizSettings]) => void
   >()
 
 let mockQuizSettings: QuizSettings
-let mockQuizSettingsValidation: Record<string, boolean | undefined>
-let mockAllQuizSettingsValid = true
+let mockQuizSettingsValidation: { errors?: unknown[] }
+let mockAllQuizSettingsValid: boolean
 
 let mockGameMode: GameMode | undefined
-let mockQuestions: unknown[] = []
-let mockQuestionValidations: Record<string, unknown>[] = []
-let mockAllQuestionsValid = true
-let mockSelectedQuestion: unknown
-let mockSelectedQuestionIndex = -1
+let mockQuestions: unknown[]
+let mockQuestionValidations: Array<{ valid: boolean }>
+let mockAllQuestionsValid: boolean
+let mockSelectedQuestionIndex: number
 
 let mockQuizQueryState: UseQueryResult<QuizSummary>
 let mockQuestionsQueryState: UseQueryResult<unknown[]>
 
-/**
- * Guards used during save filtering.
- */
 const isClassicMultiChoiceQuestionMock =
-  vi.fn<(mode: GameMode, q: unknown) => boolean>()
+  vi.fn<(mode: GameMode, question: unknown) => boolean>()
 const isClassicRangeQuestionMock =
-  vi.fn<(mode: GameMode, q: unknown) => boolean>()
+  vi.fn<(mode: GameMode, question: unknown) => boolean>()
 const isClassicTrueFalseQuestionMock =
-  vi.fn<(mode: GameMode, q: unknown) => boolean>()
+  vi.fn<(mode: GameMode, question: unknown) => boolean>()
 const isClassicTypeAnswerQuestionMock =
-  vi.fn<(mode: GameMode, q: unknown) => boolean>()
+  vi.fn<(mode: GameMode, question: unknown) => boolean>()
 const isClassicPinQuestionMock =
-  vi.fn<(mode: GameMode, q: unknown) => boolean>()
+  vi.fn<(mode: GameMode, question: unknown) => boolean>()
 const isClassicPuzzleQuestionMock =
-  vi.fn<(mode: GameMode, q: unknown) => boolean>()
+  vi.fn<(mode: GameMode, question: unknown) => boolean>()
 const isZeroToOneHundredRangeQuestionMock =
-  vi.fn<(mode: GameMode, q: unknown) => boolean>()
+  vi.fn<(mode: GameMode, question: unknown) => boolean>()
 
 vi.mock('react-router-dom', async () => {
   const actual =
     await vi.importActual<typeof import('react-router-dom')>('react-router-dom')
+
   return {
     ...actual,
     useNavigate: () => navigateMock,
     useParams: () => ({ quizId: mockQuizId }),
+    useBlocker: (shouldBlock: BlockerFunction) => {
+      latestShouldBlock = shouldBlock
+      return mockBlocker
+    },
   }
 })
 
-vi.mock('../../utils/notification', () => ({
-  notifyError: (msg: string) => notifyErrorMock(msg),
+vi.mock('@tanstack/react-query', () => ({
+  useQuery: (args: { queryKey: readonly unknown[] }) => {
+    const key = String(args.queryKey[0])
+    if (key === 'quiz') return mockQuizQueryState
+    if (key === 'quiz_questions') return mockQuestionsQueryState
+    throw new Error(`Unexpected queryKey: ${key}`)
+  },
+  useQueryClient: () => ({
+    invalidateQueries: invalidateQueriesMock,
+  }),
 }))
 
 vi.mock('../../api', () => ({
@@ -157,59 +166,79 @@ vi.mock('../../api', () => ({
   }),
 }))
 
-vi.mock('./utils/QuizSettingsDataSource', () => ({
-  useQuizSettingsDataSource: () => ({
-    settings: mockQuizSettings,
-    setSettings: setQuizSettingsMock,
-    settingsValidation: mockQuizSettingsValidation,
-    allSettingsValid: mockAllQuizSettingsValid,
-    updateSettingsField: updateSettingsFieldMock,
-  }),
+vi.mock('../../utils/notification', () => ({
+  notifyError: (message: string) => notifyErrorMock(message),
 }))
+
+vi.mock('./utils/QuizSettingsDataSource', async () => {
+  const React = await vi.importActual<typeof import('react')>('react')
+
+  return {
+    useQuizSettingsDataSource: () => {
+      const [settings, setSettings] = React.useState(mockQuizSettings)
+      const setSettingsWrapped = React.useCallback((next: QuizSettings) => {
+        mockQuizSettings = next
+        setQuizSettingsMock(next)
+        setSettings(next)
+      }, [])
+      const updateSettingsFieldWrapped = React.useCallback(
+        (key: keyof QuizSettings, value?: QuizSettings[keyof QuizSettings]) => {
+          updateSettingsFieldMock(key, value)
+          const next = { ...mockQuizSettings, [key]: value }
+          mockQuizSettings = next
+          setSettings(next)
+        },
+        [],
+      )
+
+      return {
+        settings,
+        setSettings: setSettingsWrapped,
+        settingsValidation: mockQuizSettingsValidation,
+        allSettingsValid: mockAllQuizSettingsValid,
+        updateSettingsField: updateSettingsFieldWrapped,
+      }
+    },
+  }
+})
 
 vi.mock('./utils/QuestionDataSource', async () => {
   const React = await vi.importActual<typeof import('react')>('react')
 
   return {
     useQuestionDataSource: () => {
-      const [gameMode, setGameMode] = React.useState<GameMode | undefined>(
-        mockGameMode,
+      const [gameMode, setGameMode] = React.useState(mockGameMode)
+      const [questions, setQuestions] = React.useState(mockQuestions)
+      const [selectedQuestionIndex, setSelectedQuestionIndex] = React.useState(
+        mockSelectedQuestionIndex,
       )
-      const [questions, setQuestions] = React.useState<unknown[]>(mockQuestions)
-
-      const selectQuestion = (index: number) => {
-        selectQuestionMock(index)
-      }
-
-      const setGameModeWrapped = (mode: GameMode) => {
+      const setGameModeWrapped = React.useCallback((mode: GameMode) => {
         mockGameMode = mode
         setGameModeMock(mode)
         setGameMode(mode)
-      }
-
-      const setQuestionsWrapped = (qs: unknown[]) => {
-        mockQuestions = qs
-        setQuestionsMock(qs)
-        setQuestions(qs)
-      }
+      }, [])
+      const setQuestionsWrapped = React.useCallback((next: unknown[]) => {
+        mockQuestions = next
+        setQuestions(next)
+      }, [])
+      const selectQuestionWrapped = React.useCallback((index: number) => {
+        mockSelectedQuestionIndex = index
+        setSelectedQuestionIndex(index)
+      }, [])
 
       return {
         gameMode,
         setGameMode: setGameModeWrapped,
-
         questions,
         setQuestions: setQuestionsWrapped,
-
         questionValidations: mockQuestionValidations,
         allQuestionsValid: mockAllQuestionsValid,
-
-        selectedQuestion: mockSelectedQuestion,
-        selectedQuestionIndex: mockSelectedQuestionIndex,
-
-        selectQuestion,
-
+        selectedQuestion: questions[selectedQuestionIndex],
+        selectedQuestionIndex,
+        selectQuestion: selectQuestionWrapped,
         addQuestion: addQuestionMock,
-        updateSelectedQuestionField: updateSelectedQuestionFieldMock,
+        updateSelectedQuestionField: vi.fn(),
+        moveSelectedQuestionTo: moveSelectedQuestionToMock,
         duplicateQuestion: duplicateQuestionMock,
         deleteQuestion: deleteQuestionMock,
         replaceQuestion: replaceQuestionMock,
@@ -218,48 +247,48 @@ vi.mock('./utils/QuestionDataSource', async () => {
   }
 })
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const latestUseQueryArgs: any[] = []
-
-vi.mock('@tanstack/react-query', () => ({
-  useQuery: (args: { queryKey: readonly unknown[]; enabled?: boolean }) => {
-    latestUseQueryArgs.push(args)
-    const key = String(args.queryKey?.[0] ?? '')
-    if (key === 'quiz') return mockQuizQueryState
-    if (key === 'quiz_questions') return mockQuestionsQueryState
-    throw new Error(`Unexpected queryKey: ${key}`)
-  },
-}))
-
 vi.mock('../../components', () => ({
   LoadingSpinner: () => <div data-testid="loading-spinner" />,
-  Page: ({ children }: { children: React.ReactNode }) => (
+  Page: ({ children }: { children?: ReactNode }) => (
     <div data-testid="page">{children}</div>
   ),
 }))
 
-vi.mock('./components/QuizCreatorPageUI', () => ({
-  default: (props: QuizCreatorPageUIProps) => {
+vi.mock('./components', () => ({
+  QuizCreatorPageUI: (props: QuizCreatorPageUIProps) => {
     latestUIProps = props
     return <div data-testid="quiz-creator-ui" />
   },
+  UnsavedChangesExitModal: ({
+    onReset,
+    onConfirm,
+  }: UnsavedChangesExitModalProps) => (
+    <div data-testid="unsaved-changes-exit-modal">
+      <button type="button" onClick={onReset}>
+        Stay
+      </button>
+      <button type="button" onClick={onConfirm}>
+        Leave
+      </button>
+    </div>
+  ),
 }))
 
 vi.mock('../../utils/questions', () => ({
-  isClassicMultiChoiceQuestion: (mode: GameMode, q: unknown) =>
-    isClassicMultiChoiceQuestionMock(mode, q),
-  isClassicRangeQuestion: (mode: GameMode, q: unknown) =>
-    isClassicRangeQuestionMock(mode, q),
-  isClassicTrueFalseQuestion: (mode: GameMode, q: unknown) =>
-    isClassicTrueFalseQuestionMock(mode, q),
-  isClassicTypeAnswerQuestion: (mode: GameMode, q: unknown) =>
-    isClassicTypeAnswerQuestionMock(mode, q),
-  isClassicPinQuestion: (mode: GameMode, q: unknown) =>
-    isClassicPinQuestionMock(mode, q),
-  isClassicPuzzleQuestion: (mode: GameMode, q: unknown) =>
-    isClassicPuzzleQuestionMock(mode, q),
-  isZeroToOneHundredRangeQuestion: (mode: GameMode, q: unknown) =>
-    isZeroToOneHundredRangeQuestionMock(mode, q),
+  isClassicMultiChoiceQuestion: (mode: GameMode, question: unknown) =>
+    isClassicMultiChoiceQuestionMock(mode, question),
+  isClassicRangeQuestion: (mode: GameMode, question: unknown) =>
+    isClassicRangeQuestionMock(mode, question),
+  isClassicTrueFalseQuestion: (mode: GameMode, question: unknown) =>
+    isClassicTrueFalseQuestionMock(mode, question),
+  isClassicTypeAnswerQuestion: (mode: GameMode, question: unknown) =>
+    isClassicTypeAnswerQuestionMock(mode, question),
+  isClassicPinQuestion: (mode: GameMode, question: unknown) =>
+    isClassicPinQuestionMock(mode, question),
+  isClassicPuzzleQuestion: (mode: GameMode, question: unknown) =>
+    isClassicPuzzleQuestionMock(mode, question),
+  isZeroToOneHundredRangeQuestion: (mode: GameMode, question: unknown) =>
+    isZeroToOneHundredRangeQuestionMock(mode, question),
 }))
 
 const flushPromises = async (): Promise<void> => {
@@ -268,40 +297,54 @@ const flushPromises = async (): Promise<void> => {
   })
 }
 
-const setAllGuardsFalse = (): void => {
-  isClassicMultiChoiceQuestionMock.mockReturnValue(false)
-  isClassicRangeQuestionMock.mockReturnValue(false)
-  isClassicTrueFalseQuestionMock.mockReturnValue(false)
-  isClassicTypeAnswerQuestionMock.mockReturnValue(false)
-  isClassicPinQuestionMock.mockReturnValue(false)
-  isClassicPuzzleQuestionMock.mockReturnValue(false)
-  isZeroToOneHundredRangeQuestionMock.mockReturnValue(false)
-}
+const makeQuizSummary = (
+  overrides: Partial<QuizSummary> = {},
+): QuizSummary => ({
+  mode: GameMode.Classic,
+  title: 'Existing quiz',
+  description: 'Existing description',
+  imageCoverURL: 'https://example.com/cover.png',
+  visibility: QuizVisibility.Public,
+  category: QuizCategory.Other,
+  languageCode: LanguageCode.English,
+  ...overrides,
+})
+
+const makeQuizQuestion = (id: string) => ({
+  id,
+  type: QuestionType.MultiChoice,
+  question: `Question ${id}`,
+})
 
 describe('QuizCreatorPage', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     latestUIProps = undefined
+    latestShouldBlock = undefined
 
     mockQuizId = undefined
+    mockBlocker = {
+      state: 'unblocked',
+      proceed: vi.fn(),
+      reset: vi.fn(),
+    }
 
     mockQuizSettings = {
-      title: '  My quiz  ',
-      description: '  Desc  ',
-      imageCoverURL: 'https://example.com/cover.png',
+      title: '',
+      description: '',
+      imageCoverURL: undefined,
       visibility: QuizVisibility.Public,
       category: QuizCategory.Other,
       languageCode: LanguageCode.English,
     }
-    mockQuizSettingsValidation = {}
+    mockQuizSettingsValidation = { errors: [] }
     mockAllQuizSettingsValid = true
 
     mockGameMode = undefined
     mockQuestions = []
     mockQuestionValidations = []
     mockAllQuestionsValid = true
-    mockSelectedQuestion = undefined
-    mockSelectedQuestionIndex = -1
+    mockSelectedQuestionIndex = 0
 
     mockQuizQueryState = { data: undefined, isLoading: false, isError: false }
     mockQuestionsQueryState = {
@@ -311,137 +354,295 @@ describe('QuizCreatorPage', () => {
       isFetchedAfterMount: false,
     }
 
-    setAllGuardsFalse()
+    createQuizMock.mockResolvedValue({ id: 'new-quiz-id' })
+    updateQuizMock.mockResolvedValue(undefined)
+    invalidateQueriesMock.mockResolvedValue(undefined)
+
+    isClassicMultiChoiceQuestionMock.mockReturnValue(false)
+    isClassicRangeQuestionMock.mockReturnValue(false)
+    isClassicTrueFalseQuestionMock.mockReturnValue(false)
+    isClassicTypeAnswerQuestionMock.mockReturnValue(false)
+    isClassicPinQuestionMock.mockReturnValue(false)
+    isClassicPuzzleQuestionMock.mockReturnValue(false)
+    isZeroToOneHundredRangeQuestionMock.mockReturnValue(false)
   })
 
-  it('renders spinner page when quizId exists and quiz or questions query is loading or errored', () => {
-    mockQuizId = 'quiz-1'
+  it('renders a loading page while an existing quiz is still loading', () => {
+    mockQuizId = 'quiz-123'
     mockQuizQueryState = { data: undefined, isLoading: true, isError: false }
-    mockQuestionsQueryState = {
-      data: undefined,
-      isLoading: false,
-      isError: false,
-    }
 
     render(<QuizCreatorPage />)
 
-    expect(latestUIProps).toBeUndefined()
-    expect(document.querySelector('[data-testid="page"]')).toBeTruthy()
-    expect(
-      document.querySelector('[data-testid="loading-spinner"]'),
-    ).toBeTruthy()
+    expect(screen.getByTestId('page')).toBeInTheDocument()
+    expect(screen.getByTestId('loading-spinner')).toBeInTheDocument()
+    expect(screen.queryByTestId('quiz-creator-ui')).not.toBeInTheDocument()
   })
 
-  it('when originalQuiz loads, sets game mode and copies settings', async () => {
-    mockQuizId = 'quiz-123'
-    mockQuizQueryState = {
-      data: {
-        mode: GameMode.Classic,
-        title: 'Loaded title',
-        description: 'Loaded desc',
-        imageCoverURL: 'https://cdn/cover.jpg',
-        visibility: QuizVisibility.Private,
-        category: QuizCategory.Other,
-        languageCode: LanguageCode.Swedish,
-      },
-      isLoading: false,
-      isError: false,
-    }
-
+  it('does not mark a new quiz as dirty before any changes are made', () => {
     render(<QuizCreatorPage />)
 
-    expect(setGameModeMock).toHaveBeenCalledWith(GameMode.Classic)
-    expect(setQuizSettingsMock).toHaveBeenCalledWith({
-      title: 'Loaded title',
-      description: 'Loaded desc',
-      imageCoverURL: 'https://cdn/cover.jpg',
-      visibility: QuizVisibility.Private,
-      category: QuizCategory.Other,
-      languageCode: LanguageCode.Swedish,
+    expect(latestUIProps?.canSaveQuiz).toBe(false)
+    expect(latestShouldBlock?.({} as never)).toBe(false)
+  })
+
+  it('marks a new quiz as dirty after the user makes changes', async () => {
+    render(<QuizCreatorPage />)
+
+    act(() => {
+      latestUIProps?.onSelectGameMode(GameMode.Classic)
     })
+
+    await flushPromises()
+
+    expect(latestUIProps?.canSaveQuiz).toBe(true)
+    expect(latestShouldBlock?.({} as never)).toBe(true)
   })
 
-  it('configures quiz_questions query with refetchOnMount=always', () => {
-    render(<QuizCreatorPage />)
+  it('tracks unsaved changes for an existing quiz only after editing away from the saved snapshot', async () => {
+    const question = makeQuizQuestion('q-1')
 
-    const quizQuestionsCall = latestUseQueryArgs.find(
-      (a) => String(a.queryKey?.[0]) === 'quiz_questions',
-    )
-
-    expect(quizQuestionsCall?.refetchOnMount).toBe('always')
-  })
-
-  it('when gameMode and originalQuizQuestions load, sets questions and selects question 0', async () => {
     mockQuizId = 'quiz-123'
-
     mockQuizQueryState = {
-      data: {
-        mode: GameMode.Classic,
-        title: 'Loaded title',
-        visibility: QuizVisibility.Public,
-        category: QuizCategory.Other,
-        languageCode: LanguageCode.English,
-      },
+      data: makeQuizSummary(),
       isLoading: false,
       isError: false,
     }
-
-    const loadedQuestions = [{ id: 'q1' }, { id: 'q2' }]
-
     mockQuestionsQueryState = {
-      data: loadedQuestions,
+      data: [question],
       isLoading: false,
       isError: false,
       isFetchedAfterMount: true,
     }
 
     render(<QuizCreatorPage />)
+    await flushPromises()
 
-    await act(async () => {
-      await Promise.resolve()
+    expect(latestUIProps?.canSaveQuiz).toBe(false)
+    expect(latestShouldBlock?.({} as never)).toBe(false)
+
+    act(() => {
+      latestUIProps?.onQuizSettingsValueChange('title', 'Updated quiz title')
     })
 
-    expect(setQuestionsMock).toHaveBeenCalledWith(loadedQuestions)
-    expect(selectQuestionMock).toHaveBeenCalledWith(0)
+    await flushPromises()
+
+    expect(latestUIProps?.canSaveQuiz).toBe(true)
+    expect(latestShouldBlock?.({} as never)).toBe(true)
   })
 
-  it('handleAddQuestion adds MultiChoice for Classic and Range for ZeroToOneHundred', async () => {
-    render(<QuizCreatorPage />)
-    expect(latestUIProps).toBeDefined()
+  it('shows the exit modal when navigation is blocked and staying resets the blocker', async () => {
+    const { rerender } = render(<QuizCreatorPage />)
 
     act(() => {
       latestUIProps?.onSelectGameMode(GameMode.Classic)
     })
 
-    await act(async () => {
-      await Promise.resolve()
-    })
+    await flushPromises()
 
-    act(() => {
-      latestUIProps?.onAddQuestion()
+    mockBlocker.reset = vi.fn(() => {
+      mockBlocker.state = 'unblocked'
     })
-    expect(addQuestionMock).toHaveBeenCalledWith(QuestionType.MultiChoice)
+    mockBlocker.state = 'blocked'
 
-    addQuestionMock.mockClear()
+    rerender(<QuizCreatorPage />)
 
-    act(() => {
-      latestUIProps?.onSelectGameMode(GameMode.ZeroToOneHundred)
-    })
+    expect(screen.getByTestId('unsaved-changes-exit-modal')).toBeInTheDocument()
 
-    await act(async () => {
-      await Promise.resolve()
-    })
+    fireEvent.click(screen.getByRole('button', { name: 'Stay' }))
 
-    act(() => {
-      latestUIProps?.onAddQuestion()
-    })
-    expect(addQuestionMock).toHaveBeenCalledWith(QuestionType.Range)
+    rerender(<QuizCreatorPage />)
+
+    expect(mockBlocker.reset).toHaveBeenCalledTimes(1)
+    expect(
+      screen.queryByTestId('unsaved-changes-exit-modal'),
+    ).not.toBeInTheDocument()
+    expect(navigateMock).not.toHaveBeenCalled()
   })
 
-  it('save: if invalid settings or questions -> notify and does not save', () => {
-    mockAllQuizSettingsValid = false
+  it('proceeds with blocked navigation when leaving from the exit modal', async () => {
+    const { rerender } = render(<QuizCreatorPage />)
+
+    act(() => {
+      latestUIProps?.onSelectGameMode(GameMode.Classic)
+    })
+
+    await flushPromises()
+
+    mockBlocker.proceed = vi.fn()
+    mockBlocker.state = 'blocked'
+
+    rerender(<QuizCreatorPage />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Leave' }))
+
+    expect(mockBlocker.proceed).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps save disabled when there are no unsaved changes', async () => {
+    const question = makeQuizQuestion('q-1')
+
+    mockQuizId = 'quiz-123'
+    mockQuizQueryState = {
+      data: makeQuizSummary(),
+      isLoading: false,
+      isError: false,
+    }
+    mockQuestionsQueryState = {
+      data: [question],
+      isLoading: false,
+      isError: false,
+      isFetchedAfterMount: true,
+    }
 
     render(<QuizCreatorPage />)
+    await flushPromises()
+
+    act(() => {
+      latestUIProps?.onSaveQuiz()
+    })
+
+    expect(latestUIProps?.canSaveQuiz).toBe(false)
+    expect(updateQuizMock).not.toHaveBeenCalled()
+    expect(createQuizMock).not.toHaveBeenCalled()
+  })
+
+  it('only enables saving when the quiz is valid and has unsaved changes', async () => {
+    mockAllQuizSettingsValid = false
+
+    const { rerender } = render(<QuizCreatorPage />)
+
+    act(() => {
+      latestUIProps?.onSelectGameMode(GameMode.Classic)
+    })
+
+    await flushPromises()
+
+    expect(latestUIProps?.canSaveQuiz).toBe(false)
+
+    mockAllQuizSettingsValid = true
+
+    rerender(<QuizCreatorPage />)
+
+    await flushPromises()
+
+    expect(latestUIProps?.canSaveQuiz).toBe(true)
+  })
+
+  it('updates the saved snapshot after saving an existing quiz', async () => {
+    const question = makeQuizQuestion('q-1')
+
+    mockQuizId = 'quiz-123'
+    mockQuizQueryState = {
+      data: makeQuizSummary(),
+      isLoading: false,
+      isError: false,
+    }
+    mockQuestionsQueryState = {
+      data: [question],
+      isLoading: false,
+      isError: false,
+      isFetchedAfterMount: true,
+    }
+    isClassicMultiChoiceQuestionMock.mockReturnValue(true)
+
+    render(<QuizCreatorPage />)
+    await flushPromises()
+
+    act(() => {
+      latestUIProps?.onQuizSettingsValueChange('title', 'Updated quiz title')
+    })
+
+    await flushPromises()
+
+    expect(latestUIProps?.canSaveQuiz).toBe(true)
+
+    act(() => {
+      latestUIProps?.onSaveQuiz()
+    })
+
+    await flushPromises()
+
+    expect(updateQuizMock).toHaveBeenCalledWith(
+      'quiz-123',
+      expect.objectContaining({
+        title: 'Updated quiz title',
+        mode: GameMode.Classic,
+      }),
+    )
+    expect(latestUIProps?.canSaveQuiz).toBe(false)
+    expect(latestShouldBlock?.({} as never)).toBe(false)
+  })
+
+  it('navigates to the edit route after creating a new quiz', async () => {
+    const question = makeQuizQuestion('q-1')
+
+    mockGameMode = GameMode.Classic
+    mockQuizSettings = {
+      ...mockQuizSettings,
+      title: 'New quiz',
+      description: 'Description',
+    }
+    mockQuestions = [question]
+    mockQuestionValidations = [{ valid: true }]
+    isClassicMultiChoiceQuestionMock.mockReturnValue(true)
+
+    render(<QuizCreatorPage />)
+
+    act(() => {
+      latestUIProps?.onSaveQuiz()
+    })
+
+    await flushPromises()
+
+    expect(createQuizMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: 'New quiz',
+        description: 'Description',
+        mode: GameMode.Classic,
+        questions: [question],
+      }),
+    )
+    expect(navigateMock).toHaveBeenCalledWith('/quiz/details/new-quiz-id/edit')
+  })
+
+  it('invalidates myProfileQuizzes and exits to the quiz details page for an existing quiz', async () => {
+    mockQuizId = 'quiz-123'
+
+    render(<QuizCreatorPage />)
+
+    act(() => {
+      latestUIProps?.onExit()
+    })
+
+    await flushPromises()
+
+    expect(invalidateQueriesMock).toHaveBeenCalledWith({
+      queryKey: ['myProfileQuizzes'],
+    })
+    expect(navigateMock).toHaveBeenCalledWith('/quiz/details/quiz-123')
+  })
+
+  it('exits to profile quizzes for a new quiz', () => {
+    render(<QuizCreatorPage />)
+
+    act(() => {
+      latestUIProps?.onExit()
+    })
+
+    expect(invalidateQueriesMock).not.toHaveBeenCalled()
+    expect(navigateMock).toHaveBeenCalledWith('/profile/quizzes')
+  })
+
+  it('shows a validation error instead of saving when dirty data is invalid', async () => {
+    mockAllQuestionsValid = false
+
+    render(<QuizCreatorPage />)
+
+    act(() => {
+      latestUIProps?.onSelectGameMode(GameMode.Classic)
+    })
+
+    await flushPromises()
 
     act(() => {
       latestUIProps?.onSaveQuiz()
@@ -452,359 +653,5 @@ describe('QuizCreatorPage', () => {
     )
     expect(createQuizMock).not.toHaveBeenCalled()
     expect(updateQuizMock).not.toHaveBeenCalled()
-    expect(navigateMock).not.toHaveBeenCalled()
-  })
-
-  it('save: missing game mode -> notify and does not save', () => {
-    render(<QuizCreatorPage />)
-
-    act(() => {
-      latestUIProps?.onSaveQuiz()
-    })
-
-    expect(notifyErrorMock).toHaveBeenCalledWith('Game mode is required')
-    expect(createQuizMock).not.toHaveBeenCalled()
-    expect(updateQuizMock).not.toHaveBeenCalled()
-  })
-
-  it('save: missing/blank title -> notify and does not save', () => {
-    mockGameMode = GameMode.Classic
-    mockQuizSettings = {
-      ...mockQuizSettings,
-      title: '   ',
-    }
-
-    render(<QuizCreatorPage />)
-
-    act(() => {
-      latestUIProps?.onSaveQuiz()
-    })
-
-    expect(notifyErrorMock).toHaveBeenCalledWith('Title is required')
-    expect(createQuizMock).not.toHaveBeenCalled()
-    expect(updateQuizMock).not.toHaveBeenCalled()
-  })
-
-  it('save: filters questions and errors if some are unsupported (length mismatch)', () => {
-    mockGameMode = GameMode.Classic
-
-    const q1 = { type: QuestionType.MultiChoice, id: 'q1' }
-    const q2 = { type: 'Unsupported', id: 'q2' }
-    mockQuestions = [q1, q2]
-
-    // Only q1 is considered valid classic multi
-    isClassicMultiChoiceQuestionMock.mockImplementation((_mode, q) => q === q1)
-
-    render(<QuizCreatorPage />)
-
-    act(() => {
-      latestUIProps?.onSaveQuiz()
-    })
-
-    expect(notifyErrorMock).toHaveBeenCalledWith(
-      'Some questions are invalid or unsupported. Please review your questions.',
-    )
-    expect(createQuizMock).not.toHaveBeenCalled()
-    expect(updateQuizMock).not.toHaveBeenCalled()
-  })
-
-  it('save: creates Classic quiz with trimmed title/description and defaults', async () => {
-    mockQuizId = undefined
-    mockGameMode = GameMode.Classic
-
-    mockQuizSettings = {
-      title: '  My quiz  ',
-      description: '  Desc  ',
-      imageCoverURL: 'https://example.com/cover.png',
-      visibility: undefined,
-      category: undefined,
-      languageCode: undefined,
-    }
-
-    const q1 = { type: QuestionType.MultiChoice, id: 'q1' }
-    const q2 = { type: QuestionType.TrueFalse, id: 'q2' }
-    mockQuestions = [q1, q2]
-
-    isClassicMultiChoiceQuestionMock.mockImplementation((_mode, q) => q === q1)
-    isClassicTrueFalseQuestionMock.mockImplementation((_mode, q) => q === q2)
-
-    render(<QuizCreatorPage />)
-
-    act(() => {
-      latestUIProps?.onSaveQuiz()
-    })
-
-    expect(createQuizMock).toHaveBeenCalledTimes(1)
-    const req = createQuizMock.mock.calls[0]?.[0]
-    expect(req).toEqual({
-      title: 'My quiz',
-      description: 'Desc',
-      visibility: QuizVisibility.Public,
-      category: QuizCategory.Other,
-      imageCoverURL: 'https://example.com/cover.png',
-      languageCode: LanguageCode.English,
-      mode: GameMode.Classic,
-      questions: [q1, q2],
-    })
-
-    await flushPromises()
-    expect(navigateMock).toHaveBeenCalledWith('/profile/quizzes')
-  })
-
-  it('save: creates ZeroToOneHundred quiz and only saves supported range questions', async () => {
-    mockQuizId = undefined
-    mockGameMode = GameMode.ZeroToOneHundred
-
-    const q1 = { type: QuestionType.Range, id: 'q1' }
-    const q2 = { type: QuestionType.Range, id: 'q2' }
-    mockQuestions = [q1, q2]
-
-    isZeroToOneHundredRangeQuestionMock.mockReturnValue(true)
-
-    render(<QuizCreatorPage />)
-
-    act(() => {
-      latestUIProps?.onSaveQuiz()
-    })
-
-    expect(createQuizMock).toHaveBeenCalledTimes(1)
-    const req = createQuizMock.mock.calls[0]?.[0]
-    expect(req).toMatchObject({
-      mode: GameMode.ZeroToOneHundred,
-      questions: [q1, q2],
-    })
-
-    await flushPromises()
-    expect(navigateMock).toHaveBeenCalledWith('/profile/quizzes')
-  })
-
-  it('save: updates quiz when quizId exists', async () => {
-    mockQuizId = 'quiz-123'
-    mockGameMode = GameMode.Classic
-
-    const q1 = { type: QuestionType.MultiChoice, id: 'q1' }
-    mockQuestions = [q1]
-    isClassicMultiChoiceQuestionMock.mockReturnValue(true)
-
-    render(<QuizCreatorPage />)
-
-    act(() => {
-      latestUIProps?.onSaveQuiz()
-    })
-
-    expect(updateQuizMock).toHaveBeenCalledTimes(1)
-    expect(updateQuizMock.mock.calls[0]?.[0]).toBe('quiz-123')
-    expect(updateQuizMock.mock.calls[0]?.[1]).toMatchObject({
-      mode: GameMode.Classic,
-      questions: [q1],
-    })
-
-    await flushPromises()
-    expect(navigateMock).toHaveBeenCalledWith('/profile/quizzes')
-  })
-
-  it('save: ignores subsequent save attempts while saving (create called once)', async () => {
-    mockGameMode = GameMode.Classic
-    const q1 = { type: QuestionType.MultiChoice, id: 'q1' }
-    mockQuestions = [q1]
-    isClassicMultiChoiceQuestionMock.mockReturnValue(true)
-
-    let resolveCreate: (() => void) | undefined
-    createQuizMock.mockImplementationOnce(
-      () =>
-        new Promise<void>((resolve) => {
-          resolveCreate = resolve
-        }),
-    )
-
-    render(<QuizCreatorPage />)
-
-    act(() => {
-      latestUIProps?.onSaveQuiz()
-    })
-
-    await act(async () => {
-      await Promise.resolve()
-    })
-
-    act(() => {
-      latestUIProps?.onSaveQuiz()
-    })
-
-    expect(createQuizMock).toHaveBeenCalledTimes(1)
-
-    await act(async () => {
-      resolveCreate?.()
-      await Promise.resolve()
-    })
-  })
-
-  it('hydrates questions only once per quizId', async () => {
-    mockQuizId = 'quiz-123'
-    mockQuizQueryState = {
-      data: {
-        mode: GameMode.Classic,
-        title: 'Loaded title',
-        visibility: QuizVisibility.Public,
-        category: QuizCategory.Other,
-        languageCode: LanguageCode.English,
-      },
-      isLoading: false,
-      isError: false,
-    }
-
-    const loadedQuestions = [{ id: 'q1' }, { id: 'q2' }]
-
-    mockQuestionsQueryState = {
-      data: loadedQuestions,
-      isLoading: false,
-      isError: false,
-      isFetchedAfterMount: true,
-    }
-
-    const { rerender } = render(<QuizCreatorPage />)
-
-    await flushPromises()
-
-    expect(setQuestionsMock).toHaveBeenCalledTimes(1)
-    expect(setQuestionsMock).toHaveBeenCalledWith(loadedQuestions)
-    expect(selectQuestionMock).toHaveBeenCalledWith(0)
-
-    rerender(<QuizCreatorPage />)
-    await flushPromises()
-
-    expect(setQuestionsMock).toHaveBeenCalledTimes(1)
-    expect(selectQuestionMock).toHaveBeenCalledTimes(1)
-  })
-
-  it('does not hydrate questions from cached query data when not fetched after mount', async () => {
-    mockQuizId = 'quiz-123'
-
-    mockQuizQueryState = {
-      data: {
-        mode: GameMode.Classic,
-        title: 'Loaded title',
-        visibility: QuizVisibility.Public,
-        category: QuizCategory.Other,
-        languageCode: LanguageCode.English,
-      },
-      isLoading: false,
-      isError: false,
-    }
-
-    const cachedQuestions = [{ id: 'q1' }, { id: 'q2' }]
-
-    mockQuestionsQueryState = {
-      data: cachedQuestions,
-      isLoading: false,
-      isError: false,
-      isFetchedAfterMount: false,
-    }
-
-    render(<QuizCreatorPage />)
-    await flushPromises()
-
-    expect(setQuestionsMock).not.toHaveBeenCalled()
-    expect(selectQuestionMock).not.toHaveBeenCalled()
-  })
-
-  it('does not overwrite local question edits after initial hydration', async () => {
-    mockQuizId = 'quiz-123'
-    mockQuizQueryState = {
-      data: {
-        mode: GameMode.Classic,
-        title: 'Loaded title',
-        visibility: QuizVisibility.Public,
-        category: QuizCategory.Other,
-        languageCode: LanguageCode.English,
-      },
-      isLoading: false,
-      isError: false,
-    }
-
-    const loadedQuestions = [{ id: 'q1' }, { id: 'q2' }]
-
-    mockQuestionsQueryState = {
-      data: loadedQuestions,
-      isLoading: false,
-      isError: false,
-      isFetchedAfterMount: true,
-    }
-
-    const { rerender } = render(<QuizCreatorPage />)
-
-    await flushPromises()
-
-    // First hydration call
-    expect(setQuestionsMock).toHaveBeenCalledTimes(1)
-    expect(setQuestionsMock.mock.calls[0]?.[0]).toBe(loadedQuestions)
-
-    const localQuestions = [...loadedQuestions, { id: 'q3-local' }]
-
-    act(() => {
-      latestUIProps?.onSetQuestions(localQuestions)
-    })
-
-    // This call is the local edit we just applied
-    expect(setQuestionsMock).toHaveBeenCalledTimes(2)
-    expect(setQuestionsMock.mock.calls[1]?.[0]).toEqual(localQuestions)
-
-    // Re-render should NOT trigger a new hydration back to loadedQuestions
-    rerender(<QuizCreatorPage />)
-    await flushPromises()
-
-    expect(setQuestionsMock).toHaveBeenCalledTimes(2)
-    expect(latestUIProps?.questions).toEqual(localQuestions)
-  })
-
-  it('rehydrates questions when quizId changes', async () => {
-    mockQuizQueryState = {
-      data: {
-        mode: GameMode.Classic,
-        title: 'Loaded title',
-        visibility: QuizVisibility.Public,
-        category: QuizCategory.Other,
-        languageCode: LanguageCode.English,
-      },
-      isLoading: false,
-      isError: false,
-    }
-
-    const questionsQuiz1 = [{ id: 'q1' }]
-    const questionsQuiz2 = [{ id: 'q2' }]
-
-    mockQuizId = 'quiz-1'
-    mockQuestionsQueryState = {
-      data: questionsQuiz1,
-      isLoading: false,
-      isError: false,
-      isFetchedAfterMount: true,
-    }
-
-    const { rerender } = render(<QuizCreatorPage />)
-    await flushPromises()
-
-    expect(setQuestionsMock).toHaveBeenCalledTimes(1)
-    expect(setQuestionsMock.mock.calls[0]?.[0]).toBe(questionsQuiz1)
-
-    // Switch quizId + query payload
-    mockQuizId = 'quiz-2'
-    mockQuestionsQueryState = {
-      data: questionsQuiz2,
-      isLoading: false,
-      isError: false,
-      isFetchedAfterMount: true,
-    }
-
-    // Render once to trigger the [quizId] ref-reset effect
-    rerender(<QuizCreatorPage />)
-    await flushPromises()
-
-    // Render again so the hydrate effect runs with didHydrateQuestionsRef=false
-    rerender(<QuizCreatorPage />)
-    await flushPromises()
-
-    expect(setQuestionsMock).toHaveBeenCalledTimes(2)
-    expect(setQuestionsMock.mock.calls[1]?.[0]).toBe(questionsQuiz2)
   })
 })

--- a/packages/klurigo-web/src/pages/QuizCreatorPage/QuizCreatorPage.tsx
+++ b/packages/klurigo-web/src/pages/QuizCreatorPage/QuizCreatorPage.tsx
@@ -15,10 +15,17 @@ import {
   QuizCategory,
   QuizVisibility,
 } from '@klurigo/common'
-import { useQuery } from '@tanstack/react-query'
-import { type FC, useRef } from 'react'
-import { useEffect, useState } from 'react'
-import { useNavigate, useParams } from 'react-router-dom'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
+import {
+  type FC,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react'
+import { type BlockerFunction, useNavigate, useParams } from 'react-router-dom'
+import { useBlocker } from 'react-router-dom'
 
 import { useKlurigoServiceClient } from '../../api'
 import { LoadingSpinner, Page } from '../../components'
@@ -33,7 +40,7 @@ import {
   isZeroToOneHundredRangeQuestion,
 } from '../../utils/questions'
 
-import QuizCreatorPageUI from './components/QuizCreatorPageUI'
+import { QuizCreatorPageUI, UnsavedChangesExitModal } from './components'
 import { useQuestionDataSource } from './utils/QuestionDataSource'
 import { useQuizSettingsDataSource } from './utils/QuizSettingsDataSource'
 
@@ -41,6 +48,8 @@ const QuizCreatorPage: FC = () => {
   const { quizId } = useParams<{ quizId: string }>()
 
   const navigate = useNavigate()
+
+  const queryClient = useQueryClient()
 
   const { createQuiz, getQuiz, getQuizQuestions, updateQuiz } =
     useKlurigoServiceClient()
@@ -134,6 +143,55 @@ const QuizCreatorPage: FC = () => {
     selectQuestion,
   ])
 
+  const [isSavingQuiz, setIsSavingQuiz] = useState(false)
+
+  type SavedQuizSnapshot = {
+    gameMode: GameMode | null
+    quizSettings: {
+      title: string
+      description: string
+      imageCoverURL: string | undefined
+      visibility: QuizVisibility
+      category: QuizCategory
+      languageCode: LanguageCode
+    }
+    questions: typeof questions
+  }
+
+  const [savedQuizSnapshot, setSavedQuizSnapshot] =
+    useState<SavedQuizSnapshot | null>(null)
+
+  useEffect(() => {
+    if (!quizId) return
+    if (!originalQuiz) return
+    if (!originalQuizQuestions) return
+    if (isQuizLoading || isQuizError) return
+    if (isQuizQuestionsLoading || isQuizQuestionsError) return
+    if (!isFetchedAfterMount) return
+
+    setSavedQuizSnapshot({
+      gameMode: originalQuiz.mode,
+      quizSettings: {
+        title: originalQuiz.title ?? '',
+        description: originalQuiz.description ?? '',
+        imageCoverURL: originalQuiz.imageCoverURL,
+        visibility: originalQuiz.visibility,
+        category: originalQuiz.category,
+        languageCode: originalQuiz.languageCode,
+      },
+      questions: structuredClone(originalQuizQuestions),
+    })
+  }, [
+    quizId,
+    originalQuiz,
+    originalQuizQuestions,
+    isQuizLoading,
+    isQuizError,
+    isQuizQuestionsLoading,
+    isQuizQuestionsError,
+    isFetchedAfterMount,
+  ])
+
   useEffect(() => {
     didHydrateQuestionsRef.current = false
   }, [quizId])
@@ -147,10 +205,58 @@ const QuizCreatorPage: FC = () => {
     }
   }
 
-  const [isSavingQuiz, setIsSavingQuiz] = useState(false)
+  const currentQuizSettings = useMemo(
+    () => ({
+      title: quizSettings.title?.trim() ?? '',
+      description: quizSettings.description?.trim() ?? '',
+      imageCoverURL: quizSettings.imageCoverURL,
+      visibility: quizSettings.visibility ?? QuizVisibility.Public,
+      category: quizSettings.category ?? QuizCategory.Other,
+      languageCode: quizSettings.languageCode ?? LanguageCode.English,
+    }),
+    [quizSettings],
+  )
+
+  const normalizedCurrentQuestions = useMemo(() => questions, [questions])
+
+  const hasUnsavedChanges = useMemo(() => {
+    if (!quizId) {
+      return (
+        !!gameMode ||
+        currentQuizSettings.title !== '' ||
+        currentQuizSettings.description !== '' ||
+        !!currentQuizSettings.imageCoverURL ||
+        normalizedCurrentQuestions.length > 0
+      )
+    }
+
+    if (!savedQuizSnapshot) {
+      return false
+    }
+
+    return (
+      gameMode !== savedQuizSnapshot.gameMode ||
+      JSON.stringify(savedQuizSnapshot.quizSettings) !==
+        JSON.stringify(currentQuizSettings) ||
+      JSON.stringify(savedQuizSnapshot.questions) !==
+        JSON.stringify(normalizedCurrentQuestions)
+    )
+  }, [
+    quizId,
+    gameMode,
+    currentQuizSettings,
+    normalizedCurrentQuestions,
+    savedQuizSnapshot,
+  ])
+
+  const shouldBlock = useCallback<BlockerFunction>(() => {
+    return hasUnsavedChanges && !isSavingQuiz
+  }, [hasUnsavedChanges, isSavingQuiz])
+
+  const blocker = useBlocker(shouldBlock)
 
   const handleSaveQuiz = () => {
-    if (isSavingQuiz) {
+    if (isSavingQuiz || !hasUnsavedChanges) {
       return
     }
 
@@ -230,13 +336,39 @@ const QuizCreatorPage: FC = () => {
 
     setIsSavingQuiz(true)
 
-    const savePromise = quizId
-      ? updateQuiz(quizId, requestData)
-      : createQuiz(requestData)
+    if (quizId) {
+      updateQuiz(quizId, requestData)
+        .then(() => {
+          setSavedQuizSnapshot({
+            gameMode,
+            quizSettings: currentQuizSettings,
+            questions: structuredClone(normalizedCurrentQuestions),
+          })
+        })
+        .finally(() => setIsSavingQuiz(false))
+    } else {
+      createQuiz(requestData)
+        .then((response) => {
+          navigate(`/quiz/details/${response.id}/edit`)
+        })
+        .finally(() => setIsSavingQuiz(false))
+    }
+  }
 
-    savePromise
-      .then(() => navigate('/profile/quizzes'))
-      .finally(() => setIsSavingQuiz(false))
+  const handleExit = () => {
+    if (quizId) {
+      queryClient
+        .invalidateQueries({ queryKey: ['myProfileQuizzes'] })
+        .then(() => navigate(`/quiz/details/${quizId}`))
+    } else {
+      navigate('/profile/quizzes')
+    }
+  }
+
+  const handleConfirmedExit = () => {
+    if (blocker.state === 'blocked') {
+      blocker.proceed()
+    }
   }
 
   if (
@@ -254,29 +386,40 @@ const QuizCreatorPage: FC = () => {
   }
 
   return (
-    <QuizCreatorPageUI
-      gameMode={gameMode}
-      onSelectGameMode={setGameMode}
-      quizSettings={quizSettings}
-      quizSettingsValidation={quizSettingsValidation}
-      allQuizSettingsValid={allQuizSettingsValid}
-      onQuizSettingsValueChange={onQuizSettingsValueChange}
-      questions={questions}
-      questionValidations={questionValidations}
-      allQuestionsValid={allQuestionsValid}
-      selectedQuestion={selectedQuestion}
-      selectedQuestionIndex={selectedQuestionIndex}
-      onSetQuestions={setQuestions}
-      onSelectedQuestionIndex={selectQuestion}
-      onAddQuestion={handleAddQuestion}
-      onQuestionValueChange={updateSelectedQuestionField}
-      onDropQuestionIndex={moveSelectedQuestionTo}
-      onDuplicateQuestionIndex={duplicateQuestion}
-      onDeleteQuestionIndex={deleteQuestion}
-      onReplaceQuestion={replaceQuestion}
-      isSavingQuiz={isSavingQuiz}
-      onSaveQuiz={handleSaveQuiz}
-    />
+    <>
+      <QuizCreatorPageUI
+        gameMode={gameMode}
+        onSelectGameMode={setGameMode}
+        quizSettings={quizSettings}
+        quizSettingsValidation={quizSettingsValidation}
+        onQuizSettingsValueChange={onQuizSettingsValueChange}
+        questions={questions}
+        questionValidations={questionValidations}
+        selectedQuestion={selectedQuestion}
+        selectedQuestionIndex={selectedQuestionIndex}
+        canSaveQuiz={
+          allQuizSettingsValid && allQuestionsValid && hasUnsavedChanges
+        }
+        isSavingQuiz={isSavingQuiz}
+        onSetQuestions={setQuestions}
+        onSelectedQuestionIndex={selectQuestion}
+        onAddQuestion={handleAddQuestion}
+        onQuestionValueChange={updateSelectedQuestionField}
+        onDropQuestionIndex={moveSelectedQuestionTo}
+        onDuplicateQuestionIndex={duplicateQuestion}
+        onDeleteQuestionIndex={deleteQuestion}
+        onReplaceQuestion={replaceQuestion}
+        onSaveQuiz={handleSaveQuiz}
+        onExit={handleExit}
+      />
+
+      {blocker.state === 'blocked' && (
+        <UnsavedChangesExitModal
+          onReset={() => blocker.reset()}
+          onConfirm={handleConfirmedExit}
+        />
+      )}
+    </>
   )
 }
 

--- a/packages/klurigo-web/src/pages/QuizCreatorPage/components/QuizCreatorPageUI/QuizCreatorPageUI.stories.tsx
+++ b/packages/klurigo-web/src/pages/QuizCreatorPage/components/QuizCreatorPageUI/QuizCreatorPageUI.stories.tsx
@@ -17,7 +17,6 @@ const QuizCreatorPageUIStoryComponent: FC<QuizCreatorPageUIProps> = () => {
   const {
     settings: quizSettings,
     settingsValidation: quizSettingsValidation,
-    allSettingsValid: allQuizSettingsValid,
     updateSettingsField: onQuizSettingsValueChange,
   } = useQuizSettingsDataSource()
 
@@ -27,7 +26,6 @@ const QuizCreatorPageUIStoryComponent: FC<QuizCreatorPageUIProps> = () => {
     questions,
     setQuestions,
     questionValidations,
-    allQuestionsValid,
     selectedQuestion,
     selectedQuestionIndex,
     selectQuestion,
@@ -54,13 +52,12 @@ const QuizCreatorPageUIStoryComponent: FC<QuizCreatorPageUIProps> = () => {
       onSelectGameMode={setGameMode}
       quizSettings={quizSettings}
       quizSettingsValidation={quizSettingsValidation}
-      allQuizSettingsValid={allQuizSettingsValid}
       onQuizSettingsValueChange={onQuizSettingsValueChange}
       questions={questions}
       questionValidations={questionValidations}
-      allQuestionsValid={allQuestionsValid}
       selectedQuestion={selectedQuestion}
       selectedQuestionIndex={selectedQuestionIndex}
+      canSaveQuiz={false}
       onSetQuestions={setQuestions}
       onSelectedQuestionIndex={selectQuestion}
       onAddQuestion={handleAddQuestion}
@@ -70,6 +67,7 @@ const QuizCreatorPageUIStoryComponent: FC<QuizCreatorPageUIProps> = () => {
       onDeleteQuestionIndex={deleteQuestion}
       onReplaceQuestion={replaceQuestion}
       onSaveQuiz={() => undefined}
+      onExit={() => undefined}
     />
   )
 }
@@ -91,12 +89,11 @@ export const Default = {
   args: {
     quizSettings: {},
     quizSettingsValidation: {} as QuizSettingsValidationResult,
-    allQuizSettingsValid: false,
     questions: [],
     questionValidations: [] as QuizQuestionValidationResult[],
-    allQuestionsValid: false,
     selectedQuestion: undefined,
     selectedQuestionIndex: -1,
+    canSaveQuiz: true,
     onSetQuestions: () => undefined,
     onQuizSettingsValueChange: () => undefined,
     onSelectedQuestionIndex: () => undefined,
@@ -107,5 +104,6 @@ export const Default = {
     onDeleteQuestionIndex: () => undefined,
     onReplaceQuestion: () => undefined,
     onSaveQuiz: () => undefined,
+    onExit: () => undefined,
   },
 } satisfies Story

--- a/packages/klurigo-web/src/pages/QuizCreatorPage/components/QuizCreatorPageUI/QuizCreatorPageUI.test.tsx
+++ b/packages/klurigo-web/src/pages/QuizCreatorPage/components/QuizCreatorPageUI/QuizCreatorPageUI.test.tsx
@@ -4,10 +4,11 @@ import {
   QuestionRangeAnswerMargin,
   QuestionType,
 } from '@klurigo/common'
-import { render } from '@testing-library/react'
+import { fireEvent, render } from '@testing-library/react'
 import '@testing-library/jest-dom'
+import type { ComponentProps } from 'react'
 import { MemoryRouter } from 'react-router-dom'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import type { ValidationResult } from '../../../../validation'
 
@@ -27,8 +28,39 @@ function makeValidation(
   } as unknown as AnyValidation
 }
 
+const renderQuizCreatorPageUI = (
+  props: Partial<ComponentProps<typeof QuizCreatorPageUI>> = {},
+) =>
+  render(
+    <MemoryRouter>
+      <QuizCreatorPageUI
+        gameMode={undefined}
+        onSelectGameMode={() => undefined}
+        quizSettings={{}}
+        quizSettingsValidation={makeValidation()}
+        onQuizSettingsValueChange={() => undefined}
+        questions={[]}
+        questionValidations={[]}
+        selectedQuestion={undefined}
+        selectedQuestionIndex={0}
+        canSaveQuiz={false}
+        onSetQuestions={() => undefined}
+        onSelectedQuestionIndex={() => undefined}
+        onAddQuestion={() => undefined}
+        onQuestionValueChange={() => undefined}
+        onDropQuestionIndex={() => undefined}
+        onDuplicateQuestionIndex={() => undefined}
+        onDeleteQuestionIndex={() => undefined}
+        onReplaceQuestion={() => undefined}
+        onSaveQuiz={() => undefined}
+        onExit={() => undefined}
+        {...props}
+      />
+    </MemoryRouter>,
+  )
+
 describe('QuizCreatorPageUI', () => {
-  it('renders QuizCreatorPageUI without mdoe', () => {
+  it('renders QuizCreatorPageUI without mode', () => {
     const { container } = render(
       <MemoryRouter>
         <QuizCreatorPageUI
@@ -36,13 +68,12 @@ describe('QuizCreatorPageUI', () => {
           onSelectGameMode={() => undefined}
           quizSettings={{}}
           quizSettingsValidation={makeValidation()}
-          allQuizSettingsValid={false}
           onQuizSettingsValueChange={() => undefined}
           questions={[]}
           questionValidations={[]}
-          allQuestionsValid={false}
           selectedQuestion={undefined}
           selectedQuestionIndex={0}
+          canSaveQuiz={false}
           onSetQuestions={() => undefined}
           onSelectedQuestionIndex={() => undefined}
           onAddQuestion={() => undefined}
@@ -52,6 +83,7 @@ describe('QuizCreatorPageUI', () => {
           onDeleteQuestionIndex={() => undefined}
           onReplaceQuestion={() => undefined}
           onSaveQuiz={() => undefined}
+          onExit={() => undefined}
         />
       </MemoryRouter>,
     )
@@ -67,13 +99,12 @@ describe('QuizCreatorPageUI', () => {
           onSelectGameMode={() => undefined}
           quizSettings={{}}
           quizSettingsValidation={makeValidation()}
-          allQuizSettingsValid={false}
           onQuizSettingsValueChange={() => undefined}
           questions={[]}
           questionValidations={[]}
-          allQuestionsValid={false}
           selectedQuestion={undefined}
           selectedQuestionIndex={0}
+          canSaveQuiz={false}
           onSetQuestions={() => undefined}
           onSelectedQuestionIndex={() => undefined}
           onAddQuestion={() => undefined}
@@ -83,6 +114,7 @@ describe('QuizCreatorPageUI', () => {
           onDeleteQuestionIndex={() => undefined}
           onReplaceQuestion={() => undefined}
           onSaveQuiz={() => undefined}
+          onExit={() => undefined}
         />
       </MemoryRouter>,
     )
@@ -98,7 +130,6 @@ describe('QuizCreatorPageUI', () => {
           onSelectGameMode={() => undefined}
           quizSettings={{}}
           quizSettingsValidation={makeValidation()}
-          allQuizSettingsValid={false}
           onQuizSettingsValueChange={() => undefined}
           questions={[
             {
@@ -180,8 +211,8 @@ describe('QuizCreatorPageUI', () => {
             points: 1000,
             duration: 30,
           }}
-          allQuestionsValid={false}
           selectedQuestionIndex={0}
+          canSaveQuiz={false}
           onSetQuestions={() => undefined}
           onSelectedQuestionIndex={() => undefined}
           onAddQuestion={() => undefined}
@@ -191,6 +222,7 @@ describe('QuizCreatorPageUI', () => {
           onDeleteQuestionIndex={() => undefined}
           onReplaceQuestion={() => undefined}
           onSaveQuiz={() => undefined}
+          onExit={() => undefined}
         />
       </MemoryRouter>,
     )
@@ -206,13 +238,12 @@ describe('QuizCreatorPageUI', () => {
           onSelectGameMode={() => undefined}
           quizSettings={{}}
           quizSettingsValidation={makeValidation()}
-          allQuizSettingsValid={false}
           onQuizSettingsValueChange={() => undefined}
           questions={[]}
           questionValidations={[]}
-          allQuestionsValid={false}
           selectedQuestion={undefined}
           selectedQuestionIndex={0}
+          canSaveQuiz={false}
           onSetQuestions={() => undefined}
           onSelectedQuestionIndex={() => undefined}
           onAddQuestion={() => undefined}
@@ -222,6 +253,7 @@ describe('QuizCreatorPageUI', () => {
           onDeleteQuestionIndex={() => undefined}
           onReplaceQuestion={() => undefined}
           onSaveQuiz={() => undefined}
+          onExit={() => undefined}
         />
       </MemoryRouter>,
     )
@@ -237,7 +269,6 @@ describe('QuizCreatorPageUI', () => {
           onSelectGameMode={() => undefined}
           quizSettings={{}}
           quizSettingsValidation={makeValidation()}
-          allQuizSettingsValid={false}
           onQuizSettingsValueChange={() => undefined}
           questions={[
             {
@@ -253,9 +284,9 @@ describe('QuizCreatorPageUI', () => {
             },
           ]}
           questionValidations={[]}
-          allQuestionsValid={false}
           selectedQuestion={undefined}
           selectedQuestionIndex={0}
+          canSaveQuiz={false}
           onSetQuestions={() => undefined}
           onSelectedQuestionIndex={() => undefined}
           onAddQuestion={() => undefined}
@@ -265,10 +296,35 @@ describe('QuizCreatorPageUI', () => {
           onDeleteQuestionIndex={() => undefined}
           onReplaceQuestion={() => undefined}
           onSaveQuiz={() => undefined}
+          onExit={() => undefined}
         />
       </MemoryRouter>,
     )
 
     expect(container).toMatchSnapshot()
+  })
+
+  it('disables the save button when canSaveQuiz is false', () => {
+    const { container } = renderQuizCreatorPageUI({ canSaveQuiz: false })
+
+    expect(container.querySelector('#save-button')).toBeDisabled()
+  })
+
+  it('enables the save button when canSaveQuiz is true', () => {
+    const { container } = renderQuizCreatorPageUI({ canSaveQuiz: true })
+
+    expect(container.querySelector('#save-button')).toBeEnabled()
+  })
+
+  it('calls onExit when the exit button is clicked', () => {
+    const onExit = vi.fn()
+
+    const { container } = renderQuizCreatorPageUI({ onExit })
+
+    fireEvent.click(
+      container.querySelector('#exit-button') as HTMLButtonElement,
+    )
+
+    expect(onExit).toHaveBeenCalledTimes(1)
   })
 })

--- a/packages/klurigo-web/src/pages/QuizCreatorPage/components/QuizCreatorPageUI/QuizCreatorPageUI.tsx
+++ b/packages/klurigo-web/src/pages/QuizCreatorPage/components/QuizCreatorPageUI/QuizCreatorPageUI.tsx
@@ -1,4 +1,5 @@
 import {
+  faArrowRightFromBracket,
   faCode,
   faFloppyDisk,
   faGear,
@@ -7,7 +8,7 @@ import {
 import type { QuestionDto } from '@klurigo/common'
 import { GameMode, QuestionType } from '@klurigo/common'
 import type { FC } from 'react'
-import { useMemo, useState } from 'react'
+import { useState } from 'react'
 
 import { Button, Page, TextField } from '../../../../components'
 import { DeviceType } from '../../../../utils/device-size.types'
@@ -37,14 +38,14 @@ export interface QuizCreatorPageUIProps {
   onSelectGameMode?: (gameMode: GameMode) => void
   quizSettings: QuizSettingsModel
   quizSettingsValidation: QuizSettingsValidationResult
-  allQuizSettingsValid: boolean
   onQuizSettingsValueChange: QuizSettingsModelFieldChangeFunction
   questions: QuizQuestionModel[]
   questionValidations: QuizQuestionValidationResult[]
   onSetQuestions: (questions: QuizQuestionModel[]) => void
-  allQuestionsValid: boolean
   selectedQuestion?: QuizQuestionModel
   selectedQuestionIndex: number
+  canSaveQuiz: boolean
+  isSavingQuiz?: boolean
   onSelectedQuestionIndex: (index: number) => void
   onAddQuestion: () => void
   onQuestionValueChange: QuizQuestionModelFieldChangeFunction<QuestionDto>
@@ -52,8 +53,8 @@ export interface QuizCreatorPageUIProps {
   onDuplicateQuestionIndex: (index: number) => void
   onDeleteQuestionIndex: (index: number) => void
   onReplaceQuestion: (type: QuestionType) => void
-  isSavingQuiz?: boolean
   onSaveQuiz: () => void
+  onExit: () => void
 }
 
 const QuizCreatorPageUI: FC<QuizCreatorPageUIProps> = ({
@@ -61,14 +62,14 @@ const QuizCreatorPageUI: FC<QuizCreatorPageUIProps> = ({
   onSelectGameMode,
   quizSettings,
   quizSettingsValidation,
-  allQuizSettingsValid,
   onQuizSettingsValueChange,
   questions,
   questionValidations,
   onSetQuestions,
-  allQuestionsValid,
   selectedQuestion,
   selectedQuestionIndex,
+  canSaveQuiz,
+  isSavingQuiz,
   onSelectedQuestionIndex,
   onAddQuestion,
   onQuestionValueChange,
@@ -76,8 +77,8 @@ const QuizCreatorPageUI: FC<QuizCreatorPageUIProps> = ({
   onDuplicateQuestionIndex,
   onDeleteQuestionIndex,
   onReplaceQuestion,
-  isSavingQuiz,
   onSaveQuiz,
+  onExit,
 }) => {
   const deviceType = useDeviceSizeType()
 
@@ -85,11 +86,6 @@ const QuizCreatorPageUI: FC<QuizCreatorPageUIProps> = ({
 
   const [showAdvancedQuestionEditor, setShowAdvancedQuestionEditor] =
     useState(false)
-
-  const isValid = useMemo(
-    () => allQuestionsValid && allQuizSettingsValid,
-    [allQuestionsValid, allQuizSettingsValid],
-  )
 
   return (
     <Page
@@ -135,8 +131,18 @@ const QuizCreatorPageUI: FC<QuizCreatorPageUIProps> = ({
             hideValue="mobile"
             icon={faFloppyDisk}
             loading={!!isSavingQuiz}
-            disabled={!isValid}
+            disabled={!canSaveQuiz}
             onClick={onSaveQuiz}
+          />
+          <Button
+            id="exit-button"
+            type="button"
+            size="small"
+            kind="primary"
+            value="Exit"
+            hideValue="mobile"
+            icon={faArrowRightFromBracket}
+            onClick={onExit}
           />
         </div>
       }

--- a/packages/klurigo-web/src/pages/QuizCreatorPage/components/QuizCreatorPageUI/__snapshots__/QuizCreatorPageUI.test.tsx.snap
+++ b/packages/klurigo-web/src/pages/QuizCreatorPage/components/QuizCreatorPageUI/__snapshots__/QuizCreatorPageUI.test.tsx.snap
@@ -106,6 +106,33 @@ exports[`QuizCreatorPageUI > renders QuizCreatorPageUI for classic mode 1`] = `
               </span>
             </button>
           </div>
+          <div
+            class="buttonInputContainer buttonInputKindPrimary buttonInputSizeSmall"
+          >
+            <button
+              data-testid="test-exit-button-button"
+              id="exit-button"
+              name="exit-button"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                class="svg-inline--fa fa-arrow-right-from-bracket"
+                data-icon="arrow-right-from-bracket"
+                data-prefix="fas"
+                role="img"
+                viewBox="0 0 512 512"
+              >
+                <path
+                  d="M160 96c17.7 0 32-14.3 32-32s-14.3-32-32-32L96 32C43 32 0 75 0 128L0 384c0 53 43 96 96 96l64 0c17.7 0 32-14.3 32-32s-14.3-32-32-32l-64 0c-17.7 0-32-14.3-32-32l0-256c0-17.7 14.3-32 32-32l64 0zM502.6 278.6c12.5-12.5 12.5-32.8 0-45.3l-128-128c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3L402.7 224 192 224c-17.7 0-32 14.3-32 32s14.3 32 32 32l210.7 0-73.4 73.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0l128-128z"
+                  fill="currentColor"
+                />
+              </svg>
+              <span>
+                Exit
+              </span>
+            </button>
+          </div>
         </div>
       </div>
     </div>
@@ -164,7 +191,7 @@ exports[`QuizCreatorPageUI > renders QuizCreatorPageUI for classic mode 1`] = `
                       class="questionPickerItemOverlayBottom"
                     >
                       <button
-                        class="questionPickerItemOverlayDuplicate"
+                        class="cloneButton"
                       >
                         <svg
                           aria-hidden="true"
@@ -181,7 +208,7 @@ exports[`QuizCreatorPageUI > renders QuizCreatorPageUI for classic mode 1`] = `
                         </svg>
                       </button>
                       <button
-                        class="questionPickerItemOverlayDelete"
+                        class="deleteButton"
                       >
                         <svg
                           aria-hidden="true"
@@ -632,21 +659,21 @@ exports[`QuizCreatorPageUI > renders QuizCreatorPageUI for classic mode 1`] = `
                             >
                               <input
                                 class="textfield"
-                                data-testid="test-multi-choice-option-_r_18_-0-textfield"
-                                id="multi-choice-option-_r_18_-0"
-                                name="multi-choice-option-_r_18_-0"
+                                data-testid="test-multi-choice-option-_r_1e_-0-textfield"
+                                id="multi-choice-option-_r_1e_-0"
+                                name="multi-choice-option-_r_1e_-0"
                                 placeholder="Option 1"
                                 type="text"
                                 value="Vincent van Gogh"
                               />
                               <label
                                 class="checkboxLabel"
-                                for="multi-choice-option-_r_18_-0-checkbox"
+                                for="multi-choice-option-_r_1e_-0-checkbox"
                               >
                                 <input
                                   checked=""
                                   class="checkbox"
-                                  id="multi-choice-option-_r_18_-0-checkbox"
+                                  id="multi-choice-option-_r_1e_-0-checkbox"
                                   type="checkbox"
                                 />
                                 <span
@@ -708,20 +735,20 @@ exports[`QuizCreatorPageUI > renders QuizCreatorPageUI for classic mode 1`] = `
                             >
                               <input
                                 class="textfield"
-                                data-testid="test-multi-choice-option-_r_18_-1-textfield"
-                                id="multi-choice-option-_r_18_-1"
-                                name="multi-choice-option-_r_18_-1"
+                                data-testid="test-multi-choice-option-_r_1e_-1-textfield"
+                                id="multi-choice-option-_r_1e_-1"
+                                name="multi-choice-option-_r_1e_-1"
                                 placeholder="Option 2"
                                 type="text"
                                 value="Pablo Picasso"
                               />
                               <label
                                 class="checkboxLabel"
-                                for="multi-choice-option-_r_18_-1-checkbox"
+                                for="multi-choice-option-_r_1e_-1-checkbox"
                               >
                                 <input
                                   class="checkbox"
-                                  id="multi-choice-option-_r_18_-1-checkbox"
+                                  id="multi-choice-option-_r_1e_-1-checkbox"
                                   type="checkbox"
                                 />
                               </label>
@@ -766,20 +793,20 @@ exports[`QuizCreatorPageUI > renders QuizCreatorPageUI for classic mode 1`] = `
                             >
                               <input
                                 class="textfield"
-                                data-testid="test-multi-choice-option-_r_18_-2-textfield"
-                                id="multi-choice-option-_r_18_-2"
-                                name="multi-choice-option-_r_18_-2"
+                                data-testid="test-multi-choice-option-_r_1e_-2-textfield"
+                                id="multi-choice-option-_r_1e_-2"
+                                name="multi-choice-option-_r_1e_-2"
                                 placeholder="Option 3"
                                 type="text"
                                 value="Leonardo da Vinci"
                               />
                               <label
                                 class="checkboxLabel"
-                                for="multi-choice-option-_r_18_-2-checkbox"
+                                for="multi-choice-option-_r_1e_-2-checkbox"
                               >
                                 <input
                                   class="checkbox"
-                                  id="multi-choice-option-_r_18_-2-checkbox"
+                                  id="multi-choice-option-_r_1e_-2-checkbox"
                                   type="checkbox"
                                 />
                               </label>
@@ -824,20 +851,20 @@ exports[`QuizCreatorPageUI > renders QuizCreatorPageUI for classic mode 1`] = `
                             >
                               <input
                                 class="textfield"
-                                data-testid="test-multi-choice-option-_r_18_-3-textfield"
-                                id="multi-choice-option-_r_18_-3"
-                                name="multi-choice-option-_r_18_-3"
+                                data-testid="test-multi-choice-option-_r_1e_-3-textfield"
+                                id="multi-choice-option-_r_1e_-3"
+                                name="multi-choice-option-_r_1e_-3"
                                 placeholder="Option 4"
                                 type="text"
                                 value="Claude Monet"
                               />
                               <label
                                 class="checkboxLabel"
-                                for="multi-choice-option-_r_18_-3-checkbox"
+                                for="multi-choice-option-_r_1e_-3-checkbox"
                               >
                                 <input
                                   class="checkbox"
-                                  id="multi-choice-option-_r_18_-3-checkbox"
+                                  id="multi-choice-option-_r_1e_-3-checkbox"
                                   type="checkbox"
                                 />
                               </label>
@@ -882,20 +909,20 @@ exports[`QuizCreatorPageUI > renders QuizCreatorPageUI for classic mode 1`] = `
                             >
                               <input
                                 class="textfield"
-                                data-testid="test-multi-choice-option-_r_18_-4-textfield"
-                                id="multi-choice-option-_r_18_-4"
-                                name="multi-choice-option-_r_18_-4"
+                                data-testid="test-multi-choice-option-_r_1e_-4-textfield"
+                                id="multi-choice-option-_r_1e_-4"
+                                name="multi-choice-option-_r_1e_-4"
                                 placeholder="Option 5"
                                 type="text"
                                 value="Michelangelo"
                               />
                               <label
                                 class="checkboxLabel"
-                                for="multi-choice-option-_r_18_-4-checkbox"
+                                for="multi-choice-option-_r_1e_-4-checkbox"
                               >
                                 <input
                                   class="checkbox"
-                                  id="multi-choice-option-_r_18_-4-checkbox"
+                                  id="multi-choice-option-_r_1e_-4-checkbox"
                                   type="checkbox"
                                 />
                               </label>
@@ -940,20 +967,20 @@ exports[`QuizCreatorPageUI > renders QuizCreatorPageUI for classic mode 1`] = `
                             >
                               <input
                                 class="textfield"
-                                data-testid="test-multi-choice-option-_r_18_-5-textfield"
-                                id="multi-choice-option-_r_18_-5"
-                                name="multi-choice-option-_r_18_-5"
+                                data-testid="test-multi-choice-option-_r_1e_-5-textfield"
+                                id="multi-choice-option-_r_1e_-5"
+                                name="multi-choice-option-_r_1e_-5"
                                 placeholder="Option 6"
                                 type="text"
                                 value="Rembrandt"
                               />
                               <label
                                 class="checkboxLabel"
-                                for="multi-choice-option-_r_18_-5-checkbox"
+                                for="multi-choice-option-_r_1e_-5-checkbox"
                               >
                                 <input
                                   class="checkbox"
-                                  id="multi-choice-option-_r_18_-5-checkbox"
+                                  id="multi-choice-option-_r_1e_-5-checkbox"
                                   type="checkbox"
                                 />
                               </label>
@@ -1399,6 +1426,33 @@ exports[`QuizCreatorPageUI > renders QuizCreatorPageUI for classic mode without 
               </span>
             </button>
           </div>
+          <div
+            class="buttonInputContainer buttonInputKindPrimary buttonInputSizeSmall"
+          >
+            <button
+              data-testid="test-exit-button-button"
+              id="exit-button"
+              name="exit-button"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                class="svg-inline--fa fa-arrow-right-from-bracket"
+                data-icon="arrow-right-from-bracket"
+                data-prefix="fas"
+                role="img"
+                viewBox="0 0 512 512"
+              >
+                <path
+                  d="M160 96c17.7 0 32-14.3 32-32s-14.3-32-32-32L96 32C43 32 0 75 0 128L0 384c0 53 43 96 96 96l64 0c17.7 0 32-14.3 32-32s-14.3-32-32-32l-64 0c-17.7 0-32-14.3-32-32l0-256c0-17.7 14.3-32 32-32l64 0zM502.6 278.6c12.5-12.5 12.5-32.8 0-45.3l-128-128c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3L402.7 224 192 224c-17.7 0-32 14.3-32 32s14.3 32 32 32l210.7 0-73.4 73.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0l128-128z"
+                  fill="currentColor"
+                />
+              </svg>
+              <span>
+                Exit
+              </span>
+            </button>
+          </div>
         </div>
       </div>
     </div>
@@ -1563,6 +1617,33 @@ exports[`QuizCreatorPageUI > renders QuizCreatorPageUI for zero to one hundred m
               </svg>
               <span>
                 Save
+              </span>
+            </button>
+          </div>
+          <div
+            class="buttonInputContainer buttonInputKindPrimary buttonInputSizeSmall"
+          >
+            <button
+              data-testid="test-exit-button-button"
+              id="exit-button"
+              name="exit-button"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                class="svg-inline--fa fa-arrow-right-from-bracket"
+                data-icon="arrow-right-from-bracket"
+                data-prefix="fas"
+                role="img"
+                viewBox="0 0 512 512"
+              >
+                <path
+                  d="M160 96c17.7 0 32-14.3 32-32s-14.3-32-32-32L96 32C43 32 0 75 0 128L0 384c0 53 43 96 96 96l64 0c17.7 0 32-14.3 32-32s-14.3-32-32-32l-64 0c-17.7 0-32-14.3-32-32l0-256c0-17.7 14.3-32 32-32l64 0zM502.6 278.6c12.5-12.5 12.5-32.8 0-45.3l-128-128c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3L402.7 224 192 224c-17.7 0-32 14.3-32 32s14.3 32 32 32l210.7 0-73.4 73.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0l128-128z"
+                  fill="currentColor"
+                />
+              </svg>
+              <span>
+                Exit
               </span>
             </button>
           </div>
@@ -1733,6 +1814,33 @@ exports[`QuizCreatorPageUI > renders QuizCreatorPageUI for zero to one hundred m
               </span>
             </button>
           </div>
+          <div
+            class="buttonInputContainer buttonInputKindPrimary buttonInputSizeSmall"
+          >
+            <button
+              data-testid="test-exit-button-button"
+              id="exit-button"
+              name="exit-button"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                class="svg-inline--fa fa-arrow-right-from-bracket"
+                data-icon="arrow-right-from-bracket"
+                data-prefix="fas"
+                role="img"
+                viewBox="0 0 512 512"
+              >
+                <path
+                  d="M160 96c17.7 0 32-14.3 32-32s-14.3-32-32-32L96 32C43 32 0 75 0 128L0 384c0 53 43 96 96 96l64 0c17.7 0 32-14.3 32-32s-14.3-32-32-32l-64 0c-17.7 0-32-14.3-32-32l0-256c0-17.7 14.3-32 32-32l64 0zM502.6 278.6c12.5-12.5 12.5-32.8 0-45.3l-128-128c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3L402.7 224 192 224c-17.7 0-32 14.3-32 32s14.3 32 32 32l210.7 0-73.4 73.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0l128-128z"
+                  fill="currentColor"
+                />
+              </svg>
+              <span>
+                Exit
+              </span>
+            </button>
+          </div>
         </div>
       </div>
     </div>
@@ -1794,7 +1902,7 @@ exports[`QuizCreatorPageUI > renders QuizCreatorPageUI for zero to one hundred m
 </div>
 `;
 
-exports[`QuizCreatorPageUI > renders QuizCreatorPageUI without mdoe 1`] = `
+exports[`QuizCreatorPageUI > renders QuizCreatorPageUI without mode 1`] = `
 <div>
   <div
     class="main"
@@ -1902,6 +2010,33 @@ exports[`QuizCreatorPageUI > renders QuizCreatorPageUI without mdoe 1`] = `
               </span>
             </button>
           </div>
+          <div
+            class="buttonInputContainer buttonInputKindPrimary buttonInputSizeSmall"
+          >
+            <button
+              data-testid="test-exit-button-button"
+              id="exit-button"
+              name="exit-button"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                class="svg-inline--fa fa-arrow-right-from-bracket"
+                data-icon="arrow-right-from-bracket"
+                data-prefix="fas"
+                role="img"
+                viewBox="0 0 512 512"
+              >
+                <path
+                  d="M160 96c17.7 0 32-14.3 32-32s-14.3-32-32-32L96 32C43 32 0 75 0 128L0 384c0 53 43 96 96 96l64 0c17.7 0 32-14.3 32-32s-14.3-32-32-32l-64 0c-17.7 0-32-14.3-32-32l0-256c0-17.7 14.3-32 32-32l64 0zM502.6 278.6c12.5-12.5 12.5-32.8 0-45.3l-128-128c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3L402.7 224 192 224c-17.7 0-32 14.3-32 32s14.3 32 32 32l210.7 0-73.4 73.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0l128-128z"
+                  fill="currentColor"
+                />
+              </svg>
+              <span>
+                Exit
+              </span>
+            </button>
+          </div>
         </div>
       </div>
     </div>
@@ -1929,10 +2064,10 @@ exports[`QuizCreatorPageUI > renders QuizCreatorPageUI without mdoe 1`] = `
                 tabindex="0"
               />
               <div
-                aria-labelledby="_r_6_"
+                aria-labelledby="_r_8_"
                 class="modalContainer sizeNormal"
                 data-floating-ui-focusable=""
-                id="_r_4_"
+                id="_r_6_"
                 role="dialog"
                 tabindex="-1"
               >
@@ -1941,7 +2076,7 @@ exports[`QuizCreatorPageUI > renders QuizCreatorPageUI without mdoe 1`] = `
                 >
                   <div
                     class="title"
-                    id="_r_6_"
+                    id="_r_8_"
                   >
                     Choose Your Game Mode
                   </div>

--- a/packages/klurigo-web/src/pages/QuizCreatorPage/components/QuizCreatorPageUI/components/GameModeSelectionModal/GameModeSelectionModal.module.scss
+++ b/packages/klurigo-web/src/pages/QuizCreatorPage/components/QuizCreatorPageUI/components/GameModeSelectionModal/GameModeSelectionModal.module.scss
@@ -30,7 +30,7 @@ $outline-offset: helpers.pxToRem(2px);
     flex-direction: column;
     flex: 1;
     background-color: colors.$color-action-accent;
-    outline: colors.$color-action-accent solid $outline-offset;
+    outline: colors.$color-action-accent solid $outline-offset !important;
     outline-offset: $outline-offset;
     border: $outline-offset solid transparent;
     border-radius: radius.$radius-surface-lg;

--- a/packages/klurigo-web/src/pages/QuizCreatorPage/components/QuizCreatorPageUI/components/QuestionPicker/QuestionPicker.test.tsx
+++ b/packages/klurigo-web/src/pages/QuizCreatorPage/components/QuizCreatorPageUI/components/QuestionPicker/QuestionPicker.test.tsx
@@ -1,0 +1,209 @@
+import { QuestionType } from '@klurigo/common'
+import { fireEvent, render, screen } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import type { ReactElement } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import QuestionPicker from './QuestionPicker'
+
+type QuestionPickerItemProps = {
+  index: number
+  canDelete: boolean
+  onDelete?: () => void
+}
+
+const questionPickerItemMock =
+  vi.fn<(props: QuestionPickerItemProps) => ReactElement>()
+
+vi.mock('./components', () => ({
+  QuestionPickerItem: (props: QuestionPickerItemProps) => {
+    questionPickerItemMock(props)
+    return (
+      <button type="button" onClick={props.onDelete}>
+        delete-{props.index}
+      </button>
+    )
+  },
+}))
+
+vi.mock('../../../../../../components', () => ({
+  ConfirmDialog: ({
+    open,
+    onConfirm,
+    onClose,
+  }: {
+    open: boolean
+    onConfirm: () => void
+    onClose: () => void
+  }) =>
+    open ? (
+      <div>
+        <button type="button" onClick={onConfirm}>
+          confirm
+        </button>
+        <button type="button" onClick={onClose}>
+          close
+        </button>
+      </div>
+    ) : null,
+}))
+
+describe('QuestionPicker', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    Object.defineProperty(HTMLElement.prototype, 'scrollTo', {
+      configurable: true,
+      value: vi.fn(),
+    })
+  })
+
+  it('passes canDelete=false when there is only one question', () => {
+    render(
+      <QuestionPicker
+        questions={[
+          {
+            type: QuestionType.MultiChoice,
+            text: 'Question 1',
+            valid: true,
+          },
+        ]}
+        selectedQuestionIndex={0}
+        onAddQuestion={vi.fn()}
+        onSelectQuestion={vi.fn()}
+        onDropQuestion={vi.fn()}
+        onDuplicateQuestion={vi.fn()}
+        onDeleteQuestion={vi.fn()}
+      />,
+    )
+
+    expect(questionPickerItemMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        index: 0,
+        canDelete: false,
+      }),
+    )
+  })
+
+  it('passes canDelete=true when there are multiple questions', () => {
+    render(
+      <QuestionPicker
+        questions={[
+          {
+            type: QuestionType.MultiChoice,
+            text: 'Question 1',
+            valid: true,
+          },
+          {
+            type: QuestionType.TrueFalse,
+            text: 'Question 2',
+            valid: true,
+          },
+        ]}
+        selectedQuestionIndex={0}
+        onAddQuestion={vi.fn()}
+        onSelectQuestion={vi.fn()}
+        onDropQuestion={vi.fn()}
+        onDuplicateQuestion={vi.fn()}
+        onDeleteQuestion={vi.fn()}
+      />,
+    )
+
+    expect(questionPickerItemMock).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        index: 0,
+        canDelete: true,
+      }),
+    )
+    expect(questionPickerItemMock).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        index: 1,
+        canDelete: true,
+      }),
+    )
+  })
+
+  it('deletes the selected question only when the index is still in range', () => {
+    const onDeleteQuestion = vi.fn()
+
+    render(
+      <QuestionPicker
+        questions={[
+          {
+            type: QuestionType.MultiChoice,
+            text: 'Question 1',
+            valid: true,
+          },
+          {
+            type: QuestionType.TrueFalse,
+            text: 'Question 2',
+            valid: true,
+          },
+        ]}
+        selectedQuestionIndex={0}
+        onAddQuestion={vi.fn()}
+        onSelectQuestion={vi.fn()}
+        onDropQuestion={vi.fn()}
+        onDuplicateQuestion={vi.fn()}
+        onDeleteQuestion={onDeleteQuestion}
+      />,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'delete-1' }))
+    fireEvent.click(screen.getByRole('button', { name: 'confirm' }))
+
+    expect(onDeleteQuestion).toHaveBeenCalledWith(1)
+  })
+
+  it('does not delete when the pending delete index becomes out of range', () => {
+    const onDeleteQuestion = vi.fn()
+
+    const { rerender } = render(
+      <QuestionPicker
+        questions={[
+          {
+            type: QuestionType.MultiChoice,
+            text: 'Question 1',
+            valid: true,
+          },
+          {
+            type: QuestionType.TrueFalse,
+            text: 'Question 2',
+            valid: true,
+          },
+        ]}
+        selectedQuestionIndex={0}
+        onAddQuestion={vi.fn()}
+        onSelectQuestion={vi.fn()}
+        onDropQuestion={vi.fn()}
+        onDuplicateQuestion={vi.fn()}
+        onDeleteQuestion={onDeleteQuestion}
+      />,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'delete-1' }))
+
+    rerender(
+      <QuestionPicker
+        questions={[
+          {
+            type: QuestionType.MultiChoice,
+            text: 'Question 1',
+            valid: true,
+          },
+        ]}
+        selectedQuestionIndex={0}
+        onAddQuestion={vi.fn()}
+        onSelectQuestion={vi.fn()}
+        onDropQuestion={vi.fn()}
+        onDuplicateQuestion={vi.fn()}
+        onDeleteQuestion={onDeleteQuestion}
+      />,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'confirm' }))
+
+    expect(onDeleteQuestion).not.toHaveBeenCalled()
+  })
+})

--- a/packages/klurigo-web/src/pages/QuizCreatorPage/components/QuizCreatorPageUI/components/QuestionPicker/QuestionPicker.tsx
+++ b/packages/klurigo-web/src/pages/QuizCreatorPage/components/QuizCreatorPageUI/components/QuestionPicker/QuestionPicker.tsx
@@ -64,7 +64,12 @@ const QuestionPicker: FC<QuestionPickerProps> = ({
   }
 
   const handleDeleteQuestion = () => {
-    if (deleteQuestionIndex) {
+    if (
+      deleteQuestionIndex !== undefined &&
+      deleteQuestionIndex >= 0 &&
+      deleteQuestionIndex < questions.length &&
+      questions.length > 1
+    ) {
       onDeleteQuestion?.(deleteQuestionIndex)
       setDeleteQuestionIndex(undefined)
     }
@@ -83,6 +88,7 @@ const QuestionPicker: FC<QuestionPickerProps> = ({
             type={type}
             active={isActive(index)}
             valid={valid}
+            canDelete={questions.length > 1}
             onClick={() => onSelectQuestion(index)}
             onDrop={onDropQuestion}
             onDuplicate={() => onDuplicateQuestion(index)}

--- a/packages/klurigo-web/src/pages/QuizCreatorPage/components/QuizCreatorPageUI/components/QuestionPicker/components/QuestionPickerItem/QuestionPickerItem.module.scss
+++ b/packages/klurigo-web/src/pages/QuizCreatorPage/components/QuizCreatorPageUI/components/QuestionPicker/components/QuestionPickerItem/QuestionPickerItem.module.scss
@@ -219,13 +219,11 @@ $normal-question-picker-item-indicator-size: helpers.pxToRem(22px);
     }
 
     .questionPickerItemOverlayBottom {
-      .questionPickerItemOverlayDuplicate, .questionPickerItemOverlayDelete {
+      .cloneButton, .deleteButton {
         @include button.button-reset;
 
         outline: none;
         pointer-events: auto;
-        color: colors.$color-text-control-default;
-        background-color: colors.$color-surface-control-muted;
 
         @include helpers.mobile {
           @include helpers.fontSize(10px);
@@ -239,16 +237,39 @@ $normal-question-picker-item-indicator-size: helpers.pxToRem(22px);
           @include helpers.fontSize(12px);
         }
 
-        &:hover {
-          color: colors.$color-text-control-default-hover;
-          background-color: colors.$color-surface-control-muted-hover;
+        &:disabled {
+          color: colors.$color-text-control-disabled;
+          background-color: colors.$color-surface-control-disabled;
         }
       }
 
-      .questionPickerItemOverlayError {
+      .cloneButton {
+        color: colors.$color-text-control-default;
+        background-color: colors.$color-surface-control-accent;
+
+        &:hover {
+          &:not(:disabled) {
+            color: colors.$color-text-control-default-hover;
+            background-color: colors.$color-surface-control-accent-hover;
+          }
+        }
+      }
+
+      .deleteButton {
+        color: colors.$color-text-inverse;
+        background-color: colors.$color-surface-control-danger;
+
+        &:hover {
+          &:not(:disabled) {
+            color: colors.$color-text-inverse;
+            background-color: colors.$color-surface-control-danger-hover;
+          }
+        }
+      }
+
+      .validationErrorSymbol {
         color: colors.$color-status-warning;
         background-color: colors.$color-surface-default;
-        pointer-events: none;
 
         @include helpers.mobile {
           @include helpers.fontSize(16px);

--- a/packages/klurigo-web/src/pages/QuizCreatorPage/components/QuizCreatorPageUI/components/QuestionPicker/components/QuestionPickerItem/QuestionPickerItem.test.tsx
+++ b/packages/klurigo-web/src/pages/QuizCreatorPage/components/QuizCreatorPageUI/components/QuestionPicker/components/QuestionPickerItem/QuestionPickerItem.test.tsx
@@ -1,0 +1,62 @@
+import { QuestionType } from '@klurigo/common'
+import { fireEvent, render } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import type { ComponentProps } from 'react'
+import { describe, expect, it, vi } from 'vitest'
+
+import QuestionPickerItem from './QuestionPickerItem'
+
+const renderQuestionPickerItem = (
+  overrides: Partial<ComponentProps<typeof QuestionPickerItem>> = {},
+) =>
+  render(
+    <QuestionPickerItem
+      index={0}
+      text="What is the capital of Sweden?"
+      type={QuestionType.MultiChoice}
+      active
+      valid
+      canDelete
+      onClick={vi.fn()}
+      onDrop={vi.fn()}
+      onDuplicate={vi.fn()}
+      onDelete={vi.fn()}
+      {...overrides}
+    />,
+  )
+
+describe('QuestionPickerItem', () => {
+  it('disables delete when canDelete is false', () => {
+    const { container } = renderQuestionPickerItem({ canDelete: false })
+
+    const deleteButton = container
+      .querySelector('svg[data-icon="trash"]')
+      ?.closest('button')
+
+    expect(deleteButton).toBeTruthy()
+    expect(deleteButton as HTMLButtonElement).toBeDisabled()
+  })
+
+  it('shows the validation error indicator when the question is invalid', () => {
+    const { container } = renderQuestionPickerItem({ valid: false })
+
+    expect(
+      container.querySelector('svg[data-icon="circle-exclamation"]'),
+    ).toBeInTheDocument()
+  })
+
+  it('keeps duplicate working for the active question', () => {
+    const onDuplicate = vi.fn()
+    const { container } = renderQuestionPickerItem({ onDuplicate })
+
+    const duplicateButton = container
+      .querySelector('svg[data-icon="copy"]')
+      ?.closest('button')
+
+    expect(duplicateButton).toBeTruthy()
+
+    fireEvent.click(duplicateButton as HTMLButtonElement)
+
+    expect(onDuplicate).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/klurigo-web/src/pages/QuizCreatorPage/components/QuizCreatorPageUI/components/QuestionPicker/components/QuestionPickerItem/QuestionPickerItem.tsx
+++ b/packages/klurigo-web/src/pages/QuizCreatorPage/components/QuizCreatorPageUI/components/QuestionPicker/components/QuestionPickerItem/QuestionPickerItem.tsx
@@ -15,6 +15,7 @@ export interface QuestionPickerItemProps {
   type: QuestionType
   active?: boolean
   valid: boolean
+  canDelete: boolean
   onClick?: () => void
   onDrop?: (id: number) => void
   onDuplicate?: () => void
@@ -27,6 +28,7 @@ const QuestionPickerItem: FC<QuestionPickerItemProps> = ({
   type,
   active,
   valid,
+  canDelete,
   onClick,
   onDrop,
   onDuplicate,
@@ -92,19 +94,20 @@ const QuestionPickerItem: FC<QuestionPickerItemProps> = ({
         <div className={styles.questionPickerItemOverlayBottom}>
           {active && (
             <button
-              className={styles.questionPickerItemOverlayDuplicate}
+              className={styles.cloneButton}
               onClick={handleClickDuplicate}>
               <FontAwesomeIcon icon={faCopy} />
             </button>
           )}
           {!valid && (
-            <div className={styles.questionPickerItemOverlayError}>
+            <div className={styles.validationErrorSymbol}>
               <FontAwesomeIcon icon={faCircleExclamation} />
             </div>
           )}
           {active && (
             <button
-              className={styles.questionPickerItemOverlayDelete}
+              disabled={!canDelete}
+              className={styles.deleteButton}
               onClick={handleClickDelete}>
               <FontAwesomeIcon icon={faTrash} />
             </button>

--- a/packages/klurigo-web/src/pages/QuizCreatorPage/components/QuizCreatorPageUI/index.ts
+++ b/packages/klurigo-web/src/pages/QuizCreatorPage/components/QuizCreatorPageUI/index.ts
@@ -1,1 +1,1 @@
-export { default } from './QuizCreatorPageUI'
+export { type QuizCreatorPageUIProps, default } from './QuizCreatorPageUI'

--- a/packages/klurigo-web/src/pages/QuizCreatorPage/components/UnsavedChangesExitModal/UnsavedChangesExitModal.module.scss
+++ b/packages/klurigo-web/src/pages/QuizCreatorPage/components/UnsavedChangesExitModal/UnsavedChangesExitModal.module.scss
@@ -1,0 +1,30 @@
+@use '../../../../styles/helpers';
+@use '../../../../styles/variables';
+@use '../../../../styles/spacing.semantic' as spacing;
+
+.actions {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: nowrap;
+  justify-content: center;
+  align-items: center;
+  align-self: center;
+  width: 100%;
+  max-width: variables.$mobile-width;
+
+  @include helpers.mobile {
+    column-gap: spacing.$space-compact-mobile;
+  }
+
+  @include helpers.tablet {
+    column-gap: spacing.$space-compact-tablet;
+  }
+
+  @include helpers.desktop {
+    column-gap: spacing.$space-compact-desktop;
+  }
+
+  div[class*='buttonInputContainer'] {
+    flex: 1;
+  }
+}

--- a/packages/klurigo-web/src/pages/QuizCreatorPage/components/UnsavedChangesExitModal/UnsavedChangesExitModal.test.tsx
+++ b/packages/klurigo-web/src/pages/QuizCreatorPage/components/UnsavedChangesExitModal/UnsavedChangesExitModal.test.tsx
@@ -1,0 +1,76 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import type { ReactNode } from 'react'
+import { describe, expect, it, vi } from 'vitest'
+
+import UnsavedChangesExitModal from './UnsavedChangesExitModal'
+
+vi.mock('../../../../components', () => ({
+  Modal: ({
+    title,
+    open,
+    children,
+  }: {
+    title: string
+    open: boolean
+    children?: ReactNode
+  }) =>
+    open ? (
+      <div role="dialog" aria-label={title}>
+        {children}
+      </div>
+    ) : null,
+}))
+
+vi.mock('../../../../components/Button', () => ({
+  default: ({
+    id,
+    value,
+    onClick,
+  }: {
+    id?: string
+    value: string
+    onClick: () => void
+  }) => (
+    <button id={id} type="button" onClick={onClick}>
+      {value}
+    </button>
+  ),
+}))
+
+describe('UnsavedChangesExitModal', () => {
+  it('renders the exit confirmation copy and actions', () => {
+    render(<UnsavedChangesExitModal onReset={vi.fn()} onConfirm={vi.fn()} />)
+
+    expect(
+      screen.getByRole('dialog', { name: 'Leave your quiz?' }),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText(
+        'You have unsaved changes. If you leave now, your changes will be lost.',
+      ),
+    ).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Stay' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Leave' })).toBeInTheDocument()
+  })
+
+  it('calls onReset when Stay is clicked', () => {
+    const onReset = vi.fn()
+
+    render(<UnsavedChangesExitModal onReset={onReset} onConfirm={vi.fn()} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Stay' }))
+
+    expect(onReset).toHaveBeenCalledTimes(1)
+  })
+
+  it('calls onConfirm when Leave is clicked', () => {
+    const onConfirm = vi.fn()
+
+    render(<UnsavedChangesExitModal onReset={vi.fn()} onConfirm={onConfirm} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Leave' }))
+
+    expect(onConfirm).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/klurigo-web/src/pages/QuizCreatorPage/components/UnsavedChangesExitModal/UnsavedChangesExitModal.tsx
+++ b/packages/klurigo-web/src/pages/QuizCreatorPage/components/UnsavedChangesExitModal/UnsavedChangesExitModal.tsx
@@ -1,0 +1,46 @@
+import { type FC } from 'react'
+
+import { Modal } from '../../../../components'
+import Button from '../../../../components/Button'
+
+import styles from './UnsavedChangesExitModal.module.scss'
+
+/**
+ * Props for the UnsavedChangesExitModal component.
+ */
+export type UnsavedChangesExitModalProps = {
+  onReset: () => void
+  onConfirm: () => void
+}
+
+/**
+ * Modal that confirms whether the user wants to leave and discard unsaved changes.
+ */
+const UnsavedChangesExitModal: FC<UnsavedChangesExitModalProps> = ({
+  onReset,
+  onConfirm,
+}) => {
+  return (
+    <Modal title="Leave your quiz?" open>
+      You have unsaved changes. If you leave now, your changes will be lost.
+      <div className={styles.actions}>
+        <Button
+          id="cancel-button"
+          type="button"
+          kind="secondary"
+          value="Stay"
+          onClick={onReset}
+        />
+        <Button
+          id="exit-button"
+          type="button"
+          kind="destructive"
+          value="Leave"
+          onClick={onConfirm}
+        />
+      </div>
+    </Modal>
+  )
+}
+
+export default UnsavedChangesExitModal

--- a/packages/klurigo-web/src/pages/QuizCreatorPage/components/UnsavedChangesExitModal/index.ts
+++ b/packages/klurigo-web/src/pages/QuizCreatorPage/components/UnsavedChangesExitModal/index.ts
@@ -1,0 +1,4 @@
+export {
+  type UnsavedChangesExitModalProps,
+  default,
+} from './UnsavedChangesExitModal'

--- a/packages/klurigo-web/src/pages/QuizCreatorPage/components/index.ts
+++ b/packages/klurigo-web/src/pages/QuizCreatorPage/components/index.ts
@@ -1,0 +1,8 @@
+export {
+  type QuizCreatorPageUIProps,
+  default as QuizCreatorPageUI,
+} from './QuizCreatorPageUI'
+export {
+  type UnsavedChangesExitModalProps,
+  default as UnsavedChangesExitModal,
+} from './UnsavedChangesExitModal'

--- a/packages/klurigo-web/src/pages/QuizDetailsPage/QuizDetailsPage.test.tsx
+++ b/packages/klurigo-web/src/pages/QuizDetailsPage/QuizDetailsPage.test.tsx
@@ -1,0 +1,132 @@
+import { act, render } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import QuizDetailsPage from './QuizDetailsPage'
+
+type QuizResponse = {
+  id: string
+  author: {
+    id: string
+  }
+}
+
+type UseQueryResult<T> = {
+  data?: T
+  isLoading: boolean
+  isError: boolean
+}
+
+type QuizDetailsPageUIProps = {
+  onDeleteQuiz: () => void
+}
+
+let latestUIProps: QuizDetailsPageUIProps | undefined
+let mockQuizId = 'quiz-123'
+
+const navigateMock = vi.fn<(path: string | number) => void>()
+const invalidateQueriesMock = vi.fn<
+  (args: { queryKey: readonly string[] }) => Promise<void>
+>(() => Promise.resolve())
+const deleteQuizMock = vi.fn<(quizId: string) => Promise<void>>(() =>
+  Promise.resolve(),
+)
+
+let mockQuizQueryState: UseQueryResult<QuizResponse>
+let mockRatingsQueryState: UseQueryResult<{ results: [] }>
+
+vi.mock('react-router-dom', async () => {
+  const actual =
+    await vi.importActual<typeof import('react-router-dom')>('react-router-dom')
+
+  return {
+    ...actual,
+    useNavigate: () => navigateMock,
+    useParams: () => ({ quizId: mockQuizId }),
+  }
+})
+
+vi.mock('@tanstack/react-query', () => ({
+  useQuery: (args: { queryKey: readonly unknown[] }) => {
+    const key = String(args.queryKey[0])
+    if (key === 'quiz') return mockQuizQueryState
+    if (key === 'quiz-ratings') return mockRatingsQueryState
+    throw new Error(`Unexpected queryKey: ${key}`)
+  },
+  useQueryClient: () => ({
+    invalidateQueries: invalidateQueriesMock,
+  }),
+}))
+
+vi.mock('../../context/auth', () => ({
+  useAuthContext: () => ({
+    user: {
+      ACCESS: {
+        sub: 'user-1',
+      },
+    },
+  }),
+}))
+
+vi.mock('../../api', () => ({
+  useKlurigoServiceClient: () => ({
+    getQuiz: vi.fn(),
+    getQuizRatings: vi.fn(),
+    deleteQuiz: deleteQuizMock,
+    createGame: vi.fn(),
+    authenticateGame: vi.fn(),
+  }),
+}))
+
+vi.mock('./components', () => ({
+  QuizDetailsPageUI: (props: QuizDetailsPageUIProps) => {
+    latestUIProps = props
+    return <div data-testid="quiz-details-page-ui" />
+  },
+}))
+
+const flushPromises = async (): Promise<void> => {
+  await act(async () => {
+    await Promise.resolve()
+  })
+}
+
+describe('QuizDetailsPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    latestUIProps = undefined
+    mockQuizId = 'quiz-123'
+    mockQuizQueryState = {
+      data: {
+        id: 'quiz-123',
+        author: {
+          id: 'user-1',
+        },
+      },
+      isLoading: false,
+      isError: false,
+    }
+    mockRatingsQueryState = {
+      data: {
+        results: [],
+      },
+      isLoading: false,
+      isError: false,
+    }
+  })
+
+  it('invalidates myProfileQuizzes and navigates back to profile quizzes after deleting a quiz', async () => {
+    render(<QuizDetailsPage />)
+
+    act(() => {
+      latestUIProps?.onDeleteQuiz()
+    })
+
+    await flushPromises()
+
+    expect(deleteQuizMock).toHaveBeenCalledWith('quiz-123')
+    expect(invalidateQueriesMock).toHaveBeenCalledWith({
+      queryKey: ['myProfileQuizzes'],
+    })
+    expect(navigateMock).toHaveBeenCalledWith('/profile/quizzes')
+  })
+})

--- a/packages/klurigo-web/src/pages/QuizDetailsPage/QuizDetailsPage.tsx
+++ b/packages/klurigo-web/src/pages/QuizDetailsPage/QuizDetailsPage.tsx
@@ -1,4 +1,4 @@
-import { useQuery } from '@tanstack/react-query'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
 import type { FC } from 'react'
 import { useEffect, useMemo, useState } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
@@ -10,6 +10,8 @@ import { QuizDetailsPageUI } from './components'
 
 const QuizDetailsPage: FC = () => {
   const navigate = useNavigate()
+
+  const queryClient = useQueryClient()
 
   const { quizId } = useParams<{ quizId: string }>()
 
@@ -83,6 +85,9 @@ const QuizDetailsPage: FC = () => {
     if (quizId) {
       setIsDeleteQuizLoading(true)
       deleteQuiz(quizId)
+        .then(() =>
+          queryClient.invalidateQueries({ queryKey: ['myProfileQuizzes'] }),
+        )
         .then(() => navigate('/profile/quizzes'))
         .finally(() => setIsDeleteQuizLoading(false))
     }


### PR DESCRIPTION
- Add unsaved changes tracking in the quiz creator and block navigation until the user confirms leaving.
- Introduce an exit action and confirmation modal for leaving the editor without saving.
- Navigate to the new quiz edit route after create instead of returning to the quizzes list.
- Invalidate myProfileQuizzes after exiting the editor or deleting a quiz so the quizzes list refreshes correctly.
- Disable deleting the last remaining question and harden question picker delete handling with test coverage.
- Update quiz creator UI props and tests to use canSaveQuiz and the new exit behavior.
- Tweak page menu label and styling polish for the profile entry and quiz creator UI states.

This improves quiz editor safety, keeps quiz list data fresh after create/delete flows, and strengthens question picker behavior.