### PR TITLE
refactor(typography): update default alignment and color usage

### DIFF
--- a/packages/klurigo-web/src/components/ConfirmDialog/ConfirmDialog.tsx
+++ b/packages/klurigo-web/src/components/ConfirmDialog/ConfirmDialog.tsx
@@ -30,7 +30,7 @@ const ConfirmDialog: FC<ConfirmDialogProps> = ({
   onClose,
 }) => (
   <Modal title={title} open={open}>
-    <Typography variant="body2" align="left" color="default" noOpacity>
+    <Typography variant="body2" noOpacity>
       {message}
     </Typography>
     <div className={styles.actions}>

--- a/packages/klurigo-web/src/components/MediaInfoCard/MediaInfoCard.tsx
+++ b/packages/klurigo-web/src/components/MediaInfoCard/MediaInfoCard.tsx
@@ -68,14 +68,7 @@ const MediaInfoCard: FC<MediaInfoCardProps> = ({
       </div>
 
       <div className={styles.body}>
-        <Typography
-          variant="control"
-          align="left"
-          color="default"
-          title={title}
-          noOpacity
-          truncate
-          bold>
+        <Typography variant="control" title={title} noOpacity truncate bold>
           {title}
         </Typography>
 

--- a/packages/klurigo-web/src/components/Modal/Modal.tsx
+++ b/packages/klurigo-web/src/components/Modal/Modal.tsx
@@ -63,12 +63,7 @@ const Modal: FC<ModalProps> = ({
           ref={refs.setFloating}
           {...getFloatingProps()}>
           <div className={styles.header}>
-            <Typography
-              id={titleId}
-              variant="title4"
-              align="left"
-              color="default"
-              noOpacity>
+            <Typography id={titleId} variant="title4" noOpacity>
               {title}
             </Typography>
             {onClose && (

--- a/packages/klurigo-web/src/components/QuizTableFilter/components/FilterModal/FilterModal.tsx
+++ b/packages/klurigo-web/src/components/QuizTableFilter/components/FilterModal/FilterModal.tsx
@@ -72,16 +72,11 @@ const FilterModal: FC<FilterModalProps> = ({
   return (
     <Modal title="Refine Your Quiz Search" open={open}>
       <div className={styles.filterModalContainer}>
-        <Typography variant="body2" align="left" color="default" noOpacity>
+        <Typography variant="body2" noOpacity>
           Narrow down your search and find the perfect quiz!
         </Typography>
         <div className={styles.row}>
-          <Typography
-            variant="control"
-            align="left"
-            color="default"
-            noOpacity
-            bold>
+          <Typography variant="control" noOpacity bold>
             Category
           </Typography>
           <Select
@@ -106,12 +101,7 @@ const FilterModal: FC<FilterModalProps> = ({
         </div>
         {showVisibilityFilter && (
           <div className={styles.row}>
-            <Typography
-              variant="control"
-              align="left"
-              color="default"
-              noOpacity
-              bold>
+            <Typography variant="control" noOpacity bold>
               Visibility
             </Typography>
             <Select
@@ -136,12 +126,7 @@ const FilterModal: FC<FilterModalProps> = ({
           </div>
         )}
         <div className={styles.row}>
-          <Typography
-            variant="control"
-            align="left"
-            color="default"
-            noOpacity
-            bold>
+          <Typography variant="control" noOpacity bold>
             Language
           </Typography>
           <Select
@@ -165,12 +150,7 @@ const FilterModal: FC<FilterModalProps> = ({
           />
         </div>
         <div className={styles.row}>
-          <Typography
-            variant="control"
-            align="left"
-            color="default"
-            noOpacity
-            bold>
+          <Typography variant="control" noOpacity bold>
             Game Mode
           </Typography>
           <Select
@@ -194,12 +174,7 @@ const FilterModal: FC<FilterModalProps> = ({
           />
         </div>
         <div className={styles.row}>
-          <Typography
-            variant="control"
-            align="left"
-            color="default"
-            noOpacity
-            bold>
+          <Typography variant="control" noOpacity bold>
             Sort By
           </Typography>
           <Select
@@ -220,12 +195,7 @@ const FilterModal: FC<FilterModalProps> = ({
           />
         </div>
         <div className={styles.row}>
-          <Typography
-            variant="control"
-            align="left"
-            color="default"
-            noOpacity
-            bold>
+          <Typography variant="control" noOpacity bold>
             Sort Order
           </Typography>
           <Select

--- a/packages/klurigo-web/src/components/RailHeader/RailHeader.tsx
+++ b/packages/klurigo-web/src/components/RailHeader/RailHeader.tsx
@@ -25,11 +25,11 @@ export type RailHeaderProps = {
 const RailHeader: FC<RailHeaderProps> = ({ title, description, action }) => (
   <div className={styles.header}>
     <div className={styles.headerText}>
-      <Typography variant="title4" align="left">
+      <Typography variant="title4" color="inverse">
         {title}
       </Typography>
       {description && (
-        <Typography variant="body2" align="left">
+        <Typography variant="body2" color="inverse">
           {description}
         </Typography>
       )}

--- a/packages/klurigo-web/src/components/Typography/Typography.stories.tsx
+++ b/packages/klurigo-web/src/components/Typography/Typography.stories.tsx
@@ -13,19 +13,25 @@ const meta = {
 export default meta
 type Story = StoryObj<typeof meta>
 
-const variants = [
-  'extraLargeTitle',
-  'title',
-  'title2',
-  'title3',
-  'title4',
-  'title5',
-  'body',
-  'body2',
-  'control',
-  'control2',
-  'link',
-  'link2',
+const samples = [
+  { variant: 'extraLargeTitle', text: 'Heading' },
+  { variant: 'title', text: 'Heading' },
+  { variant: 'title2', text: 'Heading' },
+  { variant: 'title3', text: 'Heading' },
+  { variant: 'title4', text: 'Heading' },
+  { variant: 'title5', text: 'Heading' },
+  {
+    variant: 'body',
+    text: 'Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quos blanditiis tenetur',
+  },
+  {
+    variant: 'body2',
+    text: 'Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quos blanditiis tenetur',
+  },
+  { variant: 'control', text: 'Sample text' },
+  { variant: 'control2', text: 'Sample text' },
+  { variant: 'link', text: 'Sample text' },
+  { variant: 'link2', text: 'Sample text' },
 ] as const
 
 export const AllVariants: Story = {
@@ -33,35 +39,24 @@ export const AllVariants: Story = {
     variant: 'body',
     children: 'Preview',
   },
-  render: () => {
-    return (
-      <div
-        style={{
-          minHeight: '100vh',
-          padding: 24,
-          display: 'flex',
-          flexDirection: 'column',
-          gap: 24,
-          maxWidth: 1000,
-          margin: '0 auto',
-          overflowY: 'auto',
-        }}>
-        {variants.map((variant) => (
-          <div
-            key={variant}
-            style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
-            <Typography variant="title2" width="full">
-              Variant: {variant}
-            </Typography>
-
-            <Typography variant={variant}>
-              The quick brown fox jumps over the lazy dog.
-            </Typography>
-
-            <div style={{ height: 1, opacity: 0.2, background: 'white' }} />
-          </div>
-        ))}
-      </div>
-    )
-  },
+  render: () => (
+    <div
+      style={{
+        minHeight: '100vh',
+        padding: '48px 56px',
+        maxWidth: 1200,
+        margin: '0 auto',
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'flex-start',
+        gap: 16,
+        boxSizing: 'border-box',
+      }}>
+      {samples.map(({ variant, text }) => (
+        <Typography key={variant} variant={variant} color="inverse" noOpacity>
+          {variant}. {text}
+        </Typography>
+      ))}
+    </div>
+  ),
 }

--- a/packages/klurigo-web/src/components/Typography/Typography.test.tsx
+++ b/packages/klurigo-web/src/components/Typography/Typography.test.tsx
@@ -213,7 +213,7 @@ describe('Typography', () => {
 
   it('matches snapshot for title variant', () => {
     const { asFragment } = render(
-      <Typography variant="title" width="small" align="left">
+      <Typography variant="title" width="small">
         Leaderboard
       </Typography>,
     )
@@ -345,11 +345,11 @@ describe('Typography', () => {
     expect(asFragment()).toMatchSnapshot()
   })
 
-  it('applies center alignment by default when align is not provided', () => {
-    render(<Typography>Centered</Typography>)
+  it('applies left alignment by default when align is not provided', () => {
+    render(<Typography>Left aligned</Typography>)
 
-    const el = screen.getByText('Centered')
-    expect(el).toHaveClass('alignCenter')
+    const el = screen.getByText('Left aligned')
+    expect(el).toHaveClass('alignLeft')
   })
 
   it('applies alignment modifier classes', () => {
@@ -359,7 +359,7 @@ describe('Typography', () => {
     rerender(<Typography align="justify">Justify</Typography>)
     expect(screen.getByText('Justify')).toHaveClass('alignJustify')
 
-    rerender(<Typography align="left">Left</Typography>)
+    rerender(<Typography>Left</Typography>)
     expect(screen.getByText('Left')).toHaveClass('alignLeft')
 
     rerender(<Typography align="right">Right</Typography>)
@@ -377,17 +377,15 @@ describe('Typography', () => {
     expect(el).toHaveClass('alignRight')
   })
 
-  it('applies inverse color by default when color is not provided', () => {
+  it('applies default color by default when color is not provided', () => {
     render(<Typography>Default color</Typography>)
 
     const el = screen.getByText('Default color')
-    expect(el).toHaveClass('colorInverse')
+    expect(el).toHaveClass('colorDefault')
   })
 
   it('applies color modifier classes', () => {
-    const { rerender } = render(
-      <Typography color="default">Default</Typography>,
-    )
+    const { rerender } = render(<Typography>Default</Typography>)
     expect(screen.getByText('Default')).toHaveClass('colorDefault')
 
     rerender(<Typography color="subtle">Subtle</Typography>)
@@ -594,7 +592,7 @@ describe('Typography', () => {
 
   it('matches snapshot for body variant with semantic color', () => {
     const { asFragment } = render(
-      <Typography variant="body" color="success" align="left" width="medium">
+      <Typography variant="body" color="success" width="medium">
         Saved successfully
       </Typography>,
     )

--- a/packages/klurigo-web/src/components/Typography/Typography.tsx
+++ b/packages/klurigo-web/src/components/Typography/Typography.tsx
@@ -301,9 +301,9 @@ export type TypographyProps = NonLinkProps | LinkProps
 const Typography: FC<TypographyProps> = (props) => {
   const {
     variant = 'body',
-    align = 'center',
+    align = 'left',
     width = 'full',
-    color = 'inverse',
+    color = 'default',
     noOpacity = false,
     noWrap = false,
     truncate = false,

--- a/packages/klurigo-web/src/components/Typography/__snapshots__/Typography.test.tsx.snap
+++ b/packages/klurigo-web/src/components/Typography/__snapshots__/Typography.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Typography > matches snapshot for asChild composition 1`] = `
 <DocumentFragment>
   <a
-    class="inner typography link alignCenter widthSmall colorInverse outer"
+    class="inner typography link alignLeft widthSmall colorDefault outer"
     href="/quiz/create"
   >
     Create your own quiz
@@ -24,7 +24,7 @@ exports[`Typography > matches snapshot for body variant with semantic color 1`] 
 exports[`Typography > matches snapshot for extraLargeTitle variant 1`] = `
 <DocumentFragment>
   <h1
-    class="typography extraLargeTitle alignCenter widthMedium colorInverse"
+    class="typography extraLargeTitle alignLeft widthMedium colorDefault"
   >
     Let’s play
   </h1>
@@ -34,7 +34,7 @@ exports[`Typography > matches snapshot for extraLargeTitle variant 1`] = `
 exports[`Typography > matches snapshot for link variant 1`] = `
 <DocumentFragment>
   <a
-    class="typography link alignCenter widthFull colorInverse"
+    class="typography link alignLeft widthFull colorDefault"
     href="/profile"
   >
     Profile
@@ -45,7 +45,7 @@ exports[`Typography > matches snapshot for link variant 1`] = `
 exports[`Typography > matches snapshot for title variant 1`] = `
 <DocumentFragment>
   <h1
-    class="typography title alignLeft widthSmall colorInverse"
+    class="typography title alignLeft widthSmall colorDefault"
   >
     Leaderboard
   </h1>

--- a/packages/klurigo-web/src/pages/AuthGoogleCallbackPage/components/AuthGoogleCallbackPageUI/AuthGoogleCallbackPageUI.tsx
+++ b/packages/klurigo-web/src/pages/AuthGoogleCallbackPage/components/AuthGoogleCallbackPageUI/AuthGoogleCallbackPageUI.tsx
@@ -5,10 +5,10 @@ import { LoadingSpinner, Page, Typography } from '../../../../components'
 const AuthGoogleCallbackPageUI: FC = () => {
   return (
     <Page>
-      <Typography variant="title" width="small">
+      <Typography variant="title" width="small" align="center" color="inverse">
         Hold tight—calling in the Google cavalry!
       </Typography>
-      <Typography variant="body" width="small">
+      <Typography variant="body" width="small" align="center" color="inverse">
         We’re doing the secret handshake with Google. Almost there…
       </Typography>
       <LoadingSpinner />

--- a/packages/klurigo-web/src/pages/AuthLoginPage/components/AuthLoginPageUI/AuthLoginPageUI.tsx
+++ b/packages/klurigo-web/src/pages/AuthLoginPage/components/AuthLoginPageUI/AuthLoginPageUI.tsx
@@ -84,10 +84,10 @@ const AuthLoginPageUI: FC<AuthLoginPageUIProps> = ({
 
   return (
     <Page align="start">
-      <Typography variant="title" width="medium">
+      <Typography variant="title" width="medium" align="center" color="inverse">
         {title}
       </Typography>
-      <Typography variant="body" width="small">
+      <Typography variant="body" width="small" align="center" color="inverse">
         {message}
       </Typography>
       <form className={styles.loginForm} onSubmit={handleSubmit}>
@@ -123,7 +123,12 @@ const AuthLoginPageUI: FC<AuthLoginPageUIProps> = ({
           onValid={(valid) => handleChangeValidFormField('password', valid)}
           required
         />
-        <Typography variant="link" width="small" asChild>
+        <Typography
+          variant="link"
+          width="small"
+          align="center"
+          color="inverse"
+          asChild>
           <Link to={'/auth/password/forgot'}>Forgot your password?</Link>
         </Typography>
         <IconButtonArrowRight
@@ -135,7 +140,12 @@ const AuthLoginPageUI: FC<AuthLoginPageUIProps> = ({
           disabled={!isFormValid || loading}
         />
       </form>
-      <Typography variant="link" width="small" asChild>
+      <Typography
+        variant="link"
+        width="small"
+        align="center"
+        color="inverse"
+        asChild>
         <Link to={'/auth/register'}>
           New here? Join the fun and create your account!
         </Link>

--- a/packages/klurigo-web/src/pages/AuthPasswordForgotPage/components/AuthPasswordForgotPageUI/AuthPasswordForgotPageUI.tsx
+++ b/packages/klurigo-web/src/pages/AuthPasswordForgotPage/components/AuthPasswordForgotPageUI/AuthPasswordForgotPageUI.tsx
@@ -71,8 +71,10 @@ const AuthPasswordForgotPageUI: FC<AuthPasswordForgotPageUIProps> = ({
 
   return (
     <Page>
-      <Typography variant="title">Uh-oh, Lost Your Key?</Typography>
-      <Typography variant="body" width="medium">
+      <Typography variant="title" align="center" color="inverse">
+        Uh-oh, Lost Your Key?
+      </Typography>
+      <Typography variant="body" width="medium" align="center" color="inverse">
         Don’t panic – it happens! Drop your email below and we’ll beam you a
         shiny new password link.
       </Typography>

--- a/packages/klurigo-web/src/pages/AuthPasswordResetPage/components/AuthPasswordResetPageUI/AuthPasswordResetPageUI.tsx
+++ b/packages/klurigo-web/src/pages/AuthPasswordResetPage/components/AuthPasswordResetPageUI/AuthPasswordResetPageUI.tsx
@@ -88,11 +88,19 @@ const AuthPasswordResetPageUI: FC<AuthPasswordResetPageUIProps> = ({
           <FontAwesomeIcon icon={faXmark} />
         </Badge>
 
-        <Typography variant="title" width="small">
+        <Typography
+          variant="title"
+          width="small"
+          align="center"
+          color="inverse">
           Oops! Something went wrong.
         </Typography>
 
-        <Typography variant="body" width="medium">
+        <Typography
+          variant="body"
+          width="medium"
+          align="center"
+          color="inverse">
           The supplied link is invalid or has expired.
         </Typography>
       </Page>
@@ -101,8 +109,10 @@ const AuthPasswordResetPageUI: FC<AuthPasswordResetPageUIProps> = ({
 
   return (
     <Page>
-      <Typography variant="title">Lock It Down!</Typography>
-      <Typography variant="body" width="medium">
+      <Typography variant="title" align="center" color="inverse">
+        Lock It Down!
+      </Typography>
+      <Typography variant="body" width="medium" align="center" color="inverse">
         Choose your dazzling new password and confirm it below. Let’s keep those
         sneaky hackers out!
       </Typography>

--- a/packages/klurigo-web/src/pages/AuthRegisterPage/components/AuthRegisterPageUI/AuthRegisterPageUI.tsx
+++ b/packages/klurigo-web/src/pages/AuthRegisterPage/components/AuthRegisterPageUI/AuthRegisterPageUI.tsx
@@ -100,10 +100,10 @@ const AuthRegisterPageUI: FC<AuthRegisterPageUIProps> = ({
 
   return (
     <Page align="start">
-      <Typography variant="title" width="medium">
+      <Typography variant="title" width="medium" align="center" color="inverse">
         {title}
       </Typography>
-      <Typography variant="body" width="small">
+      <Typography variant="body" width="small" align="center" color="inverse">
         {message}
       </Typography>
       <form className={styles.createUserForm} onSubmit={handleSubmit}>
@@ -184,7 +184,12 @@ const AuthRegisterPageUI: FC<AuthRegisterPageUIProps> = ({
           disabled={!isFormValid || loading}
         />
       </form>
-      <Typography variant="link" width="small" asChild>
+      <Typography
+        variant="link"
+        width="small"
+        align="center"
+        color="inverse"
+        asChild>
         <Link to={'/auth/login'}>
           Got an account? Flash your credentials and come on in!
         </Link>

--- a/packages/klurigo-web/src/pages/AuthVerifyPage/components/AuthVerifyPageUI/AuthVerifyPageUI.tsx
+++ b/packages/klurigo-web/src/pages/AuthVerifyPage/components/AuthVerifyPageUI/AuthVerifyPageUI.tsx
@@ -23,20 +23,38 @@ const AuthVerifyPageUI: FC<AuthVerifyPageUIProps> = ({
           <FontAwesomeIcon icon={faCheck} />
         </Badge>
 
-        <Typography variant="title" width="medium">
+        <Typography
+          variant="title"
+          width="medium"
+          align="center"
+          color="inverse">
           Hooray! Your email’s all set!
         </Typography>
 
-        <Typography variant="body" width="medium">
+        <Typography
+          variant="body"
+          width="medium"
+          align="center"
+          color="inverse">
           Welcome aboard the fun train. Let’s roll!
         </Typography>
 
         {loggedIn ? (
-          <Typography variant="link" width="small" asChild>
+          <Typography
+            variant="link"
+            width="small"
+            align="center"
+            color="inverse"
+            asChild>
             <Link to={'/'}>Take me home</Link>
           </Typography>
         ) : (
-          <Typography variant="link" width="small" asChild>
+          <Typography
+            variant="link"
+            width="small"
+            align="center"
+            color="inverse"
+            asChild>
             <Link to={'/auth/login'}>Log in to get started!</Link>
           </Typography>
         )}
@@ -45,13 +63,17 @@ const AuthVerifyPageUI: FC<AuthVerifyPageUIProps> = ({
 
     {!verified && !error && (
       <>
-        <Typography variant="title" width="medium">
+        <Typography
+          variant="title"
+          width="medium"
+          align="center"
+          color="inverse">
           One moment… verifying your magic link!
         </Typography>
 
         <LoadingSpinner />
 
-        <Typography variant="body" width="small">
+        <Typography variant="body" width="small" align="center" color="inverse">
           Good things come to those who wait!
         </Typography>
       </>
@@ -63,11 +85,19 @@ const AuthVerifyPageUI: FC<AuthVerifyPageUIProps> = ({
           <FontAwesomeIcon icon={faXmark} />
         </Badge>
 
-        <Typography variant="title" width="medium">
+        <Typography
+          variant="title"
+          width="medium"
+          align="center"
+          color="inverse">
           Oops! Something went wrong.
         </Typography>
 
-        <Typography variant="body" width="medium">
+        <Typography
+          variant="body"
+          width="medium"
+          align="center"
+          color="inverse">
           The supplied link is invalid or has expired.
         </Typography>
       </>

--- a/packages/klurigo-web/src/pages/DiscoverRailsPage/components/DiscoverRailsPageUI/DiscoverRailsPageUI.tsx
+++ b/packages/klurigo-web/src/pages/DiscoverRailsPage/components/DiscoverRailsPageUI/DiscoverRailsPageUI.tsx
@@ -77,10 +77,18 @@ const DiscoverRailsPageUI: FC<DiscoverRailsPageUIProps> = ({
     <Page align="start" discover profile>
       <div className={styles.container}>
         <div className={styles.heading}>
-          <Typography variant="title" width="full">
+          <Typography
+            variant="title"
+            width="full"
+            align="center"
+            color="inverse">
             Discover
           </Typography>
-          <Typography variant="body" width="full">
+          <Typography
+            variant="body"
+            width="full"
+            align="center"
+            color="inverse">
             Explore curated quizzes across different categories
           </Typography>
         </div>
@@ -90,7 +98,11 @@ const DiscoverRailsPageUI: FC<DiscoverRailsPageUIProps> = ({
         {filterActive ? (
           <>
             {isSearchLoading ? null : searchResults.length === 0 ? (
-              <Typography variant="body2" data-testid="search-empty-state">
+              <Typography
+                variant="body2"
+                align="center"
+                color="inverse"
+                data-testid="search-empty-state">
                 No quizzes found. Try a different search or{' '}
                 <button
                   className={styles.clearLink}
@@ -155,7 +167,11 @@ const DiscoverRailsPageUI: FC<DiscoverRailsPageUIProps> = ({
                 />
               ))
             ) : (
-              <Typography variant="body2" data-testid="empty-state">
+              <Typography
+                variant="body2"
+                align="center"
+                color="inverse"
+                data-testid="empty-state">
                 More quizzes coming soon — check back later!
               </Typography>
             )}

--- a/packages/klurigo-web/src/pages/DiscoverRailsPage/components/DiscoverRailsPageUI/components/DiscoveryRailSection/DiscoveryRailSection.tsx
+++ b/packages/klurigo-web/src/pages/DiscoverRailsPage/components/DiscoverRailsPageUI/components/DiscoveryRailSection/DiscoveryRailSection.tsx
@@ -56,7 +56,12 @@ const DiscoveryRailSection: FC<DiscoveryRailSectionProps> = ({
       title={title}
       description={description}
       action={
-        <Typography variant="link2" width="small" align="right" asChild>
+        <Typography
+          variant="link2"
+          width="small"
+          align="right"
+          color="inverse"
+          asChild>
           <Link to={`/discover/section/${sectionKey}`}>
             See all <FontAwesomeIcon icon={faArrowRight} />
           </Link>

--- a/packages/klurigo-web/src/pages/DiscoverSectionPage/components/DiscoverSectionPageUI/DiscoverSectionPageUI.tsx
+++ b/packages/klurigo-web/src/pages/DiscoverSectionPage/components/DiscoverSectionPageUI/DiscoverSectionPageUI.tsx
@@ -57,16 +57,28 @@ const DiscoverSectionPageUI: FC<DiscoverSectionPageUIProps> = ({
     <Page align="start" discover profile>
       <div className={styles.container}>
         {isError || !sectionKey || (!isLoading && quizzes.length === 0) ? (
-          <Typography variant="body2" data-testid="section-empty-state">
+          <Typography
+            variant="body2"
+            align="center"
+            color="inverse"
+            data-testid="section-empty-state">
             This section is not available right now.
           </Typography>
         ) : (
           <>
             <div className={styles.heading}>
-              <Typography variant="title" width="full">
+              <Typography
+                variant="title"
+                width="full"
+                align="center"
+                color="inverse">
                 {title}
               </Typography>
-              <Typography variant="body" width="full">
+              <Typography
+                variant="body"
+                width="full"
+                align="center"
+                color="inverse">
                 {description}
               </Typography>
             </div>

--- a/packages/klurigo-web/src/pages/ErrorPage/ErrorPage.tsx
+++ b/packages/klurigo-web/src/pages/ErrorPage/ErrorPage.tsx
@@ -29,13 +29,17 @@ const ErrorPage: FC = () => {
       <div className={styles.errorIcon}>
         <FontAwesomeIcon icon={faHeartCrack} />
       </div>
-      <Typography variant="title" width="medium">
+      <Typography variant="title" width="medium" align="center" color="inverse">
         Oops! Something went wrong.
       </Typography>
-      <Typography variant="title2" width="medium">
+      <Typography
+        variant="title2"
+        width="medium"
+        align="center"
+        color="inverse">
         {error?.statusText || 'An unexpected error occurred.'}
       </Typography>
-      <Typography variant="body" width="medium">
+      <Typography variant="body" width="medium" align="center" color="inverse">
         {error?.data ||
           'Please try refreshing the page or go back to the homepage.'}
       </Typography>

--- a/packages/klurigo-web/src/pages/GameJoinPage/GameJoinPage.tsx
+++ b/packages/klurigo-web/src/pages/GameJoinPage/GameJoinPage.tsx
@@ -69,7 +69,11 @@ const GameJoinPage: FC = () => {
       <RotatingMessage
         messages={TITLES}
         renderMessage={(title) => (
-          <Typography variant="title" width="medium">
+          <Typography
+            variant="title"
+            width="medium"
+            align="center"
+            color="inverse">
             {title}
           </Typography>
         )}
@@ -78,7 +82,11 @@ const GameJoinPage: FC = () => {
       <RotatingMessage
         messages={MESSAGES}
         renderMessage={(message) => (
-          <Typography variant="body" width="small">
+          <Typography
+            variant="body"
+            width="small"
+            align="center"
+            color="inverse">
             {message}
           </Typography>
         )}

--- a/packages/klurigo-web/src/pages/GameResultsPage/components/GameResultsPageUI/GameResultsPageUI.tsx
+++ b/packages/klurigo-web/src/pages/GameResultsPage/components/GameResultsPageUI/GameResultsPageUI.tsx
@@ -68,9 +68,11 @@ const GameResultsPageUI: FC<GameResultsPageUIProps> = ({
   return (
     <Page align="start" height="normal" discover profile>
       <div className={styles.gameResultsPage}>
-        <Typography variant="title">{results.name}</Typography>
+        <Typography variant="title" align="center" color="inverse">
+          {results.name}
+        </Typography>
 
-        <Typography variant="body">
+        <Typography variant="body" align="center" color="inverse">
           A quick look at how this game unfolded — see how players performed,
           how fast they answered, and who stood out.
         </Typography>

--- a/packages/klurigo-web/src/pages/GameResultsPage/components/GameResultsPageUI/sections/SummarySection/RatingCard.tsx
+++ b/packages/klurigo-web/src/pages/GameResultsPage/components/GameResultsPageUI/sections/SummarySection/RatingCard.tsx
@@ -59,7 +59,9 @@ const RatingCard: FC<RatingCardProps> = ({
 }) => (
   <div className={classNames(styles.card, styles.rating)}>
     <div className={styles.content}>
-      <Typography variant="title3">Rate this quiz</Typography>
+      <Typography variant="title3" align="center" color="inverse">
+        Rate this quiz
+      </Typography>
       <StarRating
         value={stars}
         size="large"
@@ -79,7 +81,9 @@ const RatingCard: FC<RatingCardProps> = ({
       )}
     </div>
     {!canRateQuiz && (
-      <Typography variant="control">You cannot rate your own quiz</Typography>
+      <Typography variant="control" align="center" color="inverse">
+        You cannot rate your own quiz
+      </Typography>
     )}
   </div>
 )

--- a/packages/klurigo-web/src/pages/GameResultsPage/components/GameResultsPageUI/sections/SummarySection/SummarySection.module.scss
+++ b/packages/klurigo-web/src/pages/GameResultsPage/components/GameResultsPageUI/sections/SummarySection/SummarySection.module.scss
@@ -284,6 +284,14 @@ $contrast-opacity: 0.8;
               @include helpers.fontSize(typography.$font-size-body2-desktop);
             }
           }
+
+          p > a {
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            font-weight: 600;
+            opacity: 1;
+          }
         }
       }
 

--- a/packages/klurigo-web/src/pages/GameResultsPage/components/GameResultsPageUI/sections/SummarySection/SummarySection.tsx
+++ b/packages/klurigo-web/src/pages/GameResultsPage/components/GameResultsPageUI/sections/SummarySection/SummarySection.tsx
@@ -66,10 +66,10 @@ const DetailsItem: FC<{
 }> = ({ title, icon, children }) => (
   <div className={styles.item}>
     <FontAwesomeIcon icon={icon} className={styles.icon} />
-    <Typography variant="body2" align="left">
+    <Typography variant="body2" color="inverse">
       {title}
     </Typography>
-    <Typography variant="body2" align="right" noOpacity bold>
+    <Typography variant="body2" align="right" color="inverse" noOpacity bold>
       {children}
     </Typography>
   </div>
@@ -81,8 +81,10 @@ const MetricCard: FC<{ title: string; value: string; nicknames: string[] }> = ({
   nicknames,
 }) => (
   <div className={classNames(styles.card, styles.metric)}>
-    <Typography variant="body2">{title}</Typography>
-    <Typography variant="title3" noOpacity>
+    <Typography variant="body2" align="center" color="inverse">
+      {title}
+    </Typography>
+    <Typography variant="title3" align="center" color="inverse" noOpacity>
       {value}
     </Typography>
     <div className={styles.nicknames}>
@@ -235,7 +237,7 @@ const SummarySection: FC<SummarySectionProps> = ({
             progress={percentage}
             percentageColor="white"
           />
-          <Typography variant="body2" align="left" className={styles.text}>
+          <Typography variant="body2" color="inverse" className={styles.text}>
             {getQuizDifficultyMessage(percentage)}
           </Typography>
         </div>
@@ -257,8 +259,10 @@ const SummarySection: FC<SummarySectionProps> = ({
           {quiz.canHostLiveGame ? (
             <>
               <div className={styles.content}>
-                <Typography variant="title3">Play again</Typography>
-                <Typography variant="body2">
+                <Typography variant="title3" align="center" color="inverse">
+                  Play again
+                </Typography>
+                <Typography variant="body2" align="center" color="inverse">
                   Start a new live game with this quiz and invite others to
                   join.
                 </Typography>
@@ -270,8 +274,10 @@ const SummarySection: FC<SummarySectionProps> = ({
           ) : (
             <>
               <div className={styles.content}>
-                <Typography variant="title3">Play again</Typography>
-                <Typography variant="body2">
+                <Typography variant="title3" align="center" color="inverse">
+                  Play again
+                </Typography>
+                <Typography variant="body2" align="center" color="inverse">
                   This quiz isn’t public yet. Ask the owner to make it public
                   before hosting a live game.
                 </Typography>

--- a/packages/klurigo-web/src/pages/GameResultsPage/components/GameResultsPageUI/sections/SummarySection/__snapshots__/SummarySection.test.tsx.snap
+++ b/packages/klurigo-web/src/pages/GameResultsPage/components/GameResultsPageUI/sections/SummarySection/__snapshots__/SummarySection.test.tsx.snap
@@ -26,8 +26,8 @@ exports[`SummarySection > omits metric cards when playerMetrics has no data 1`] 
           data-testid="circular-progress"
         />
         <p
-          align="left"
           class="body2 text"
+          color="inverse"
         >
           Difficulty: 100%
         </p>
@@ -71,12 +71,16 @@ exports[`SummarySection > omits metric cards when playerMetrics has no data 1`] 
           class="content"
         >
           <h3
+            align="center"
             class="title3"
+            color="inverse"
           >
             Play again
           </h3>
           <p
+            align="center"
             class="body2"
+            color="inverse"
           >
             This quiz isn’t public yet. Ask the owner to make it public before hosting a live game.
           </p>
@@ -105,14 +109,15 @@ exports[`SummarySection > omits metric cards when playerMetrics has no data 1`] 
               />
             </svg>
             <p
-              align="left"
               class="body2"
+              color="inverse"
             >
               Game Mode
             </p>
             <p
               align="right"
               class="body2"
+              color="inverse"
             >
               Classic
             </p>
@@ -134,14 +139,15 @@ exports[`SummarySection > omits metric cards when playerMetrics has no data 1`] 
               />
             </svg>
             <p
-              align="left"
               class="body2"
+              color="inverse"
             >
               Players
             </p>
             <p
               align="right"
               class="body2"
+              color="inverse"
             >
               2
             </p>
@@ -163,14 +169,15 @@ exports[`SummarySection > omits metric cards when playerMetrics has no data 1`] 
               />
             </svg>
             <p
-              align="left"
               class="body2"
+              color="inverse"
             >
               Questions
             </p>
             <p
               align="right"
               class="body2"
+              color="inverse"
             >
               2
             </p>
@@ -199,14 +206,15 @@ exports[`SummarySection > omits metric cards when playerMetrics has no data 1`] 
               />
             </svg>
             <p
-              align="left"
               class="body2"
+              color="inverse"
             >
               Host
             </p>
             <p
               align="right"
               class="body2"
+              color="inverse"
             >
               <a
                 data-discover="true"
@@ -233,14 +241,15 @@ exports[`SummarySection > omits metric cards when playerMetrics has no data 1`] 
               />
             </svg>
             <p
-              align="left"
               class="body2"
+              color="inverse"
             >
               Date
             </p>
             <p
               align="right"
               class="body2"
+              color="inverse"
             >
               2025-01-01 12:00
             </p>
@@ -262,14 +271,15 @@ exports[`SummarySection > omits metric cards when playerMetrics has no data 1`] 
               />
             </svg>
             <p
-              align="left"
               class="body2"
+              color="inverse"
             >
               Duration
             </p>
             <p
               align="right"
               class="body2"
+              color="inverse"
             >
               dur:0
             </p>
@@ -307,8 +317,8 @@ exports[`SummarySection > renders Classic summary, uses getCorrectPercentage, sh
           data-testid="circular-progress"
         />
         <p
-          align="left"
           class="body2 text"
+          color="inverse"
         >
           Difficulty: 70%
         </p>
@@ -351,12 +361,16 @@ exports[`SummarySection > renders Classic summary, uses getCorrectPercentage, sh
           class="content"
         >
           <h3
+            align="center"
             class="title3"
+            color="inverse"
           >
             Play again
           </h3>
           <p
+            align="center"
             class="body2"
+            color="inverse"
           >
             Start a new live game with this quiz and invite others to join.
           </p>
@@ -402,14 +416,15 @@ exports[`SummarySection > renders Classic summary, uses getCorrectPercentage, sh
               />
             </svg>
             <p
-              align="left"
               class="body2"
+              color="inverse"
             >
               Game Mode
             </p>
             <p
               align="right"
               class="body2"
+              color="inverse"
             >
               Classic
             </p>
@@ -431,14 +446,15 @@ exports[`SummarySection > renders Classic summary, uses getCorrectPercentage, sh
               />
             </svg>
             <p
-              align="left"
               class="body2"
+              color="inverse"
             >
               Players
             </p>
             <p
               align="right"
               class="body2"
+              color="inverse"
             >
               2
             </p>
@@ -460,14 +476,15 @@ exports[`SummarySection > renders Classic summary, uses getCorrectPercentage, sh
               />
             </svg>
             <p
-              align="left"
               class="body2"
+              color="inverse"
             >
               Questions
             </p>
             <p
               align="right"
               class="body2"
+              color="inverse"
             >
               2
             </p>
@@ -496,14 +513,15 @@ exports[`SummarySection > renders Classic summary, uses getCorrectPercentage, sh
               />
             </svg>
             <p
-              align="left"
               class="body2"
+              color="inverse"
             >
               Host
             </p>
             <p
               align="right"
               class="body2"
+              color="inverse"
             >
               <a
                 data-discover="true"
@@ -530,14 +548,15 @@ exports[`SummarySection > renders Classic summary, uses getCorrectPercentage, sh
               />
             </svg>
             <p
-              align="left"
               class="body2"
+              color="inverse"
             >
               Date
             </p>
             <p
               align="right"
               class="body2"
+              color="inverse"
             >
               2025-01-01 12:00
             </p>
@@ -559,14 +578,15 @@ exports[`SummarySection > renders Classic summary, uses getCorrectPercentage, sh
               />
             </svg>
             <p
-              align="left"
               class="body2"
+              color="inverse"
             >
               Duration
             </p>
             <p
               align="right"
               class="body2"
+              color="inverse"
             >
               dur:123
             </p>
@@ -577,12 +597,16 @@ exports[`SummarySection > renders Classic summary, uses getCorrectPercentage, sh
         class="card metric"
       >
         <p
+          align="center"
           class="body2"
+          color="inverse"
         >
           Fastest Overall Player
         </p>
         <h3
+          align="center"
           class="title3"
+          color="inverse"
         >
           sec:3.2
         </h3>
@@ -598,12 +622,16 @@ exports[`SummarySection > renders Classic summary, uses getCorrectPercentage, sh
         class="card metric"
       >
         <p
+          align="center"
           class="body2"
+          color="inverse"
         >
           Longest Correct Streak
         </p>
         <h3
+          align="center"
           class="title3"
+          color="inverse"
         >
           7
         </h3>
@@ -619,12 +647,16 @@ exports[`SummarySection > renders Classic summary, uses getCorrectPercentage, sh
         class="card metric"
       >
         <p
+          align="center"
           class="body2"
+          color="inverse"
         >
           Most Accurate Player
         </p>
         <h3
+          align="center"
           class="title3"
+          color="inverse"
         >
           NaN%
         </h3>
@@ -636,12 +668,16 @@ exports[`SummarySection > renders Classic summary, uses getCorrectPercentage, sh
         class="card metric"
       >
         <p
+          align="center"
           class="body2"
+          color="inverse"
         >
           Biggest Comeback
         </p>
         <h3
+          align="center"
           class="title3"
+          color="inverse"
         >
           NaN
         </h3>
@@ -680,8 +716,8 @@ exports[`SummarySection > renders ZeroToOneHundred summary and uses getAveragePr
           data-testid="circular-progress"
         />
         <p
-          align="left"
           class="body2 text"
+          color="inverse"
         >
           Difficulty: 50%
         </p>
@@ -725,12 +761,16 @@ exports[`SummarySection > renders ZeroToOneHundred summary and uses getAveragePr
           class="content"
         >
           <h3
+            align="center"
             class="title3"
+            color="inverse"
           >
             Play again
           </h3>
           <p
+            align="center"
             class="body2"
+            color="inverse"
           >
             This quiz isn’t public yet. Ask the owner to make it public before hosting a live game.
           </p>
@@ -759,14 +799,15 @@ exports[`SummarySection > renders ZeroToOneHundred summary and uses getAveragePr
               />
             </svg>
             <p
-              align="left"
               class="body2"
+              color="inverse"
             >
               Game Mode
             </p>
             <p
               align="right"
               class="body2"
+              color="inverse"
             >
               0 to 100
             </p>
@@ -788,14 +829,15 @@ exports[`SummarySection > renders ZeroToOneHundred summary and uses getAveragePr
               />
             </svg>
             <p
-              align="left"
               class="body2"
+              color="inverse"
             >
               Players
             </p>
             <p
               align="right"
               class="body2"
+              color="inverse"
             >
               2
             </p>
@@ -817,14 +859,15 @@ exports[`SummarySection > renders ZeroToOneHundred summary and uses getAveragePr
               />
             </svg>
             <p
-              align="left"
               class="body2"
+              color="inverse"
             >
               Questions
             </p>
             <p
               align="right"
               class="body2"
+              color="inverse"
             >
               2
             </p>
@@ -853,14 +896,15 @@ exports[`SummarySection > renders ZeroToOneHundred summary and uses getAveragePr
               />
             </svg>
             <p
-              align="left"
               class="body2"
+              color="inverse"
             >
               Host
             </p>
             <p
               align="right"
               class="body2"
+              color="inverse"
             >
               <a
                 data-discover="true"
@@ -887,14 +931,15 @@ exports[`SummarySection > renders ZeroToOneHundred summary and uses getAveragePr
               />
             </svg>
             <p
-              align="left"
               class="body2"
+              color="inverse"
             >
               Date
             </p>
             <p
               align="right"
               class="body2"
+              color="inverse"
             >
               2025-01-01 12:00
             </p>
@@ -916,14 +961,15 @@ exports[`SummarySection > renders ZeroToOneHundred summary and uses getAveragePr
               />
             </svg>
             <p
-              align="left"
               class="body2"
+              color="inverse"
             >
               Duration
             </p>
             <p
               align="right"
               class="body2"
+              color="inverse"
             >
               dur:45
             </p>
@@ -934,12 +980,16 @@ exports[`SummarySection > renders ZeroToOneHundred summary and uses getAveragePr
         class="card metric"
       >
         <p
+          align="center"
           class="body2"
+          color="inverse"
         >
           Fastest Overall Player
         </p>
         <h3
+          align="center"
           class="title3"
+          color="inverse"
         >
           sec:2.1
         </h3>
@@ -955,12 +1005,16 @@ exports[`SummarySection > renders ZeroToOneHundred summary and uses getAveragePr
         class="card metric"
       >
         <p
+          align="center"
           class="body2"
+          color="inverse"
         >
           Longest Correct Streak
         </p>
         <h3
+          align="center"
           class="title3"
+          color="inverse"
         >
           3
         </h3>
@@ -976,12 +1030,16 @@ exports[`SummarySection > renders ZeroToOneHundred summary and uses getAveragePr
         class="card metric"
       >
         <p
+          align="center"
           class="body2"
+          color="inverse"
         >
           Precision Champion
         </p>
         <h3
+          align="center"
           class="title3"
+          color="inverse"
         >
           NaN%
         </h3>
@@ -993,12 +1051,16 @@ exports[`SummarySection > renders ZeroToOneHundred summary and uses getAveragePr
         class="card metric"
       >
         <p
+          align="center"
           class="body2"
+          color="inverse"
         >
           Biggest Comeback
         </p>
         <h3
+          align="center"
           class="title3"
+          color="inverse"
         >
           NaN
         </h3>

--- a/packages/klurigo-web/src/pages/HomePage/HomePage.tsx
+++ b/packages/klurigo-web/src/pages/HomePage/HomePage.tsx
@@ -136,7 +136,11 @@ const HomePage: FC = () => {
         <PageProminentIcon src={KlurigoIcon} alt="Klurigo" />
       </div>
       <div className={styles.hero}>
-        <Typography variant="extraLargeTitle" width="medium">
+        <Typography
+          variant="extraLargeTitle"
+          width="medium"
+          align="center"
+          color="inverse">
           Let’s play
         </Typography>
       </div>
@@ -144,7 +148,11 @@ const HomePage: FC = () => {
         <RotatingMessage
           messages={MESSAGES}
           renderMessage={(message) => (
-            <Typography variant="body" width="small">
+            <Typography
+              variant="body"
+              width="small"
+              align="center"
+              color="inverse">
               {message}
             </Typography>
           )}
@@ -183,13 +191,23 @@ const HomePage: FC = () => {
         />
       </form>
       {isUserAuthenticated ? (
-        <Typography variant="link" width="small" asChild>
+        <Typography
+          variant="link"
+          width="small"
+          align="center"
+          color="inverse"
+          asChild>
           <Link to={'/quiz/create'} className={styles.link}>
             Create your own quiz and challenge others!
           </Link>
         </Typography>
       ) : (
-        <Typography variant="link" width="small" asChild>
+        <Typography
+          variant="link"
+          width="small"
+          align="center"
+          color="inverse"
+          asChild>
           <Link to={'/auth/login'} className={styles.link}>
             Want to create your own quiz? Log in to get started!
           </Link>

--- a/packages/klurigo-web/src/pages/ProfileGamesPage/components/ProfileGamesPageUI/ProfileGamesPageUI.tsx
+++ b/packages/klurigo-web/src/pages/ProfileGamesPage/components/ProfileGamesPageUI/ProfileGamesPageUI.tsx
@@ -53,18 +53,28 @@ const ProfileGamesPageUI: FC<ProfileGamesPageUIProps> = ({
   if (!isLoading && !isError && games.length === 0) {
     return (
       <Page align="start" width="medium" discover profile>
-        <Typography variant="title">No Games Yet</Typography>
-        <Typography variant="body">
+        <Typography variant="title" align="center" color="inverse">
+          No Games Yet
+        </Typography>
+        <Typography variant="body" align="center" color="inverse">
           Host live quizzes and play together with others. Your games will
           appear here once you start.
         </Typography>
 
         <PageDivider />
 
-        <Typography variant="title2" width="medium">
+        <Typography
+          variant="title2"
+          width="medium"
+          align="center"
+          color="inverse">
           Looking for something to play?
         </Typography>
-        <Typography variant="body" width="medium">
+        <Typography
+          variant="body"
+          width="medium"
+          align="center"
+          color="inverse">
           Browse quizzes made by others and host a live game in seconds.
         </Typography>
         <Button
@@ -80,10 +90,18 @@ const ProfileGamesPageUI: FC<ProfileGamesPageUIProps> = ({
 
         <PageDivider />
 
-        <Typography variant="title2" width="medium">
+        <Typography
+          variant="title2"
+          width="medium"
+          align="center"
+          color="inverse">
           Want to make your own?
         </Typography>
-        <Typography variant="body" width="medium">
+        <Typography
+          variant="body"
+          width="medium"
+          align="center"
+          color="inverse">
           Create a quiz in minutes and reuse it for future games.
         </Typography>
         <Button
@@ -102,12 +120,18 @@ const ProfileGamesPageUI: FC<ProfileGamesPageUIProps> = ({
 
   return (
     <Page align="start" discover profile>
-      <Typography variant="title">Game History</Typography>
-      <Typography variant="body" width="medium">
+      <Typography variant="title" align="center" color="inverse">
+        Game History
+      </Typography>
+      <Typography variant="body" width="medium" align="center" color="inverse">
         Review your past games and track your performance.
       </Typography>
       {isError ? (
-        <Typography variant="body2" data-testid="profile-games-empty-state">
+        <Typography
+          variant="body2"
+          align="center"
+          color="inverse"
+          data-testid="profile-games-empty-state">
           Oops! Your game history is playing hide-and-seek right now. Please try
           again.
         </Typography>

--- a/packages/klurigo-web/src/pages/ProfileQuizzesPage/components/ProfileQuizzesPageUI/ProfileQuizzesPageUI.tsx
+++ b/packages/klurigo-web/src/pages/ProfileQuizzesPage/components/ProfileQuizzesPageUI/ProfileQuizzesPageUI.tsx
@@ -91,8 +91,10 @@ const ProfileQuizzesPageUI: FC<ProfileQuizzesPageUIProps> = ({
 
   return (
     <Page align="start" discover profile>
-      <Typography variant="title">Your Quiz Shelf</Typography>
-      <Typography variant="body" width="medium">
+      <Typography variant="title" align="center" color="inverse">
+        Your Quiz Shelf
+      </Typography>
+      <Typography variant="body" width="medium" align="center" color="inverse">
         All your quiz creations, lined up and ready for their next moment in the
         spotlight.
       </Typography>
@@ -114,7 +116,11 @@ const ProfileQuizzesPageUI: FC<ProfileQuizzesPageUIProps> = ({
         />
       )}
       {isError || (!isLoading && quizzes.length === 0) ? (
-        <Typography variant="body2" data-testid="profile-empty-state">
+        <Typography
+          variant="body2"
+          align="center"
+          color="inverse"
+          data-testid="profile-empty-state">
           {isError
             ? 'Oops! Your quizzes are playing hide-and-seek right now. Please try again.'
             : hasSearchFilter

--- a/packages/klurigo-web/src/pages/ProfileSettingsPage/components/ProfileSettingsPageUI/components/UserDetailsForm/UserDetailsForm.tsx
+++ b/packages/klurigo-web/src/pages/ProfileSettingsPage/components/ProfileSettingsPageUI/components/UserDetailsForm/UserDetailsForm.tsx
@@ -92,8 +92,10 @@ const UserDetailsForm: FC<UserDetailsFormProps> = ({
 
   return (
     <>
-      <Typography variant="title">Shape your quiz identity</Typography>
-      <Typography variant="body" width="medium">
+      <Typography variant="title" align="center" color="inverse">
+        Shape your quiz identity
+      </Typography>
+      <Typography variant="body" width="medium" align="center" color="inverse">
         Update your personal details to keep your profile up to date. Your
         information helps personalize your quiz experience and lets others
         recognize you during games.

--- a/packages/klurigo-web/src/pages/ProfileSettingsPage/components/ProfileSettingsPageUI/components/UserPasswordForm/UserPasswordForm.tsx
+++ b/packages/klurigo-web/src/pages/ProfileSettingsPage/components/ProfileSettingsPageUI/components/UserPasswordForm/UserPasswordForm.tsx
@@ -74,8 +74,10 @@ const UserPasswordForm: FC<UserPasswordFormProps> = ({ loading, onChange }) => {
 
   return (
     <>
-      <Typography variant="title2">Upgrade Your Password</Typography>
-      <Typography variant="body" width="medium">
+      <Typography variant="title2" align="center" color="inverse">
+        Upgrade Your Password
+      </Typography>
+      <Typography variant="body" width="medium" align="center" color="inverse">
         Enhance your account security with a fresh password—verify your current
         one, choose a new one, and confirm to complete the update.
       </Typography>

--- a/packages/klurigo-web/src/pages/QuizCreatorPage/components/QuizCreatorPageUI/components/GameModeSelectionModal/GameModeSelectionModal.tsx
+++ b/packages/klurigo-web/src/pages/QuizCreatorPage/components/QuizCreatorPageUI/components/GameModeSelectionModal/GameModeSelectionModal.tsx
@@ -14,7 +14,7 @@ const GameModeSelectionModal: FC<GameModeSelectionModalProps> = ({
 }) => {
   return (
     <Modal title="Choose Your Game Mode" open>
-      <Typography variant="body2" align="left" color="default" noOpacity>
+      <Typography variant="body2" noOpacity>
         Choose the game mode for your quiz. Each mode offers a unique way for
         participants to play and enjoy!
       </Typography>
@@ -22,10 +22,10 @@ const GameModeSelectionModal: FC<GameModeSelectionModalProps> = ({
         <button
           className={styles.classic}
           onClick={() => onSelect?.(GameMode.Classic)}>
-          <Typography variant="title4" color="default" noOpacity>
+          <Typography variant="title4" align="center" noOpacity>
             Classic
           </Typography>
-          <Typography variant="control" color="default" noOpacity>
+          <Typography variant="control" align="center" noOpacity>
             Create a traditional quiz with a mix of question types, including
             multiple-choice, true/false, range sliders, and typed answers.
           </Typography>
@@ -33,10 +33,10 @@ const GameModeSelectionModal: FC<GameModeSelectionModalProps> = ({
         <button
           className={styles.zeroToOneHundred}
           onClick={() => onSelect?.(GameMode.ZeroToOneHundred)}>
-          <Typography variant="title4" color="default" noOpacity>
+          <Typography variant="title4" align="center" noOpacity>
             0-100
           </Typography>
-          <Typography variant="control" color="default" noOpacity>
+          <Typography variant="control" align="center" noOpacity>
             Design a quiz with slider-based questions, where all answers range
             between 0 and 100.
           </Typography>

--- a/packages/klurigo-web/src/pages/QuizCreatorPage/components/QuizCreatorPageUI/components/QuizSettingsModal/QuizSettingsModal.tsx
+++ b/packages/klurigo-web/src/pages/QuizCreatorPage/components/QuizCreatorPageUI/components/QuizSettingsModal/QuizSettingsModal.tsx
@@ -62,12 +62,7 @@ const QuizSettingsModal: FC<QuizSettingsModalProps> = ({
     <Modal title="Settings" onClose={onClose} open>
       <div className={styles.quizSettingsModalWrapper}>
         <div className={styles.quizSettingsRow}>
-          <Typography
-            variant="control"
-            align="left"
-            color="default"
-            noOpacity
-            bold>
+          <Typography variant="control" noOpacity bold>
             Title
           </Typography>
           <TextField
@@ -82,12 +77,7 @@ const QuizSettingsModal: FC<QuizSettingsModalProps> = ({
           />
         </div>
         <div className={styles.quizSettingsRow}>
-          <Typography
-            variant="control"
-            align="left"
-            color="default"
-            noOpacity
-            bold>
+          <Typography variant="control" noOpacity bold>
             Description
           </Typography>
           <Textarea
@@ -104,12 +94,7 @@ const QuizSettingsModal: FC<QuizSettingsModalProps> = ({
           />
         </div>
         <div className={styles.quizSettingsRow}>
-          <Typography
-            variant="control"
-            align="left"
-            color="default"
-            noOpacity
-            bold>
+          <Typography variant="control" noOpacity bold>
             Image Cover
           </Typography>
           {imageCoverURL && <ResponsiveImage imageURL={imageCoverURL} />}
@@ -137,12 +122,7 @@ const QuizSettingsModal: FC<QuizSettingsModalProps> = ({
           </div>
         </div>
         <div className={styles.quizSettingsRow}>
-          <Typography
-            variant="control"
-            align="left"
-            color="default"
-            noOpacity
-            bold>
+          <Typography variant="control" noOpacity bold>
             Category
           </Typography>
           <Select
@@ -170,12 +150,7 @@ const QuizSettingsModal: FC<QuizSettingsModalProps> = ({
           />
         </div>
         <div className={styles.quizSettingsRow}>
-          <Typography
-            variant="control"
-            align="left"
-            color="default"
-            noOpacity
-            bold>
+          <Typography variant="control" noOpacity bold>
             Visibility
           </Typography>
           <Select
@@ -200,12 +175,7 @@ const QuizSettingsModal: FC<QuizSettingsModalProps> = ({
           />
         </div>
         <div className={styles.quizSettingsRow}>
-          <Typography
-            variant="control"
-            align="left"
-            color="default"
-            noOpacity
-            bold>
+          <Typography variant="control" noOpacity bold>
             Language
           </Typography>
           <Select

--- a/packages/klurigo-web/src/pages/QuizDetailsPage/components/QuizDetailsPageUI/QuizDetailsPageUI.tsx
+++ b/packages/klurigo-web/src/pages/QuizDetailsPage/components/QuizDetailsPageUI/QuizDetailsPageUI.tsx
@@ -55,7 +55,7 @@ const DetailItem: FC<{
 }> = ({ value, icon, title, children }) => (
   <div className={styles.item} title={title ?? value}>
     <FontAwesomeIcon icon={icon} className={styles.icon} />
-    <Typography variant="body2" bold>
+    <Typography variant="body2" align="center" color="inverse" bold>
       {value || children}
     </Typography>
   </div>
@@ -102,12 +102,16 @@ const QuizDetailsPageUI: FC<QuizDetailsPageUIProps> = ({
   return (
     <Page align="start" height="full" noPadding discover profile>
       <div className={styles.layout}>
-        <Typography variant="title" width="full">
+        <Typography variant="title" width="full" align="center" color="inverse">
           {quiz.title}
         </Typography>
 
         {quiz.description && (
-          <Typography variant="body" width="medium">
+          <Typography
+            variant="body"
+            width="medium"
+            align="center"
+            color="inverse">
             {quiz.description}
           </Typography>
         )}

--- a/packages/klurigo-web/src/pages/QuizDetailsPage/components/QuizDetailsPageUI/components/RatingsSection/RatingsSection.tsx
+++ b/packages/klurigo-web/src/pages/QuizDetailsPage/components/QuizDetailsPageUI/components/RatingsSection/RatingsSection.tsx
@@ -56,7 +56,11 @@ const RatingsSection: FC<RatingsSectionProps> = ({
 
     if (ratings.length === 0) {
       return (
-        <Typography variant="body2" data-testid="ratings-empty-state">
+        <Typography
+          variant="body2"
+          align="center"
+          color="inverse"
+          data-testid="ratings-empty-state">
           No written reviews yet
         </Typography>
       )
@@ -75,13 +79,11 @@ const RatingsSection: FC<RatingsSectionProps> = ({
                 {formatTimeAgo(rating.updatedAt)}
               </Typography>
             </div>
-            <Typography variant="control" align="left" color="default" bold>
+            <Typography variant="control" bold>
               {rating.author.nickname}
             </Typography>
             {rating.comment && (
-              <Typography variant="control2" align="left" color="default">
-                {rating.comment}
-              </Typography>
+              <Typography variant="control2">{rating.comment}</Typography>
             )}
           </div>
         ))}
@@ -91,20 +93,30 @@ const RatingsSection: FC<RatingsSectionProps> = ({
 
   return (
     <section className={styles.section} data-testid="ratings-section">
-      <Typography variant="title3">Ratings &amp; Reviews</Typography>
+      <Typography variant="title3" align="center" color="inverse">
+        Ratings &amp; Reviews
+      </Typography>
 
       <div className={styles.summary} data-testid="ratings-summary">
         <div className={styles.score}>
           <Typography
             variant="title"
+            align="center"
+            color="inverse"
             aria-label={`Average rating: ${summary.stars.toFixed(1)}`}>
             {summary.stars.toFixed(1)}
           </Typography>
-          <Typography variant="control">out of 5</Typography>
+          <Typography variant="control" align="center" color="inverse">
+            out of 5
+          </Typography>
         </div>
         <div className={styles.summaryRight}>
           <StarRating value={summary.stars} size="small" />
-          <Typography variant="control" data-testid="ratings-count">
+          <Typography
+            variant="control"
+            align="center"
+            color="inverse"
+            data-testid="ratings-count">
             {summary.total} {summary.total > 1 ? 'Ratings' : 'Rating'}
           </Typography>
         </div>

--- a/packages/klurigo-web/src/pages/UserProfilePage/components/UserProfilePageUI/UserProfilePageUI.tsx
+++ b/packages/klurigo-web/src/pages/UserProfilePage/components/UserProfilePageUI/UserProfilePageUI.tsx
@@ -44,8 +44,15 @@ const Card: FC<{
   alt?: string
 }> = ({ title, value, alt }) => (
   <div className={styles.card}>
-    <Typography variant="body2">{title}</Typography>
-    <Typography variant="title3" noOpacity title={alt}>
+    <Typography variant="body2" align="center" color="inverse">
+      {title}
+    </Typography>
+    <Typography
+      variant="title3"
+      align="center"
+      color="inverse"
+      noOpacity
+      title={alt}>
       {value}
     </Typography>
   </div>
@@ -75,7 +82,11 @@ const UserProfilePageUI: FC<UserProfilePageUIProps> = ({
   if (isError || !profile) {
     return (
       <Page align="center" discover profile>
-        <Typography variant="body" data-testid="user-profile-error-state">
+        <Typography
+          variant="body"
+          align="center"
+          color="inverse"
+          data-testid="user-profile-error-state">
           This user profile is not available right now.
         </Typography>
       </Page>
@@ -84,7 +95,11 @@ const UserProfilePageUI: FC<UserProfilePageUIProps> = ({
 
   return (
     <Page align="start" discover profile>
-      <Typography variant="title" data-testid="user-profile-nickname">
+      <Typography
+        variant="title"
+        align="center"
+        color="inverse"
+        data-testid="user-profile-nickname">
         {profile.nickname}
       </Typography>
 
@@ -103,7 +118,11 @@ const UserProfilePageUI: FC<UserProfilePageUIProps> = ({
 
       {quizzes.length === 0 ? (
         <section className={styles.railSection}>
-          <Typography variant="body" data-testid="user-profile-empty-rail">
+          <Typography
+            variant="body"
+            align="center"
+            color="inverse"
+            data-testid="user-profile-empty-rail">
             This user hasn&apos;t shared any quizzes yet.
           </Typography>
         </section>
@@ -113,7 +132,12 @@ const UserProfilePageUI: FC<UserProfilePageUIProps> = ({
             title="Quizzes"
             description={`Browse quizzes created by ${profile.nickname}.`}
             action={
-              <Typography variant="link2" width="small" align="right" asChild>
+              <Typography
+                variant="link2"
+                width="small"
+                align="right"
+                color="inverse"
+                asChild>
                 <Link
                   to={`/users/${userId}/quizzes`}
                   data-testid="user-profile-see-all-link">

--- a/packages/klurigo-web/src/pages/UserQuizzesPage/components/UserQuizzesPageUI/UserQuizzesPageUI.tsx
+++ b/packages/klurigo-web/src/pages/UserQuizzesPage/components/UserQuizzesPageUI/UserQuizzesPageUI.tsx
@@ -41,12 +41,18 @@ const UserQuizzesPageUI: FC<UserQuizzesPageUIProps> = ({
 }) => {
   return (
     <Page align="start" discover profile>
-      <Typography variant="title">Public Quiz Shelf</Typography>
-      <Typography variant="body" width="medium">
+      <Typography variant="title" align="center" color="inverse">
+        Public Quiz Shelf
+      </Typography>
+      <Typography variant="body" width="medium" align="center" color="inverse">
         Browse public quizzes shared by this user.
       </Typography>
       {isError || (!isLoading && quizzes.length === 0) ? (
-        <Typography variant="body2" data-testid="profile-empty-state">
+        <Typography
+          variant="body2"
+          align="center"
+          color="inverse"
+          data-testid="profile-empty-state">
           {isError
             ? "Oops! This user's quizzes are playing hide-and-seek right now. Please try again."
             : "This user hasn't shared any quizzes yet."}

--- a/packages/klurigo-web/src/states/HostGameBeginState/HostGameBeginState.tsx
+++ b/packages/klurigo-web/src/states/HostGameBeginState/HostGameBeginState.tsx
@@ -12,10 +12,10 @@ export interface HostGameBeginStateProps {
 const HostGameBeginState: FC<HostGameBeginStateProps> = () => (
   <GamePage>
     <PageProminentIcon src={MegaphoneIcon} alt="Megaphone" />
-    <Typography variant="title" width="medium">
+    <Typography variant="title" width="medium" align="center" color="inverse">
       Loading Game
     </Typography>
-    <Typography variant="body" width="small">
+    <Typography variant="body" width="small" align="center" color="inverse">
       The game starts any second
     </Typography>
     <LoadingSpinner />

--- a/packages/klurigo-web/src/states/HostLeaderboardState/HostLeaderboardState.tsx
+++ b/packages/klurigo-web/src/states/HostLeaderboardState/HostLeaderboardState.tsx
@@ -49,7 +49,9 @@ const HostLeaderboardState: FC<HostLeaderboardStateProps> = ({
           totalQuestions={totalQuestions}
         />
       }>
-      <Typography variant="title">Leaderboard</Typography>
+      <Typography variant="title" align="center" color="inverse">
+        Leaderboard
+      </Typography>
       <Leaderboard values={leaderboard} />
     </GamePage>
   )

--- a/packages/klurigo-web/src/states/HostLobbyState/HostLobbyState.tsx
+++ b/packages/klurigo-web/src/states/HostLobbyState/HostLobbyState.tsx
@@ -159,23 +159,18 @@ const HostLobbyState: FC<HostLobbyStateProps> = ({
         }>
         <div className={styles.header}>
           <div className={classNames(styles.box, styles.info)}>
-            <Typography variant="body2" align="left" color="default" noOpacity>
+            <Typography variant="body2" noOpacity>
               Join at
             </Typography>{' '}
-            <Typography
-              variant="body2"
-              align="left"
-              color="default"
-              noOpacity
-              bold>
+            <Typography variant="body2" noOpacity bold>
               {extractUrl(config.baseUrl, { omitProtocol: true })}
             </Typography>
           </div>
           <div className={classNames(styles.box, styles.pin)}>
-            <Typography variant="body2" align="left" color="default" noOpacity>
+            <Typography variant="body2" noOpacity>
               Game PIN
             </Typography>
-            <Typography variant="title" align="left" color="default" noOpacity>
+            <Typography variant="title" noOpacity>
               {pin}
             </Typography>
           </div>

--- a/packages/klurigo-web/src/states/HostPodiumState/HostPodiumState.tsx
+++ b/packages/klurigo-web/src/states/HostPodiumState/HostPodiumState.tsx
@@ -45,7 +45,9 @@ const HostPodiumState: FC<HostPodiumStateProps> = ({
           Back to Home
         </IconButtonArrowLeft>
       }>
-      <Typography variant="title">{game.name}</Typography>
+      <Typography variant="title" align="center" color="inverse">
+        {game.name}
+      </Typography>
 
       <Podium values={leaderboard} />
 

--- a/packages/klurigo-web/src/states/HostQuestionState/HostQuestionState.tsx
+++ b/packages/klurigo-web/src/states/HostQuestionState/HostQuestionState.tsx
@@ -70,7 +70,11 @@ const HostQuestionState: FC<HostQuestionStateProps> = ({
       }>
       <div className={classNames(styles.row, styles.flexibleHeight)}>
         <div className={styles.column}>
-          <Typography variant="title" maxLines={3}>
+          <Typography
+            variant="title"
+            align="center"
+            color="inverse"
+            maxLines={3}>
             {question.question}
           </Typography>
         </div>

--- a/packages/klurigo-web/src/states/HostResultState/HostResultState.tsx
+++ b/packages/klurigo-web/src/states/HostResultState/HostResultState.tsx
@@ -82,7 +82,9 @@ const HostResultState: FC<HostResultStateProps> = ({
           totalQuestions={totalQuestions}
         />
       }>
-      <Typography variant="title">{text}</Typography>
+      <Typography variant="title" align="center" color="inverse">
+        {text}
+      </Typography>
       {(!showMedia || type === QuestionType.Pin) && (
         <>
           {type === QuestionType.Pin && (

--- a/packages/klurigo-web/src/states/HostResultState/components/PuzzleQuestionResults/PuzzleQuestionResults.tsx
+++ b/packages/klurigo-web/src/states/HostResultState/components/PuzzleQuestionResults/PuzzleQuestionResults.tsx
@@ -55,7 +55,7 @@ const PuzzleQuestionResults: FC<PuzzleQuestionResultsProps> = ({ results }) => {
           <div className={classNames(styles.inner, styles.green)}>
             <div className={styles.spacer} />
             <div className={styles.footer}>
-              <Typography>
+              <Typography variant="body" align="center" color="inverse">
                 {correct} <FontAwesomeIcon icon={faCheck} />
               </Typography>
             </div>
@@ -71,7 +71,7 @@ const PuzzleQuestionResults: FC<PuzzleQuestionResultsProps> = ({ results }) => {
           <div className={classNames(styles.inner, styles.red)}>
             <div className={styles.spacer} />
             <div className={styles.footer}>
-              <Typography>
+              <Typography align="center" color="inverse">
                 {incorrect} <FontAwesomeIcon icon={faXmark} />
               </Typography>
             </div>

--- a/packages/klurigo-web/src/states/HostResultState/components/QuestionResults/QuestionResults.tsx
+++ b/packages/klurigo-web/src/states/HostResultState/components/QuestionResults/QuestionResults.tsx
@@ -47,7 +47,7 @@ const ResultChip: FC<ResultChipProps> = ({
     }>
     {value}
     <span>
-      <Typography variant="body2" align="left" noWrap bold>
+      <Typography variant="body2" color="inverse" noWrap bold>
         <FontAwesomeIcon icon={faUserGroup} /> {count}
       </Typography>
     </span>

--- a/packages/klurigo-web/src/states/PlayerGameBeginState/PlayerGameBeginState.tsx
+++ b/packages/klurigo-web/src/states/PlayerGameBeginState/PlayerGameBeginState.tsx
@@ -22,10 +22,10 @@ const PlayerGameBeginState: FC<PlayerGameBeginStateProps> = ({
   <GamePage>
     <PageProminentIcon src={BellRingIcon} alt="BellRing" />
     <NicknameChip value={nickname} />
-    <Typography variant="title" width="medium">
+    <Typography variant="title" width="medium" align="center" color="inverse">
       Get ready!
     </Typography>
-    <Typography variant="body" width="small">
+    <Typography variant="body" width="small" align="center" color="inverse">
       The game starts any second
     </Typography>
     <LoadingSpinner />

--- a/packages/klurigo-web/src/states/PlayerGameOverState/PlayerGameOverState.tsx
+++ b/packages/klurigo-web/src/states/PlayerGameOverState/PlayerGameOverState.tsx
@@ -99,9 +99,11 @@ const PlayerGameOverState: FC<PlayerGameOverStateProps> = ({
         <Confetti trigger={true} intensity={celebrationLevel} />
       )}
 
-      <Typography variant="title">{quiz.title}</Typography>
+      <Typography variant="title" align="center" color="inverse">
+        {quiz.title}
+      </Typography>
 
-      <Typography variant="body" width="medium">
+      <Typography variant="body" width="medium" align="center" color="inverse">
         {message}
       </Typography>
 
@@ -115,7 +117,7 @@ const PlayerGameOverState: FC<PlayerGameOverStateProps> = ({
           celebration={celebrationLevel}>
           {rank}
         </Badge>
-        <Typography variant="body" width="small">
+        <Typography variant="body" width="small" align="center" color="inverse">
           out of {totalPlayers} players
         </Typography>
       </div>
@@ -125,7 +127,7 @@ const PlayerGameOverState: FC<PlayerGameOverStateProps> = ({
       <StreakBadge streak={currentStreak}>Streak</StreakBadge>
 
       {comebackRankGain > 0 && (
-        <Typography variant="body" width="small">
+        <Typography variant="body" width="small" align="center" color="inverse">
           ↗ Comeback! +{comebackRankGain} ranks
         </Typography>
       )}

--- a/packages/klurigo-web/src/states/PlayerGameOverState/components/RatingCard/RatingCard.tsx
+++ b/packages/klurigo-web/src/states/PlayerGameOverState/components/RatingCard/RatingCard.tsx
@@ -48,7 +48,9 @@ const RatingCard: FC<RatingCardProps> = ({
   onCommentChange,
 }) => (
   <div className={styles.ratingCard}>
-    <Typography variant="title3">Rate this quiz</Typography>
+    <Typography variant="title3" align="center" color="inverse">
+      Rate this quiz
+    </Typography>
     <StarRating value={stars} size="large" onChange={onRatingChange} />
     {stars && (
       <div className={styles.comment}>

--- a/packages/klurigo-web/src/states/PlayerLobbyState/PlayerLobbyState.tsx
+++ b/packages/klurigo-web/src/states/PlayerLobbyState/PlayerLobbyState.tsx
@@ -84,14 +84,22 @@ const PlayerLobbyState: FC<PlayerLobbyStateProps> = ({
 
         <NicknameChip value={nickname} />
 
-        <Typography variant="title" width="medium">
+        <Typography
+          variant="title"
+          width="medium"
+          align="center"
+          color="inverse">
           You’re in the waiting room
         </Typography>
 
         <RotatingMessage
           messages={MESSAGES}
           renderMessage={(message) => (
-            <Typography variant="body" width="small">
+            <Typography
+              variant="body"
+              width="small"
+              align="center"
+              color="inverse">
               {message}
             </Typography>
           )}

--- a/packages/klurigo-web/src/states/PlayerQuestionState/PlayerQuestionState.tsx
+++ b/packages/klurigo-web/src/states/PlayerQuestionState/PlayerQuestionState.tsx
@@ -54,7 +54,7 @@ const PlayerQuestionState: FC<PlayerQuestionStateProps> = ({
         />
       }>
       <div className={styles.fullHeight}>
-        <Typography variant="title" maxLines={2}>
+        <Typography variant="title" align="center" color="inverse" maxLines={2}>
           {question.question}
         </Typography>
 

--- a/packages/klurigo-web/src/states/PlayerResultState/PlayerResultState.tsx
+++ b/packages/klurigo-web/src/states/PlayerResultState/PlayerResultState.tsx
@@ -79,7 +79,7 @@ const PlayerResultState: FC<PlayerResultStateProps> = ({
               styles.correctnessBatch,
               showPosition ? styles.slideOutLeft : undefined,
             )}>
-            <Typography variant="title">
+            <Typography variant="title" align="center" color="inverse">
               {correct ? 'Correct' : 'Incorrect'}
             </Typography>
 
@@ -110,7 +110,7 @@ const PlayerResultState: FC<PlayerResultStateProps> = ({
 
       <ScoreChip value={lastScore} />
 
-      <Typography variant="body" width="small">
+      <Typography variant="body" width="small" align="center" color="inverse">
         {message}
       </Typography>
 

--- a/packages/klurigo-web/src/states/common/HostGameFooter/HostGameFooter.tsx
+++ b/packages/klurigo-web/src/states/common/HostGameFooter/HostGameFooter.tsx
@@ -50,7 +50,7 @@ const HostGameFooter: FC<HostGameFooterProps> = ({
     <div className={styles.main}>
       <div className={styles.questions}>
         <FontAwesomeIcon icon={faCircleQuestion} className={styles.icon} />
-        <Typography variant="body2" align="left" color="inverse" noOpacity bold>
+        <Typography variant="body2" color="inverse" noOpacity bold>
           {currentQuestion} / {totalQuestions}
         </Typography>
       </div>

--- a/packages/klurigo-web/src/states/common/HostGameFooter/components/PlayerManagementModal/PlayerManagementModal.tsx
+++ b/packages/klurigo-web/src/states/common/HostGameFooter/components/PlayerManagementModal/PlayerManagementModal.tsx
@@ -207,7 +207,7 @@ const PlayerManagementModal: FC<PlayerManagementModalProps> = ({
   return (
     <Modal title="Who’s Playing?" size="large" open={open} onClose={onClose}>
       <div className={styles.playerManagementModal}>
-        <Typography variant="body2" align="left" color="default">
+        <Typography variant="body2">
           Here’s everyone in the game. If someone shouldn’t be here, you can
           politely show them the exit.
         </Typography>

--- a/packages/klurigo-web/src/states/common/NonInteractiveInfoBox/NonInteractiveInfoBox.tsx
+++ b/packages/klurigo-web/src/states/common/NonInteractiveInfoBox/NonInteractiveInfoBox.tsx
@@ -14,7 +14,7 @@ const NonInteractiveInfoBox: FC<NonInteractiveInfoBoxProps> = ({ info }) => {
   return (
     <div className={styles.nonInteractiveInfoBox}>
       <FontAwesomeIcon icon={faCircleInfo} />
-      <Typography variant="title2" align="left" color="inverse">
+      <Typography variant="title2" color="inverse">
         {info}
       </Typography>
     </div>

--- a/packages/klurigo-web/src/states/common/PlayerGameFooter/PlayerGameFooter.tsx
+++ b/packages/klurigo-web/src/states/common/PlayerGameFooter/PlayerGameFooter.tsx
@@ -22,7 +22,7 @@ const PlayerGameFooter: FC<PlayerGameFooterProps> = ({
   <div className={styles.main}>
     <div className={styles.questions}>
       <FontAwesomeIcon icon={faCircleQuestion} className={styles.icon} />
-      <Typography variant="body2" align="left" color="inverse" noOpacity bold>
+      <Typography variant="body2" color="inverse" noOpacity bold>
         {currentQuestion} / {totalQuestions}
       </Typography>
     </div>
@@ -36,7 +36,6 @@ const PlayerGameFooter: FC<PlayerGameFooterProps> = ({
         <Typography
           variant="body2"
           align="right"
-          color="default"
           className={styles.badge}
           noOpacity
           bold>

--- a/packages/klurigo-web/src/states/common/QuestionTextPreview/QuestionTextPreview.tsx
+++ b/packages/klurigo-web/src/states/common/QuestionTextPreview/QuestionTextPreview.tsx
@@ -78,7 +78,11 @@ const QuestionTextPreview: FC<QuestionTextPreviewProps> = ({ text }) => {
       startDelayMs={1000}
       hAlign="center"
       vAlign="center">
-      <Typography variant="extraLargeTitle" width="medium">
+      <Typography
+        variant="extraLargeTitle"
+        width="medium"
+        align="center"
+        color="inverse">
         {text}
       </Typography>
     </InfiniteScrollContainer>

--- a/packages/klurigo-web/src/states/common/QuestionTypePointsBar/QuestionTypePointsBar.tsx
+++ b/packages/klurigo-web/src/states/common/QuestionTypePointsBar/QuestionTypePointsBar.tsx
@@ -22,20 +22,14 @@ const QuestionTypePointsBar: FC<QuestionTypePointsBarProps> = ({
 }) =>
   mode === GameMode.Classic ? (
     <div className={styles.chip}>
-      <Typography variant="body2" align="left" color="inverse" noOpacity bold>
+      <Typography variant="body2" color="inverse" noOpacity bold>
         <FontAwesomeIcon
           icon={faQuestionCircle}
           color={colors.colorTextInverse}
         />
         {QuestionTypeLabels[questionType]}
       </Typography>
-      <Typography
-        variant="body2"
-        align="left"
-        color="inverse"
-        noOpacity
-        noWrap
-        bold>
+      <Typography variant="body2" color="inverse" noOpacity noWrap bold>
         <FontAwesomeIcon icon={faStar} color={colors.colorRatingDefault} />
         {questionPoints === 0 && 'Zero Points'}
         {questionPoints === 1000 && 'Standard Points'}


### PR DESCRIPTION
- Change Typography defaults from centered inverse text to left-aligned default text.
- Remove redundant align="left" and color="default" props where the new defaults now apply.
- Re-add explicit align="center" and color="inverse" in views that must preserve the previous presentation.
- Update Typography tests and Storybook examples to reflect the new defaults and usage patterns.

This keeps Typography call sites cleaner while preserving intended UI styling where explicit overrides are still required.