### PR TITLE
feat(responsive-image): add fallback aspect ratio and update pin image sources

### DIFF
--- a/packages/klurigo-web/src/components/PinImage/PinImage.stories.tsx
+++ b/packages/klurigo-web/src/components/PinImage/PinImage.stories.tsx
@@ -34,7 +34,7 @@ type Story = StoryObj<typeof meta>
 export const Default = {
   args: {
     imageURL:
-      'https://upload.wikimedia.org/wikipedia/commons/thumb/f/f7/Europe_laea_location_map.svg/1401px-Europe_laea_location_map.svg.png',
+      'https://upload.wikimedia.org/wikipedia/commons/7/7c/Europe_EU_laea_location_map_%28configurable%29.svg',
     value: { x: 0.45838, y: 0.35438, tolerance: QuestionPinTolerance.Medium },
   },
 } satisfies Story
@@ -43,7 +43,7 @@ export const NoPin = {
   name: 'No Pin',
   args: {
     imageURL:
-      'https://upload.wikimedia.org/wikipedia/commons/thumb/f/f7/Europe_laea_location_map.svg/1401px-Europe_laea_location_map.svg.png',
+      'https://upload.wikimedia.org/wikipedia/commons/7/7c/Europe_EU_laea_location_map_%28configurable%29.svg',
   },
 } satisfies Story
 
@@ -51,7 +51,7 @@ export const NoTolerance = {
   name: 'No Tolerance',
   args: {
     imageURL:
-      'https://upload.wikimedia.org/wikipedia/commons/thumb/f/f7/Europe_laea_location_map.svg/1401px-Europe_laea_location_map.svg.png',
+      'https://upload.wikimedia.org/wikipedia/commons/7/7c/Europe_EU_laea_location_map_%28configurable%29.svg',
     value: { x: 0.45838, y: 0.35438 },
   },
 } satisfies Story
