### PR TITLE
chore(ci): pin GitHub Actions dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,11 +17,11 @@ jobs:
     name: Build & Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
         with:
           node-version: '24'
 
@@ -29,7 +29,7 @@ jobs:
         run: npm install -g yarn@1.22.22
 
       - name: Cache Yarn cache
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
         id: yarn-cache
         with:
           path: ~/.cache/yarn
@@ -59,7 +59,7 @@ jobs:
 
       - name: Cache Playwright browsers
         if: ${{ inputs.run_e2e }}
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
         with:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-${{ hashFiles('**/yarn.lock') }}
@@ -80,20 +80,20 @@ jobs:
 
       - name: Upload Klurigo artifacts for Sentry
         if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: klurigo-sentry-artifacts
           path: packages/klurigo-web/dist/assets/**/*.map
 
       - name: Upload Klurigo Service artifacts for Sentry
         if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: klurigo-service-sentry-artifacts
           path: packages/klurigo-service/dist/**/*.map
 
       - name: Upload coverage (common)
-        uses: codecov/codecov-action@v7
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f
         with:
           files: ./packages/common/coverage/lcov.info
           flags: common
@@ -103,7 +103,7 @@ jobs:
           verbose: true
 
       - name: Upload coverage (klurigo-web)
-        uses: codecov/codecov-action@v7
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f
         with:
           files: ./packages/klurigo-web/coverage/lcov.info
           flags: klurigo-web
@@ -113,7 +113,7 @@ jobs:
           verbose: true
 
       - name: Upload coverage (klurigo-service)
-        uses: codecov/codecov-action@v7
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f
         with:
           files: ./packages/klurigo-service/coverage/lcov.info
           flags: klurigo-service

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,7 +47,7 @@ jobs:
 
     steps:
       - name: Checkout infra repo
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           repository: emilhornlund/infra
           path: infra

--- a/.github/workflows/docker-build-and-push.yml
+++ b/.github/workflows/docker-build-and-push.yml
@@ -24,7 +24,7 @@ jobs:
     outputs:
       short_sha: ${{ steps.get_sha.outputs.short_sha }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
       - id: get_sha
         run: echo "short_sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
 
@@ -42,10 +42,10 @@ jobs:
       REGISTRY_HOST: emils-nuc-server:5000
       SHORT_SHA: ${{ needs.prepare.outputs.short_sha }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
 
       - name: Login to Private Docker Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@abd2ef45e78c5afb21d64d4ca52ee8550d9572c7
         with:
           registry: ${{ env.REGISTRY_HOST }}
           username: ${{ secrets.REGISTRY_USER }}
@@ -60,7 +60,7 @@ jobs:
           fi
 
       - name: Build & Push ${{ matrix.service }}
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a
         with:
           context: .
           file: ./packages/${{ matrix.service }}/Dockerfile

--- a/.github/workflows/sentry-release.yml
+++ b/.github/workflows/sentry-release.yml
@@ -31,11 +31,11 @@ jobs:
           - klurigo-service
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
         with:
           node-version: '24'
 
@@ -50,7 +50,7 @@ jobs:
           fi
 
       - name: Download ${{ matrix.project }} artifacts for Sentry
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: ${{ env.SENTRY_ARTIFACT_NAME }}
           path: ${{ env.SENTRY_SOURCEMAPS_PATH }}


### PR DESCRIPTION
- replace version tags with immutable commit SHAs
- pin build, deployment, Docker, coverage, and Sentry workflow actions
- reduce supply-chain risk from mutable action references

Pin all third-party GitHub Actions to specific revisions for reproducible and more secure workflow execution.