### PR TITLE
test(profile-quizzes-page-ui): update relative date snapshot

### DIFF
--- a/packages/klurigo-web/src/pages/ProfileQuizzesPage/components/ProfileQuizzesPageUI/__snapshots__/ProfileQuizzesPageUI.test.tsx.snap
+++ b/packages/klurigo-web/src/pages/ProfileQuizzesPage/components/ProfileQuizzesPageUI/__snapshots__/ProfileQuizzesPageUI.test.tsx.snap
@@ -241,7 +241,7 @@ exports[`ProfileQuizzesPageUI > should render ProfileQuizzesPageUI with card gri
                         fill="currentColor"
                       />
                     </svg>
-                    11 months ago
+                    1 year ago
                   </span>
                 </div>
               </div>
@@ -322,7 +322,7 @@ exports[`ProfileQuizzesPageUI > should render ProfileQuizzesPageUI with card gri
                         fill="currentColor"
                       />
                     </svg>
-                    11 months ago
+                    1 year ago
                   </span>
                 </div>
               </div>
@@ -403,7 +403,7 @@ exports[`ProfileQuizzesPageUI > should render ProfileQuizzesPageUI with card gri
                         fill="currentColor"
                       />
                     </svg>
-                    11 months ago
+                    1 year ago
                   </span>
                 </div>
               </div>
@@ -484,7 +484,7 @@ exports[`ProfileQuizzesPageUI > should render ProfileQuizzesPageUI with card gri
                         fill="currentColor"
                       />
                     </svg>
-                    11 months ago
+                    1 year ago
                   </span>
                 </div>
               </div>
@@ -565,7 +565,7 @@ exports[`ProfileQuizzesPageUI > should render ProfileQuizzesPageUI with card gri
                         fill="currentColor"
                       />
                     </svg>
-                    11 months ago
+                    1 year ago
                   </span>
                 </div>
               </div>


### PR DESCRIPTION
- update quiz card timestamps from 11 months to 1 year
- align snapshots with the current relative date output

Updates the ProfileQuizzesPageUI snapshots to reflect the elapsed time since the test data was created.