@@ -60,7 +60,7 @@ export const Multiple = {
   name: 'Multiple Pins',
   args: {
     imageURL:
-      'https://upload.wikimedia.org/wikipedia/commons/thumb/f/f7/Europe_laea_location_map.svg/1401px-Europe_laea_location_map.svg.png',
+      'https://upload.wikimedia.org/wikipedia/commons/7/7c/Europe_EU_laea_location_map_%28configurable%29.svg',
     value: {
       x: 0.45838,
       y: 0.35438,

--- a/packages/klurigo-web/src/components/ResponsiveImage/ResponsiveImage.module.scss
+++ b/packages/klurigo-web/src/components/ResponsiveImage/ResponsiveImage.module.scss
@@ -14,6 +14,11 @@
   align-items: center;
   justify-content: center;
 
+  &.fallbackAspectRatio {
+    height: auto;
+    display: block;
+  }
+
   .box,
   .boxNoBorder {
     position: relative;
@@ -71,8 +76,8 @@
   }
 
   .centerOverlay {
-    position: absolute;
-    inset: 0;
+    position: relative;
+    width: 100%;
     display: grid;
     place-items: center;
     background-color: colors.$color-surface-placeholder;

--- a/packages/klurigo-web/src/components/ResponsiveImage/ResponsiveImage.tsx
+++ b/packages/klurigo-web/src/components/ResponsiveImage/ResponsiveImage.tsx
@@ -2,8 +2,15 @@ import { faLinkSlash } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import type { CountdownEvent } from '@klurigo/common'
 import { QuestionImageRevealEffectType } from '@klurigo/common'
-import type { FC, ReactNode } from 'react'
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import {
+  type FC,
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react'
 import { useDebounceCallback, useResizeObserver } from 'usehooks-ts'
 
 import { classNames } from '../../utils/helpers'
@@ -143,8 +150,15 @@ const ResponsiveImage: FC<ResponsiveImageProps> = ({
     ),
   )
 
+  const shouldUseFallbackAspectRatio = phase === 'loading' || phase === 'error'
+
   return (
-    <div ref={ref} className={styles.container}>
+    <div
+      ref={ref}
+      className={classNames(
+        styles.container,
+        shouldUseFallbackAspectRatio ? styles.fallbackAspectRatio : undefined,
+      )}>
       {phase === 'ready' && displaySrc && box && (
         <div
           className={classNames(
@@ -181,25 +195,31 @@ const ResponsiveImage: FC<ResponsiveImageProps> = ({
         </div>
       )}
 
-      {phase === 'loading' && (
-        <div className={styles.centerOverlay}>
-          <LoadingSpinner />
-        </div>
-      )}
-
-      {phase === 'error' && (
+      {(phase === 'loading' || phase === 'error') && (
         <div
           className={classNames(
             styles.centerOverlay,
             noBorder ? styles.boxNoBorder : styles.box,
             noCornerRadius ? styles.noRadius : undefined,
           )}
-          style={borderColor ? { borderColor } : undefined}>
-          <FontAwesomeIcon
-            icon={faLinkSlash}
-            className={styles.icon}
-            style={{ fontSize: iconSize }}
-          />
+          style={{
+            ...(borderColor ? { borderColor } : undefined),
+            ...(shouldUseFallbackAspectRatio
+              ? {
+                  width: '100%',
+                  aspectRatio: String(16 / 10),
+                }
+              : undefined),
+          }}>
+          {phase === 'loading' ? (
+            <LoadingSpinner />
+          ) : (
+            <FontAwesomeIcon
+              icon={faLinkSlash}
+              className={styles.icon}
+              style={{ fontSize: iconSize }}
+            />
+          )}
         </div>
       )}
     </div>

--- a/packages/klurigo-web/src/components/ResponsiveImage/__snapshots__/ResponsiveImage.test.tsx.snap
+++ b/packages/klurigo-web/src/components/ResponsiveImage/__snapshots__/ResponsiveImage.test.tsx.snap
@@ -3,10 +3,11 @@
 exports[`ResponsiveImage > should render error state when image fails to load 1`] = `
 <div>
   <div
-    class="container"
+    class="container fallbackAspectRatio"
   >
     <div
       class="centerOverlay box"
+      style="width: 100%;"
     >
       <svg
         aria-hidden="true"

--- a/packages/klurigo-web/src/pages/ProfileQuizzesPage/components/ProfileQuizzesPageUI/__snapshots__/ProfileQuizzesPageUI.test.tsx.snap
+++ b/packages/klurigo-web/src/pages/ProfileQuizzesPage/components/ProfileQuizzesPageUI/__snapshots__/ProfileQuizzesPageUI.test.tsx.snap
@@ -175,10 +175,11 @@ exports[`ProfileQuizzesPageUI > should render ProfileQuizzesPageUI with card gri
                 class="cover"
               >
                 <div
-                  class="container"
+                  class="container fallbackAspectRatio"
                 >
                   <div
-                    class="centerOverlay"
+                    class="centerOverlay boxNoBorder noRadius"
+                    style="width: 100%;"
                   >
                     <div
                       class="loadingSpinnerContainer"

--- a/packages/klurigo-web/src/pages/QuizCreatorPage/components/QuizCreatorPageUI/__snapshots__/QuizCreatorPageUI.test.tsx.snap
+++ b/packages/klurigo-web/src/pages/QuizCreatorPage/components/QuizCreatorPageUI/__snapshots__/QuizCreatorPageUI.test.tsx.snap
@@ -502,10 +502,11 @@ exports[`QuizCreatorPageUI > renders QuizCreatorPageUI for classic mode 1`] = `
                           class="preview"
                         >
                           <div
-                            class="container"
+                            class="container fallbackAspectRatio"
                           >
                             <div
-                              class="centerOverlay"
+                              class="centerOverlay box"
+                              style="width: 100%;"
                             >
                               <div
                                 class="loadingSpinnerContainer"

--- a/packages/klurigo-web/src/pages/QuizCreatorPage/components/QuizCreatorPageUI/components/QuestionEditor/__snapshots__/QuestionEditor.test.tsx.snap
+++ b/packages/klurigo-web/src/pages/QuizCreatorPage/components/QuizCreatorPageUI/components/QuestionEditor/__snapshots__/QuestionEditor.test.tsx.snap
@@ -140,10 +140,11 @@ exports[`QuestionEditor > renders a classic multi choice option question editor 
                 class="preview"
               >
                 <div
-                  class="container"
+                  class="container fallbackAspectRatio"
                 >
                   <div
-                    class="centerOverlay"
+                    class="centerOverlay box"
+                    style="width: 100%;"
                   >
                     <div
                       class="loadingSpinnerContainer"
@@ -1055,10 +1056,11 @@ exports[`QuestionEditor > renders a classic range question editor 1`] = `
                 class="preview"
               >
                 <div
-                  class="container"
+                  class="container fallbackAspectRatio"
                 >
                   <div
-                    class="centerOverlay"
+                    class="centerOverlay box"
+                    style="width: 100%;"
                   >
                     <div
                       class="loadingSpinnerContainer"
@@ -1788,10 +1790,11 @@ exports[`QuestionEditor > renders a classic true or false question editor 1`] = 
                 class="preview"
               >
                 <div
-                  class="container"
+                  class="container fallbackAspectRatio"
                 >
                   <div
-                    class="centerOverlay"
+                    class="centerOverlay box"
+                    style="width: 100%;"
                   >
                     <div
                       class="loadingSpinnerContainer"
@@ -2391,10 +2394,11 @@ exports[`QuestionEditor > renders a classic type answer question editor 1`] = `
                 class="preview"
               >
                 <div
-                  class="container"
+                  class="container fallbackAspectRatio"
                 >
                   <div
-                    class="centerOverlay"
+                    class="centerOverlay box"
+                    style="width: 100%;"
                   >
                     <div
                       class="loadingSpinnerContainer"
@@ -2946,10 +2950,11 @@ exports[`QuestionEditor > renders a zero to one hundred range question editor 1`
                 class="preview"
               >
                 <div
-                  class="container"
+                  class="container fallbackAspectRatio"
                 >
                   <div
-                    class="centerOverlay"
+                    class="centerOverlay box"
+                    style="width: 100%;"
                   >
                     <div
                       class="loadingSpinnerContainer"

--- a/packages/klurigo-web/src/pages/QuizCreatorPage/components/QuizCreatorPageUI/components/QuestionEditor/components/QuestionField/__snapshots__/QuestionField.test.tsx.snap
+++ b/packages/klurigo-web/src/pages/QuizCreatorPage/components/QuizCreatorPageUI/components/QuestionEditor/components/QuestionField/__snapshots__/QuestionField.test.tsx.snap
@@ -231,10 +231,11 @@ exports[`QuestionField > renders a image media question field 1`] = `
             class="preview"
           >
             <div
-              class="container"
+              class="container fallbackAspectRatio"
             >
               <div
-                class="centerOverlay"
+                class="centerOverlay box"
+                style="width: 100%;"
               >
                 <div
                   class="loadingSpinnerContainer"
@@ -1813,10 +1814,11 @@ exports[`QuestionField > renders an image media question field with blur effect 
             class="preview"
           >
             <div
-              class="container"
+              class="container fallbackAspectRatio"
             >
               <div
-                class="centerOverlay"
+                class="centerOverlay box"
+                style="width: 100%;"
               >
                 <div
                   class="loadingSpinnerContainer"
@@ -1942,10 +1944,11 @@ exports[`QuestionField > renders an image media question field with square effec
             class="preview"
           >
             <div
-              class="container"
+              class="container fallbackAspectRatio"
             >
               <div
-                class="centerOverlay"
+                class="centerOverlay box"
+                style="width: 100%;"
               >
                 <div
                   class="loadingSpinnerContainer"

--- a/packages/klurigo-web/src/pages/QuizCreatorPage/components/QuizCreatorPageUI/components/QuestionEditor/components/QuestionForm/__snapshots__/QuestionForm.test.tsx.snap
+++ b/packages/klurigo-web/src/pages/QuizCreatorPage/components/QuizCreatorPageUI/components/QuestionEditor/components/QuestionForm/__snapshots__/QuestionForm.test.tsx.snap
@@ -60,10 +60,11 @@ exports[`QuestionForm > renders a classic multi choice option question form 1`] 
               class="preview"
             >
               <div
-                class="container"
+                class="container fallbackAspectRatio"
               >
                 <div
-                  class="centerOverlay"
+                  class="centerOverlay box"
+                  style="width: 100%;"
                 >
                   <div
                     class="loadingSpinnerContainer"
@@ -894,10 +895,11 @@ exports[`QuestionForm > renders a classic range question form 1`] = `
               class="preview"
             >
               <div
-                class="container"
+                class="container fallbackAspectRatio"
               >
                 <div
-                  class="centerOverlay"
+                  class="centerOverlay box"
+                  style="width: 100%;"
                 >
                   <div
                     class="loadingSpinnerContainer"
@@ -1546,10 +1548,11 @@ exports[`QuestionForm > renders a classic true or false question form 1`] = `
               class="preview"
             >
               <div
-                class="container"
+                class="container fallbackAspectRatio"
               >
                 <div
-                  class="centerOverlay"
+                  class="centerOverlay box"
+                  style="width: 100%;"
                 >
                   <div
                     class="loadingSpinnerContainer"
@@ -2068,10 +2071,11 @@ exports[`QuestionForm > renders a classic type answer question form 1`] = `
               class="preview"
             >
               <div
-                class="container"
+                class="container fallbackAspectRatio"
               >
                 <div
-                  class="centerOverlay"
+                  class="centerOverlay box"
+                  style="width: 100%;"
                 >
                   <div
                     class="loadingSpinnerContainer"
@@ -2619,10 +2623,11 @@ exports[`QuestionForm > renders a zero to one hundred range question form 1`] = 
               class="preview"
             >
               <div
-                class="container"
+                class="container fallbackAspectRatio"
               >
                 <div
-                  class="centerOverlay"
+                  class="centerOverlay box"
+                  style="width: 100%;"
                 >
                   <div
                     class="loadingSpinnerContainer"

--- a/packages/klurigo-web/src/states/HostQuestionState/HostQuestionState.stories.tsx
+++ b/packages/klurigo-web/src/states/HostQuestionState/HostQuestionState.stories.tsx
@@ -210,7 +210,7 @@ export const QuestionPin = {
         question:
           'Where is the capital Stockholm located? Pin the answer on a map of Europe',
         imageURL:
-          'https://upload.wikimedia.org/wikipedia/commons/thumb/f/f7/Europe_laea_location_map.svg/1401px-Europe_laea_location_map.svg.png',
+          'https://upload.wikimedia.org/wikipedia/commons/7/7c/Europe_EU_laea_location_map_%28configurable%29.svg',
         duration: 30,
       },
       countdown: {

--- a/packages/klurigo-web/src/states/HostQuestionState/__snapshots__/HostQuestionState.test.tsx.snap
+++ b/packages/klurigo-web/src/states/HostQuestionState/__snapshots__/HostQuestionState.test.tsx.snap
@@ -1076,10 +1076,11 @@ exports[`HostQuestionState > should render HostQuestionState with question type 
             data-testid="question-media"
           >
             <div
-              class="container"
+              class="container fallbackAspectRatio"
             >
               <div
-                class="centerOverlay"
+                class="centerOverlay box"
+                style="width: 100%;"
               >
                 <div
                   class="loadingSpinnerContainer"
@@ -1356,10 +1357,11 @@ exports[`HostQuestionState > should render HostQuestionState with question type 
             data-testid="question-media"
           >
             <div
-              class="container"
+              class="container fallbackAspectRatio"
             >
               <div
-                class="centerOverlay"
+                class="centerOverlay box"
+                style="width: 100%;"
               >
                 <div
                   class="loadingSpinnerContainer"
@@ -1656,10 +1658,11 @@ exports[`HostQuestionState > should render HostQuestionState with question type 
             data-testid="question-media"
           >
             <div
-              class="container"
+              class="container fallbackAspectRatio"
             >
               <div
-                class="centerOverlay"
+                class="centerOverlay box"
+                style="width: 100%;"
               >
                 <div
                   class="loadingSpinnerContainer"

--- a/packages/klurigo-web/src/states/HostResultState/HostResultState.stories.tsx
+++ b/packages/klurigo-web/src/states/HostResultState/HostResultState.stories.tsx
@@ -236,7 +236,7 @@ export const QuestionPin = {
       results: {
         type: QuestionType.Pin,
         imageURL:
-          'https://upload.wikimedia.org/wikipedia/commons/thumb/f/f7/Europe_laea_location_map.svg/1401px-Europe_laea_location_map.svg.png',
+          'https://upload.wikimedia.org/wikipedia/commons/7/7c/Europe_EU_laea_location_map_%28configurable%29.svg',
         positionX: 0.45838,
         positionY: 0.35438,
         tolerance: QuestionPinTolerance.Medium,

--- a/packages/klurigo-web/src/states/HostResultState/HostResultState.test.tsx
+++ b/packages/klurigo-web/src/states/HostResultState/HostResultState.test.tsx
@@ -287,7 +287,7 @@ describe('HostResultState', () => {
             results: {
               type: QuestionType.Pin,
               imageURL:
-                'https://upload.wikimedia.org/wikipedia/commons/thumb/f/f7/Europe_laea_location_map.svg/1401px-Europe_laea_location_map.svg.png',
+                'https://upload.wikimedia.org/wikipedia/commons/7/7c/Europe_EU_laea_location_map_%28configurable%29.svg',
               positionX: 0.45838,
               positionY: 0.35438,
               tolerance: QuestionPinTolerance.Medium,

--- a/packages/klurigo-web/src/states/HostResultState/__snapshots__/HostResultState.test.tsx.snap
+++ b/packages/klurigo-web/src/states/HostResultState/__snapshots__/HostResultState.test.tsx.snap
@@ -1339,10 +1339,11 @@ exports[`HostResultState > should render HostResultState with question type pin 
             data-testid="pin-question-results"
           >
             <div
-              class="container"
+              class="container fallbackAspectRatio"
             >
               <div
-                class="centerOverlay"
+                class="centerOverlay box"
+                style="width: 100%;"
               >
                 <div
                   class="loadingSpinnerContainer"

--- a/packages/klurigo-web/src/states/PlayerQuestionState/PlayerQuestionState.stories.tsx
+++ b/packages/klurigo-web/src/states/PlayerQuestionState/PlayerQuestionState.stories.tsx
@@ -196,7 +196,7 @@ export const QuestionPin = {
         question:
           'Where is the capital Stockholm located? Pin the answer on a map of Europe',
         imageURL:
-          'https://upload.wikimedia.org/wikipedia/commons/thumb/f/f7/Europe_laea_location_map.svg/1401px-Europe_laea_location_map.svg.png',
+          'https://upload.wikimedia.org/wikipedia/commons/7/7c/Europe_EU_laea_location_map_%28configurable%29.svg',
         duration: 30,
       },
       countdown: {

--- a/packages/klurigo-web/src/states/common/QuestionAnswerPicker/__snapshots__/QuestionAnswerPick.test.tsx.snap
+++ b/packages/klurigo-web/src/states/common/QuestionAnswerPicker/__snapshots__/QuestionAnswerPick.test.tsx.snap
@@ -56,10 +56,11 @@ exports[`QuestionAnswerPicker > renders Pin and maps coordinates on submit 1`] =
         class="interactive"
       >
         <div
-          class="container"
+          class="container fallbackAspectRatio"
         >
           <div
-            class="centerOverlay"
+            class="centerOverlay box"
+            style="width: 100%;"
           >
             <div
               class="loadingSpinnerContainer"

--- a/packages/klurigo-web/src/states/common/QuestionAnswerPicker/components/AnswerPin/AnswerPin.stories.tsx
+++ b/packages/klurigo-web/src/states/common/QuestionAnswerPicker/components/AnswerPin/AnswerPin.stories.tsx
@@ -49,7 +49,7 @@ export const Interactive = {
   name: 'Interactive',
   args: {
     imageURL:
-      'https://upload.wikimedia.org/wikipedia/commons/thumb/f/f7/Europe_laea_location_map.svg/1401px-Europe_laea_location_map.svg.png',
+      'https://upload.wikimedia.org/wikipedia/commons/7/7c/Europe_EU_laea_location_map_%28configurable%29.svg',
     submittedAnswer: undefined,
     interactive: true,
     loading: false,
@@ -61,7 +61,7 @@ export const NonInteractive = {
   name: 'Non Interactive',
   args: {
     imageURL:
-      'https://upload.wikimedia.org/wikipedia/commons/thumb/f/f7/Europe_laea_location_map.svg/1401px-Europe_laea_location_map.svg.png',
+      'https://upload.wikimedia.org/wikipedia/commons/7/7c/Europe_EU_laea_location_map_%28configurable%29.svg',
     submittedAnswer: undefined,
     interactive: false,
     loading: false,

--- a/packages/klurigo-web/src/states/common/QuestionAnswerPicker/components/AnswerPin/__snapshots__/AnswerPin.test.tsx.snap
+++ b/packages/klurigo-web/src/states/common/QuestionAnswerPicker/components/AnswerPin/__snapshots__/AnswerPin.test.tsx.snap
@@ -67,10 +67,11 @@ exports[`AnswerPin > renders non-interactive mode without submit button 1`] = `
     class="answerPin"
   >
     <div
-      class="container"
+      class="container fallbackAspectRatio"
     >
       <div
-        class="centerOverlay"
+        class="centerOverlay box"
+        style="width: 100%;"
       >
         <div
           class="loadingSpinnerContainer"


### PR DESCRIPTION
- Add conditional fallback aspect ratio for loading and error states using modifier class.
- Update overlay to participate in layout instead of absolute positioning.
- Ensure fallback only applies during loading/error without affecting ready state.
- Replace Pin image URLs with scalable SVG versions across stories and tests.

Improves loading/error visibility and consistency of image rendering.