### PR TITLE
feat(leaderboard): extract value type and integrate into summary section

### DIFF
--- a/packages/klurigo-web/src/components/Leaderboard/Leaderboard.tsx
+++ b/packages/klurigo-web/src/components/Leaderboard/Leaderboard.tsx
@@ -33,14 +33,16 @@ const getStreakBadgeStyle = (
   return 'default'
 }
 
-export interface LeaderboardProps {
-  values: {
-    position: number
-    nickname: string
-    score: number
-    streaks?: number
-    previousPosition?: number
-  }[]
+export type LeaderboardValue = {
+  position: number
+  nickname: string
+  score: number
+  streaks?: number
+  previousPosition?: number
+}
+
+export type LeaderboardProps = {
+  values: LeaderboardValue[]
   includePodium?: boolean
 }
 

--- a/packages/klurigo-web/src/components/Leaderboard/index.ts
+++ b/packages/klurigo-web/src/components/Leaderboard/index.ts
@@ -1,2 +1,5 @@
-export type { LeaderboardProps } from './Leaderboard'
-export { default } from './Leaderboard'
+export {
+  default,
+  type LeaderboardValue,
+  type LeaderboardProps,
+} from './Leaderboard'

--- a/packages/klurigo-web/src/components/MediaInfoCard/MediaInfoCard.module.scss
+++ b/packages/klurigo-web/src/components/MediaInfoCard/MediaInfoCard.module.scss
@@ -158,7 +158,7 @@
   display: flex;
   align-items: center;
   font-weight: bold;
-  color: colors.$color-text-subtle;
+  color: colors.$color-text-default;
 
   @include helpers.mobile {
     gap: spacing.$space-inline-mobile;

--- a/packages/klurigo-web/src/components/index.ts
+++ b/packages/klurigo-web/src/components/index.ts
@@ -15,7 +15,11 @@ export type { ConfirmDialogProps } from './ConfirmDialog'
 export type { DropzoneProps } from './Dropzone'
 export type { HorizontalRailProps } from './HorizontalRail'
 export type { IconTooltipProps } from './IconTooltip'
-export type { LeaderboardProps } from './Leaderboard'
+export {
+  default as Leaderboard,
+  type LeaderboardValue,
+  type LeaderboardProps,
+} from './Leaderboard'
 export type {
   CardInfoItemProps,
   CardMetaItemProps,
@@ -76,7 +80,6 @@ export { default as Dropzone } from './Dropzone'
 export { default as HorizontalRail } from './HorizontalRail'
 export { default as IconTooltip } from './IconTooltip'
 export { default as InfiniteScrollContainer } from './InfiniteScrollContainer'
-export { default as Leaderboard } from './Leaderboard'
 export { default as LoadingSpinner } from './LoadingSpinner'
 export { CardInfoItem, CardMetaItem, MediaInfoCard } from './MediaInfoCard'
 export { default as MediaModal } from './MediaModal'

--- a/packages/klurigo-web/src/pages/GameResultsPage/__snapshots__/GameResultsPage.test.tsx.snap
+++ b/packages/klurigo-web/src/pages/GameResultsPage/__snapshots__/GameResultsPage.test.tsx.snap
@@ -588,6 +588,12 @@ exports[`GameResultsPage > loads and renders results when query succeeds 1`] = `
                       />
                     </div>
                   </div>
+                  <div
+                    class="leaderboard"
+                  />
+                  <div
+                    class="pageDivider"
+                  />
                 </div>
                 <div
                   class="card full progress"
@@ -1693,6 +1699,12 @@ exports[`GameResultsPage > shows loading before data resolves then renders UI 1`
                       />
                     </div>
                   </div>
+                  <div
+                    class="leaderboard"
+                  />
+                  <div
+                    class="pageDivider"
+                  />
                 </div>
                 <div
                   class="card full progress"

--- a/packages/klurigo-web/src/pages/GameResultsPage/components/GameResultsPageUI/__snapshots__/GameResultsPageUI.test.tsx.snap
+++ b/packages/klurigo-web/src/pages/GameResultsPage/components/GameResultsPageUI/__snapshots__/GameResultsPageUI.test.tsx.snap
@@ -535,6 +535,12 @@ exports[`GameResultsPageUI > should render GameResultsPageUI for classic game mo
                       />
                     </div>
                   </div>
+                  <div
+                    class="leaderboard"
+                  />
+                  <div
+                    class="pageDivider"
+                  />
                 </div>
                 <div
                   class="card full progress"
@@ -1582,6 +1588,12 @@ exports[`GameResultsPageUI > should render GameResultsPageUI for zero to one hun
                       />
                     </div>
                   </div>
+                  <div
+                    class="leaderboard"
+                  />
+                  <div
+                    class="pageDivider"
+                  />
                 </div>
                 <div
                   class="card full progress"
@@ -2609,6 +2621,12 @@ exports[`GameResultsPageUI > shows Summary by default and switches to Players an
                       />
                     </div>
                   </div>
+                  <div
+                    class="leaderboard"
+                  />
+                  <div
+                    class="pageDivider"
+                  />
                 </div>
                 <div
                   class="card full progress"
@@ -4770,6 +4788,12 @@ exports[`GameResultsPageUI > shows Summary by default and switches to Players an
                       />
                     </div>
                   </div>
+                  <div
+                    class="leaderboard"
+                  />
+                  <div
+                    class="pageDivider"
+                  />
                 </div>
                 <div
                   class="card full progress"
@@ -5813,6 +5837,12 @@ exports[`GameResultsPageUI > switches sections and shows 0 to 100 label in Summa
                       />
                     </div>
                   </div>
+                  <div
+                    class="leaderboard"
+                  />
+                  <div
+                    class="pageDivider"
+                  />
                 </div>
                 <div
                   class="card full progress"
@@ -7718,6 +7748,12 @@ exports[`GameResultsPageUI > switches sections and shows 0 to 100 label in Summa
                       />
                     </div>
                   </div>
+                  <div
+                    class="leaderboard"
+                  />
+                  <div
+                    class="pageDivider"
+                  />
                 </div>
                 <div
                   class="card full progress"

--- a/packages/klurigo-web/src/pages/GameResultsPage/components/GameResultsPageUI/sections/SummarySection/SummarySection.module.scss
+++ b/packages/klurigo-web/src/pages/GameResultsPage/components/GameResultsPageUI/sections/SummarySection/SummarySection.module.scss
@@ -33,14 +33,17 @@ $contrast-opacity: 0.8;
 
     @include helpers.mobile {
       margin-top: spacing.$space-page-mobile;
+      row-gap: spacing.$space-page-mobile;
     }
 
     @include helpers.tablet {
       margin-top: spacing.$space-page-tablet;
+      row-gap: spacing.$space-page-tablet;
     }
 
     @include helpers.desktop {
       margin-top: spacing.$space-page-desktop;
+      row-gap: spacing.$space-page-desktop;
     }
   }
 
@@ -128,6 +131,7 @@ $contrast-opacity: 0.8;
       flex: 1;
       height: 100%;
       outline: none;
+      text-align: center;
 
       &:disabled {
         cursor: auto;

--- a/packages/klurigo-web/src/pages/GameResultsPage/components/GameResultsPageUI/sections/SummarySection/SummarySection.test.tsx
+++ b/packages/klurigo-web/src/pages/GameResultsPage/components/GameResultsPageUI/sections/SummarySection/SummarySection.test.tsx
@@ -49,6 +49,8 @@ vi.mock('../../../../../../api', () => ({
 vi.mock('../../../../../../components', () => ({
   CircularProgressBar: () => <div data-testid="circular-progress" />,
   Podium: () => <div data-testid="podium" />,
+  Leaderboard: () => <div data-testid="leaderboard" />,
+  PageDivider: () => <div data-testid="page-divider" />,
 
   CircularProgressBarKind: { Correct: 'Correct' },
   CircularProgressBarSize: { Medium: 'Medium' },

--- a/packages/klurigo-web/src/pages/GameResultsPage/components/GameResultsPageUI/sections/SummarySection/SummarySection.tsx
+++ b/packages/klurigo-web/src/pages/GameResultsPage/components/GameResultsPageUI/sections/SummarySection/SummarySection.tsx
@@ -26,6 +26,9 @@ import {
   CircularProgressBarKind,
   CircularProgressBarSize,
   ConfirmDialog,
+  Leaderboard,
+  type LeaderboardValue,
+  PageDivider,
   Podium,
   type PodiumValue,
 } from '../../../../../../components'
@@ -188,6 +191,18 @@ const SummarySection: FC<SummarySectionProps> = ({
       }))
   }, [playerMetrics])
 
+  const leaderboardValues = useMemo<LeaderboardValue[]>(
+    () =>
+      playerMetrics
+        .sort((lhs, rhs) => lhs.rank - rhs.rank)
+        .map(({ rank, player, score }) => ({
+          position: rank,
+          nickname: player?.nickname ?? '',
+          score,
+        })),
+    [playerMetrics],
+  )
+
   const handleCreateGame = (): void => {
     if (quiz.canHostLiveGame) {
       setIsHostGameLoading(true)
@@ -205,6 +220,8 @@ const SummarySection: FC<SummarySectionProps> = ({
       <div className={styles.cards}>
         <div className={styles.podiumWrapper}>
           <Podium values={podiumValues} />
+          <Leaderboard values={leaderboardValues} includePodium={false} />
+          <PageDivider />
         </div>
 
         <div className={classNames(styles.card, styles.full, styles.progress)}>

--- a/packages/klurigo-web/src/pages/GameResultsPage/components/GameResultsPageUI/sections/SummarySection/__snapshots__/SummarySection.test.tsx.snap
+++ b/packages/klurigo-web/src/pages/GameResultsPage/components/GameResultsPageUI/sections/SummarySection/__snapshots__/SummarySection.test.tsx.snap
@@ -12,6 +12,12 @@ exports[`SummarySection > omits metric cards when playerMetrics has no data 1`] 
         <div
           data-testid="podium"
         />
+        <div
+          data-testid="leaderboard"
+        />
+        <div
+          data-testid="page-divider"
+        />
       </div>
       <div
         class="card full progress"
@@ -297,6 +303,12 @@ exports[`SummarySection > renders Classic summary, uses getCorrectPercentage, sh
       >
         <div
           data-testid="podium"
+        />
+        <div
+          data-testid="leaderboard"
+        />
+        <div
+          data-testid="page-divider"
         />
       </div>
       <div
@@ -679,6 +691,12 @@ exports[`SummarySection > renders ZeroToOneHundred summary and uses getAveragePr
       >
         <div
           data-testid="podium"
+        />
+        <div
+          data-testid="leaderboard"
+        />
+        <div
+          data-testid="page-divider"
         />
       </div>
       <div


### PR DESCRIPTION
- Introduce LeaderboardValue type and refactor LeaderboardProps to use it.
- Re-export Leaderboard with types from component and root index.
- Integrate Leaderboard into SummarySection with computed values.
- Add PageDivider and adjust layout spacing and alignment.
- Update MediaInfoCard text color to default semantic token.
- Extend tests to mock Leaderboard and PageDivider.

This improves type reuse and enhances summary UI with full leaderboard display.